### PR TITLE
Update Homebrew tap formula job to use vars for APP_ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,12 +146,13 @@ jobs:
     name: Update Homebrew tap formula
     runs-on: ubuntu-latest
     needs: publish
+    environment: "Production CLI"
     steps:
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: bitloops
           repositories: homebrew-tap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.0.9] - 2026-03-09
+
+- Reissued release after rollback of v0.0.8
+
+## [0.0.8] - 2026-03-09
+
 ### Added
 
 - Native Windows CMD installer at `scripts/install.cmd` with GitHub Releases download and SHA256 verification.

--- a/bitloops_cli/Cargo.lock
+++ b/bitloops_cli/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitloops_cli"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/bitloops_cli/Cargo.toml
+++ b/bitloops_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitloops_cli"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

