### PR TITLE
Cli 1294 injest devql to agent pre hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Native Windows CMD installer at `scripts/install.cmd` with GitHub Releases download and SHA256 verification.
 - Windows ARM64 (`aarch64-pc-windows-msvc`) release artifacts and installer support.
+- DevQL query history injest in agent pre-hook.

--- a/bitloops_cli/src/commands/devql.rs
+++ b/bitloops_cli/src/commands/devql.rs
@@ -355,7 +355,25 @@ async fn run_ingest(cfg: &DevqlConfig, args: &DevqlIngestArgs) -> Result<()> {
 }
 
 async fn run_query(cfg: &DevqlConfig, args: &DevqlQueryArgs) -> Result<()> {
-    let parsed = parse_devql_query(&args.query)?;
+    let output = execute_query_json(cfg, &args.query).await?;
+    if args.compact {
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    }
+
+    Ok(())
+}
+
+#[allow(dead_code)] // Compiled in both bin/lib crates; used by lib hook runtime path.
+pub async fn execute_query_json_for_repo_root(repo_root: &Path, query: &str) -> Result<Value> {
+    let repo = resolve_repo_identity(repo_root)?;
+    let cfg = DevqlConfig::from_env(repo_root.to_path_buf(), repo);
+    execute_query_json(&cfg, query).await
+}
+
+async fn execute_query_json(cfg: &DevqlConfig, query: &str) -> Result<Value> {
+    let parsed = parse_devql_query(query)?;
     let pg_client = if parsed.has_checkpoints_stage || parsed.has_telemetry_stage {
         None
     } else {
@@ -367,14 +385,7 @@ async fn run_query(cfg: &DevqlConfig, args: &DevqlQueryArgs) -> Result<()> {
         rows = project_rows(rows, &parsed.select_fields);
     }
 
-    let output = Value::Array(rows);
-    if args.compact {
-        println!("{}", serde_json::to_string(&output)?);
-    } else {
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    }
-
-    Ok(())
+    Ok(Value::Array(rows))
 }
 
 include!("devql/support.rs");

--- a/bitloops_cli/src/engine/history/devql_prefetch.rs
+++ b/bitloops_cli/src/engine/history/devql_prefetch.rs
@@ -32,7 +32,7 @@ pub fn prefetch_for_prompt(
     turn_id: &str,
     prompt: &str,
 ) -> Result<Option<PrefetchResult>> {
-    let Some(primary_target) = extract_line_anchors_from_prompt(prompt).into_iter().next() else {
+    let Some(primary_target) = extract_history_target_from_prompt(repo_root, prompt) else {
         return Ok(None);
     };
 
@@ -49,39 +49,133 @@ pub fn prefetch_for_prompt(
     }))
 }
 
-fn extract_line_anchors_from_prompt(prompt: &str) -> Vec<HistoryTarget> {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
+fn extract_history_target_from_prompt( repo_root: &Path,prompt: &str) -> Option<HistoryTarget> {
+    let targets = extract_candidate_history_targets_from_prompt(prompt);
+    let Some(primary_target) = get_history_target(repo_root, targets) else {
+        return None;
+    };
+    Some(primary_target)
+}
+
+fn extract_candidate_history_targets_from_prompt(prompt: &str) -> Vec<HistoryTarget> {
+    static COLON_LINE_RE: OnceLock<Regex> = OnceLock::new();
+    static HASH_LINE_RE: OnceLock<Regex> = OnceLock::new();
+    static LINES_PARENS_RE: OnceLock<Regex> = OnceLock::new();
+    static FILE_ONLY_RE: OnceLock<Regex> = OnceLock::new();
+
+    let colon_line_re = COLON_LINE_RE.get_or_init(|| {
         Regex::new(r"(?P<path>[A-Za-z0-9_\-./]+\.[A-Za-z0-9_]+):(?P<start>\d+)(?:-(?P<end>\d+))?")
-            .expect("valid anchor regex")
+            .expect("valid colon line anchor regex")
+    });
+    let hash_line_re = HASH_LINE_RE.get_or_init(|| {
+        Regex::new(
+            r"(?P<path>[A-Za-z0-9_\-./]+\.[A-Za-z0-9_]+)#L(?P<start>\d+)(?:-L?(?P<end>\d+))?",
+        )
+        .expect("valid hash line anchor regex")
+    });
+    let lines_parens_re = LINES_PARENS_RE.get_or_init(|| {
+        Regex::new(
+            r"(?P<path>[A-Za-z0-9_\-./]+\.[A-Za-z0-9_]+)\s*\(lines?\s*(?P<start>\d+)(?:\s*-\s*(?P<end>\d+))?\)",
+        )
+        .expect("valid lines() anchor regex")
+    });
+    let file_only_re = FILE_ONLY_RE.get_or_init(|| {
+        Regex::new(r"(?P<path>[A-Za-z0-9_\-./]+\.[A-Za-z0-9_]+)").expect("valid file-only regex")
     });
 
-    let mut targets = Vec::new();
-    for caps in re.captures_iter(prompt) {
-        let path = caps
-            .name("path")
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_default();
-        if path.is_empty() {
-            continue;
+    let mut targets = Vec::<HistoryTarget>::new();
+    for caps in colon_line_re.captures_iter(prompt) {
+        insert_target(
+            &mut targets,
+            caps.name("path").map(|m| m.as_str()).unwrap_or_default(),
+            caps.name("start")
+                .and_then(|m| m.as_str().parse::<i32>().ok()),
+            caps.name("end")
+                .and_then(|m| m.as_str().parse::<i32>().ok()),
+        );
+    }
+    for caps in hash_line_re.captures_iter(prompt) {
+        insert_target(
+            &mut targets,
+            caps.name("path").map(|m| m.as_str()).unwrap_or_default(),
+            caps.name("start")
+                .and_then(|m| m.as_str().parse::<i32>().ok()),
+            caps.name("end")
+                .and_then(|m| m.as_str().parse::<i32>().ok()),
+        );
+    }
+    for caps in lines_parens_re.captures_iter(prompt) {
+        insert_target(
+            &mut targets,
+            caps.name("path").map(|m| m.as_str()).unwrap_or_default(),
+            caps.name("start")
+                .and_then(|m| m.as_str().parse::<i32>().ok()),
+            caps.name("end")
+                .and_then(|m| m.as_str().parse::<i32>().ok()),
+        );
+    }
+
+    if targets.is_empty() {
+        for caps in file_only_re.captures_iter(prompt) {
+            insert_target(
+                &mut targets,
+                caps.name("path").map(|m| m.as_str()).unwrap_or_default(),
+                None,
+                None,
+            );
         }
-
-        let start_line = caps
-            .name("start")
-            .and_then(|m| m.as_str().parse::<i32>().ok());
-        let end_line = caps
-            .name("end")
-            .and_then(|m| m.as_str().parse::<i32>().ok())
-            .or(start_line);
-
-        targets.push(HistoryTarget {
-            path,
-            start_line,
-            end_line,
-        });
     }
 
     targets
+}
+
+fn insert_target(
+    targets: &mut Vec<HistoryTarget>,
+    path: &str,
+    start_line: Option<i32>,
+    end_line: Option<i32>,
+) {
+    let Some(path) = sanitize_target_path(path) else {
+        return;
+    };
+
+    let final_end = end_line.or(start_line);
+    if let Some(existing) = targets.iter_mut().find(|t| t.path == path) {
+        if existing.start_line.is_none() && start_line.is_some() {
+            existing.start_line = start_line;
+            existing.end_line = final_end;
+        }
+        return;
+    }
+
+    targets.push(HistoryTarget {
+        path,
+        start_line,
+        end_line: final_end,
+    });
+}
+
+fn sanitize_target_path(path: &str) -> Option<String> {
+    let path = path.trim();
+    if path.is_empty() {
+        return None;
+    }
+    let path = path.trim_matches(|c: char| matches!(c, '`' | '"' | '\'' | ',' | ';' | ')' | ']'));
+    if path.is_empty() || path.starts_with("http://") || path.starts_with("https://") {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+fn get_history_target(repo_root: &Path, targets: Vec<HistoryTarget>) -> Option<HistoryTarget> {
+    targets.into_iter().find(|target| {
+        let candidate = Path::new(&target.path);
+        if candidate.is_absolute() {
+            candidate.is_file()
+        } else {
+            repo_root.join(candidate).is_file()
+        }
+    })
 }
 
 fn build_devql_history_query(repo_name: &str, target: &HistoryTarget) -> String {
@@ -130,12 +224,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn extract_line_anchors_parses_single_line_anchor() {
-        let targets = extract_line_anchors_from_prompt("fix src/main.rs:42");
+    fn extract_targets_parses_single_line_anchor() {
+        let targets = extract_candidate_history_targets_from_prompt("fix src/main.rs:42");
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].path, "src/main.rs");
         assert_eq!(targets[0].start_line, Some(42));
         assert_eq!(targets[0].end_line, Some(42));
+    }
+
+    #[test]
+    fn extract_targets_parses_hash_line_anchor() {
+        let targets = extract_candidate_history_targets_from_prompt("check src/main.rs#L10-L25");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].path, "src/main.rs");
+        assert_eq!(targets[0].start_line, Some(10));
+        assert_eq!(targets[0].end_line, Some(25));
+    }
+
+    #[test]
+    fn extract_targets_falls_back_to_file_level_history() {
+        let targets = extract_candidate_history_targets_from_prompt("please check src/main.rs for context");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].path, "src/main.rs");
+        assert_eq!(targets[0].start_line, None);
+        assert_eq!(targets[0].end_line, None);
+    }
+
+    #[test]
+    fn extract_targets_ignores_non_file_tokens() {
+        let targets = extract_candidate_history_targets_from_prompt(
+            "await app.register(swagger, { openapi: { info: { title: 'My API' } } });",
+        );
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].path, "app.register");
+    }
+
+    #[test]
+    fn select_existing_target_ignores_nonexistent_tokens() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let targets = extract_candidate_history_targets_from_prompt(
+            "await app.register(swagger, { openapi: { info: { title: 'My API' } } });",
+        );
+        assert!(get_history_target(dir.path(), targets).is_none());
     }
 
     #[test]

--- a/bitloops_cli/src/engine/history/devql_prefetch.rs
+++ b/bitloops_cli/src/engine/history/devql_prefetch.rs
@@ -1,0 +1,156 @@
+use std::path::Path;
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::runtime::Builder;
+use tokio::task;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryTarget {
+    pub path: String,
+    pub start_line: Option<i32>,
+    pub end_line: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrefetchResult {
+    pub session_id: String,
+    pub turn_id: String,
+    pub query: String,
+    pub targets: Vec<HistoryTarget>,
+    pub rows: Value,
+}
+
+/// Best-effort pre-hook DevQL history prefetch.
+/// Returns `Ok(None)` on normal no-op cases (no target anchors in prompt).
+pub fn prefetch_for_prompt(
+    repo_root: &Path,
+    session_id: &str,
+    turn_id: &str,
+    prompt: &str,
+) -> Result<Option<PrefetchResult>> {
+    let Some(primary_target) = extract_line_anchors_from_prompt(prompt).into_iter().next() else {
+        return Ok(None);
+    };
+
+    let repo_name = infer_repo_name(repo_root);
+    let query = build_devql_history_query(&repo_name, &primary_target);
+    let rows = run_devql_query(repo_root, &query)?;
+
+    Ok(Some(PrefetchResult {
+        session_id: session_id.to_string(),
+        turn_id: turn_id.to_string(),
+        query,
+        targets: vec![primary_target],
+        rows,
+    }))
+}
+
+fn extract_line_anchors_from_prompt(prompt: &str) -> Vec<HistoryTarget> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?P<path>[A-Za-z0-9_\-./]+\.[A-Za-z0-9_]+):(?P<start>\d+)(?:-(?P<end>\d+))?")
+            .expect("valid anchor regex")
+    });
+
+    let mut targets = Vec::new();
+    for caps in re.captures_iter(prompt) {
+        let path = caps
+            .name("path")
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if path.is_empty() {
+            continue;
+        }
+
+        let start_line = caps
+            .name("start")
+            .and_then(|m| m.as_str().parse::<i32>().ok());
+        let end_line = caps
+            .name("end")
+            .and_then(|m| m.as_str().parse::<i32>().ok())
+            .or(start_line);
+
+        targets.push(HistoryTarget {
+            path,
+            start_line,
+            end_line,
+        });
+    }
+
+    targets
+}
+
+fn build_devql_history_query(repo_name: &str, target: &HistoryTarget) -> String {
+    let escaped_repo = repo_name.replace('"', "\\\"");
+    let escaped_path = target.path.replace('"', "\\\"");
+
+    let artefacts_stage = match (target.start_line, target.end_line) {
+        (Some(start), Some(end)) => format!("artefacts(lines:{start}..{end})"),
+        _ => "artefacts()".to_string(),
+    };
+
+    format!(
+        "repo(\"{escaped_repo}\")->file(\"{escaped_path}\")->{}->chatHistory()->limit(5)",
+        artefacts_stage
+    )
+}
+
+fn infer_repo_name(repo_root: &Path) -> String {
+    repo_root
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown-repo".to_string())
+}
+
+fn run_devql_query(repo_root: &Path, query: &str) -> Result<Value> {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        return task::block_in_place(|| {
+            handle.block_on(crate::commands::devql::execute_query_json_for_repo_root(
+                repo_root, query,
+            ))
+        });
+    }
+
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime for pre-hook DevQL query")?;
+    runtime.block_on(crate::commands::devql::execute_query_json_for_repo_root(
+        repo_root, query,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_line_anchors_parses_single_line_anchor() {
+        let targets = extract_line_anchors_from_prompt("fix src/main.rs:42");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].path, "src/main.rs");
+        assert_eq!(targets[0].start_line, Some(42));
+        assert_eq!(targets[0].end_line, Some(42));
+    }
+
+    #[test]
+    fn build_history_query_includes_line_range_when_present() {
+        let query = build_devql_history_query(
+            "bitloops-cli",
+            &HistoryTarget {
+                path: "src/main.rs".to_string(),
+                start_line: Some(10),
+                end_line: Some(25),
+            },
+        );
+        assert_eq!(
+            query,
+            "repo(\"bitloops-cli\")->file(\"src/main.rs\")->artefacts(lines:10..25)->chatHistory()->limit(5)"
+        );
+    }
+}

--- a/bitloops_cli/src/engine/history/devql_prefetch.rs
+++ b/bitloops_cli/src/engine/history/devql_prefetch.rs
@@ -36,8 +36,7 @@ pub fn prefetch_for_prompt(
         return Ok(None);
     };
 
-    let repo_name = infer_repo_name(repo_root);
-    let query = build_devql_history_query(&repo_name, &primary_target);
+    let query = build_devql_history_query(&primary_target);
     let rows = run_devql_query(repo_root, &query)?;
 
     Ok(Some(PrefetchResult {
@@ -49,7 +48,7 @@ pub fn prefetch_for_prompt(
     }))
 }
 
-fn extract_history_target_from_prompt( repo_root: &Path,prompt: &str) -> Option<HistoryTarget> {
+fn extract_history_target_from_prompt(repo_root: &Path, prompt: &str) -> Option<HistoryTarget> {
     let targets = extract_candidate_history_targets_from_prompt(prompt);
     let Some(primary_target) = get_history_target(repo_root, targets) else {
         return None;
@@ -168,18 +167,39 @@ fn sanitize_target_path(path: &str) -> Option<String> {
 }
 
 fn get_history_target(repo_root: &Path, targets: Vec<HistoryTarget>) -> Option<HistoryTarget> {
-    targets.into_iter().find(|target| {
-        let candidate = Path::new(&target.path);
-        if candidate.is_absolute() {
-            candidate.is_file()
-        } else {
-            repo_root.join(candidate).is_file()
-        }
+    targets.into_iter().find_map(|target| {
+        normalize_target_for_repo(repo_root, &target.path).and_then(|repo_relative_path| {
+            if repo_root.join(&repo_relative_path).is_file() {
+                let mut normalized = target;
+                normalized.path = repo_relative_path;
+                Some(normalized)
+            } else {
+                None
+            }
+        })
     })
 }
 
-fn build_devql_history_query(repo_name: &str, target: &HistoryTarget) -> String {
-    let escaped_repo = repo_name.replace('"', "\\\"");
+fn normalize_target_for_repo(repo_root: &Path, raw_path: &str) -> Option<String> {
+    let repo_root = repo_root.canonicalize().ok()?;
+    let input = Path::new(raw_path);
+    let candidate = if input.is_absolute() {
+        input.to_path_buf()
+    } else {
+        repo_root.join(input)
+    };
+    let candidate = candidate.canonicalize().ok()?;
+    if !candidate.starts_with(&repo_root) {
+        return None;
+    }
+    let rel = candidate.strip_prefix(&repo_root).ok()?;
+    if rel.as_os_str().is_empty() {
+        return None;
+    }
+    Some(rel.to_string_lossy().replace('\\', "/"))
+}
+
+fn build_devql_history_query(target: &HistoryTarget) -> String {
     let escaped_path = target.path.replace('"', "\\\"");
 
     let artefacts_stage = match (target.start_line, target.end_line) {
@@ -188,17 +208,9 @@ fn build_devql_history_query(repo_name: &str, target: &HistoryTarget) -> String 
     };
 
     format!(
-        "repo(\"{escaped_repo}\")->file(\"{escaped_path}\")->{}->chatHistory()->limit(5)",
+        "file(\"{escaped_path}\")->{}->chatHistory()->limit(5)",
         artefacts_stage
     )
-}
-
-fn infer_repo_name(repo_root: &Path) -> String {
-    repo_root
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown-repo".to_string())
 }
 
 fn run_devql_query(repo_root: &Path, query: &str) -> Result<Value> {
@@ -243,7 +255,8 @@ mod tests {
 
     #[test]
     fn extract_targets_falls_back_to_file_level_history() {
-        let targets = extract_candidate_history_targets_from_prompt("please check src/main.rs for context");
+        let targets =
+            extract_candidate_history_targets_from_prompt("please check src/main.rs for context");
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].path, "src/main.rs");
         assert_eq!(targets[0].start_line, None);
@@ -251,7 +264,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_targets_ignores_non_file_tokens() {
+    fn extract_targets_returns_non_file_tokens() {
         let targets = extract_candidate_history_targets_from_prompt(
             "await app.register(swagger, { openapi: { info: { title: 'My API' } } });",
         );
@@ -269,18 +282,31 @@ mod tests {
     }
 
     #[test]
+    fn get_history_target_converts_absolute_path_to_repo_relative() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("src").join("main.rs");
+        std::fs::create_dir_all(file.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&file, "fn main() {}").expect("write");
+
+        let targets = vec![HistoryTarget {
+            path: file.to_string_lossy().to_string(),
+            start_line: Some(1),
+            end_line: Some(1),
+        }];
+        let selected = get_history_target(dir.path(), targets).expect("target selected");
+        assert_eq!(selected.path, "src/main.rs");
+    }
+
+    #[test]
     fn build_history_query_includes_line_range_when_present() {
-        let query = build_devql_history_query(
-            "bitloops-cli",
-            &HistoryTarget {
-                path: "src/main.rs".to_string(),
-                start_line: Some(10),
-                end_line: Some(25),
-            },
-        );
+        let query = build_devql_history_query(&HistoryTarget {
+            path: "src/main.rs".to_string(),
+            start_line: Some(10),
+            end_line: Some(25),
+        });
         assert_eq!(
             query,
-            "repo(\"bitloops-cli\")->file(\"src/main.rs\")->artefacts(lines:10..25)->chatHistory()->limit(5)"
+            "file(\"src/main.rs\")->artefacts(lines:10..25)->chatHistory()->limit(5)"
         );
     }
 }

--- a/bitloops_cli/src/engine/history/mod.rs
+++ b/bitloops_cli/src/engine/history/mod.rs
@@ -1,0 +1,1 @@
+pub mod devql_prefetch;

--- a/bitloops_cli/src/engine/hooks/runtime/agent_runtime.rs
+++ b/bitloops_cli/src/engine/hooks/runtime/agent_runtime.rs
@@ -19,6 +19,7 @@ use crate::engine::agent::{
     AGENT_NAME_CLAUDE_CODE, AGENT_NAME_CURSOR, AGENT_TYPE_CLAUDE_CODE, AGENT_TYPE_CURSOR,
 };
 use crate::engine::git_operations;
+use crate::engine::history::devql_prefetch;
 #[cfg(test)]
 use crate::engine::logging;
 use crate::engine::paths;
@@ -226,7 +227,7 @@ pub fn handle_user_prompt_submit_with_strategy_and_profile(
     // Capture pre-prompt state for use by `stop`.
     let transcript_position = get_transcript_position(&input.transcript_path).unwrap_or_default();
     let prompt_trunc = truncate_prompt_for_storage(&input.prompt);
-    let pre_prompt = PrePromptState {
+    let mut pre_prompt = PrePromptState {
         session_id: input.session_id.clone(),
         timestamp: now_rfc3339(),
         source: String::new(),
@@ -238,8 +239,8 @@ pub fn handle_user_prompt_submit_with_strategy_and_profile(
         start_message_index: 0,
         step_transcript_start: 0,
         last_transcript_line_count: 0,
+        devql_prefetch: None,
     };
-    backend.save_pre_prompt(&pre_prompt)?;
 
     // InitializeSession is best-effort (warn, do not block hook).
     if let Err(err) = strategy.initialize_session(
@@ -275,6 +276,24 @@ pub fn handle_user_prompt_submit_with_strategy_and_profile(
         state.agent_type = profile.agent_type.to_string();
     }
 
+    if let Some(root) = repo_root {
+        match devql_prefetch::prefetch_for_prompt(
+            root,
+            &input.session_id,
+            &state.turn_id,
+            &input.prompt,
+        ) {
+            Ok(Some(prefetch)) => {
+                pre_prompt.devql_prefetch = Some(prefetch);
+            }
+            Ok(None) => {}
+            Err(err) => {
+                eprintln!("[bitloops] Warning: pre-hook DevQL history prefetch failed: {err:#}");
+            }
+        }
+    }
+
+    backend.save_pre_prompt(&pre_prompt)?;
     backend.save_session(&state)
 }
 

--- a/bitloops_cli/src/engine/hooks/runtime/agent_runtime.rs
+++ b/bitloops_cli/src/engine/hooks/runtime/agent_runtime.rs
@@ -241,6 +241,7 @@ pub fn handle_user_prompt_submit_with_strategy_and_profile(
         last_transcript_line_count: 0,
         devql_prefetch: None,
     };
+    backend.save_pre_prompt(&pre_prompt)?;
 
     // InitializeSession is best-effort (warn, do not block hook).
     if let Err(err) = strategy.initialize_session(
@@ -285,6 +286,11 @@ pub fn handle_user_prompt_submit_with_strategy_and_profile(
         ) {
             Ok(Some(prefetch)) => {
                 pre_prompt.devql_prefetch = Some(prefetch);
+                if let Err(err) = backend.save_pre_prompt(&pre_prompt) {
+                    eprintln!(
+                        "[bitloops] Warning: failed to persist pre-hook DevQL prefetch: {err:#}"
+                    );
+                }
             }
             Ok(None) => {}
             Err(err) => {
@@ -293,7 +299,6 @@ pub fn handle_user_prompt_submit_with_strategy_and_profile(
         }
     }
 
-    backend.save_pre_prompt(&pre_prompt)?;
     backend.save_session(&state)
 }
 

--- a/bitloops_cli/src/engine/mod.rs
+++ b/bitloops_cli/src/engine/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod db_status;
 pub mod git_operations;
+pub mod history;
 pub mod hooks;
 pub mod lifecycle;
 pub mod logging;

--- a/bitloops_cli/src/engine/session/state.rs
+++ b/bitloops_cli/src/engine/session/state.rs
@@ -163,6 +163,8 @@ pub struct PrePromptState {
     pub step_transcript_start: i64,
     #[serde(default, skip_serializing_if = "is_zero_i64")]
     pub last_transcript_line_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devql_prefetch: Option<crate::engine::history::devql_prefetch::PrefetchResult>,
 }
 
 /// Marker written by `pre-task`; checked by `post-todo` and `post-task`.

--- a/bitloops_cli/src/engine/telemetry/mod.rs
+++ b/bitloops_cli/src/engine/telemetry/mod.rs
@@ -266,7 +266,9 @@ fn posthog_api_key() -> String {
         .ok()
         .filter(|v| !v.trim().is_empty())
         .or_else(|| {
-            option_env!("BITLOOPS_POSTHOG_API_KEY").map(String::from).filter(|v| !v.trim().is_empty())
+            option_env!("BITLOOPS_POSTHOG_API_KEY")
+                .map(String::from)
+                .filter(|v| !v.trim().is_empty())
         })
         .unwrap_or_else(|| POSTHOG_API_KEY.to_string())
 }

--- a/bitloops_cli/src/lib.rs
+++ b/bitloops_cli/src/lib.rs
@@ -1,4 +1,8 @@
+pub mod commands;
+pub mod devql_config;
 pub mod engine;
+pub mod server;
+pub mod terminal;
 
 #[cfg(test)]
 pub(crate) mod test_support;


### PR DESCRIPTION
## Summary

https://bitloops.atlassian.net/browse/CLI-1294

Implemented DevQL pre-hook history prefetch end-to-end plumbing improvements, with focus on reliable target extraction and state persistence.
**What changed**
1. Pre-hook now executes DevQL in-process (no subprocess call)
2. Added reusable query API:
devql.rs
3.execute_query_json_for_repo_root(...)
**Prefetch result is persisted in pre-prompt state**
1. Added devql_prefetch field to PrePromptState:
session/state.rs
2. Hook flow stores prefetch result before saving pre-prompt:
agent_runtime.rs
3. Improved history target extraction from prompts
Supports:
path:line[-end]
path#Lline[-Lend]
path (lines start-end)
**Added file-level fallback when only file path is present in prompt.**
1. Added stricter target validation by requiring selected target to resolve to an existing file in repo (prevents false targets like app.register).
2. Module exposure for internal reuse
Exposed modules needed by hook runtime path from library crate:
lib.rs
**Behavioral outcome**
On turn start, Bitloops pre-hook:
1.Extracts a target from prompt,
2. Runs DevQL history query immediately,
3. Stores {query, targets, rows} in .bitloops/tmp/pre-prompt-<session>.json under devql_prefetch.
If no matching history exists, rows is [].

<!-- Briefly describe what changed and why -->

## Validation

- [x] I ran the relevant tests locally.
- [x] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [x] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [x] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

