### PR TITLE
Force main via develop only

### DIFF
--- a/.github/workflows/allow-main-only-via-develop.yml
+++ b/.github/workflows/allow-main-only-via-develop.yml
@@ -1,0 +1,17 @@
+name: Enforce develop -> main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "PRs into main must come from develop."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Native Windows CMD installer at `scripts/install.cmd` with GitHub Releases download and SHA256 verification.
 - Windows ARM64 (`aarch64-pc-windows-msvc`) release artifacts and installer support.
+- Added workflow to protect main branch from merges of other than develop branches.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce branch merging rules. The workflow ensures that pull requests targeting the main branch can only originate from the develop branch.

Branch merging enforcement:

Added .github/workflows/allow-main-only-via-develop.yml workflow to block PRs into main unless their source branch is develop.