### PR TITLE
Api improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- Dashboard `/api/commits` now returns all checkpoint session agents (`checkpoint.agents`) instead of exposing only one agent, while keeping `checkpoint.agent` as the latest-session agent for compatibility.
+- Dashboard `/api/commits` now includes `checkpoint.first_prompt_preview` with the first 160 characters from the first prompt of the first checkpoint session.
+- Dashboard agent filtering/aggregation now evaluates all session agents per checkpoint, so `/api/commits` agent filters, `/api/agents`, and KPI agent counts reflect multi-session checkpoints correctly.
+- Dashboard `files_touched` payloads in `/api/commits` (`commit.files_touched` and `checkpoint.files_touched`) and `/api/checkpoints/{checkpoint_id}` now return arrays of objects (`[{ filepath, additionsCount, deletionsCount }]`) instead of path-keyed maps or plain path arrays.
+
 ## [0.0.9] - 2026-03-09
 
 - Reissued release after rollback of v0.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
-- Dashboard `/api/commits` now returns all checkpoint session agents (`checkpoint.agents`) instead of exposing only one agent, while keeping `checkpoint.agent` as the latest-session agent for compatibility.
-- Dashboard `/api/commits` now includes `checkpoint.first_prompt_preview` with the first 160 characters from the first prompt of the first checkpoint session.
+- Dashboard `/api/commits` now returns all checkpoint session agents via `checkpoint.agents` and no longer exposes a singular `checkpoint.agent` value.
+- Dashboard `/api/commits` now includes `checkpoint.first_prompt_preview` with the first 160 characters from the first prompt of the first checkpoint session, after stripping leading `<tag>...</tag>` blocks and trimming leading whitespace.
 - Dashboard agent filtering/aggregation now evaluates all session agents per checkpoint, so `/api/commits` agent filters, `/api/agents`, and KPI agent counts reflect multi-session checkpoints correctly.
 - Dashboard `files_touched` payloads in `/api/commits` (`commit.files_touched` and `checkpoint.files_touched`) and `/api/checkpoints/{checkpoint_id}` now return arrays of objects (`[{ filepath, additionsCount, deletionsCount }]`) instead of path-keyed maps or plain path arrays.
 

--- a/bitloops_cli/src/engine/strategy/manual_commit/checkpoint_views.rs
+++ b/bitloops_cli/src/engine/strategy/manual_commit/checkpoint_views.rs
@@ -75,6 +75,10 @@ pub struct CommittedInfo {
     pub session_id: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub agent: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub first_prompt_preview: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub created_at: String,
     #[serde(default, skip_serializing_if = "is_false")]
@@ -107,51 +111,94 @@ fn to_committed_info(
         return info;
     }
 
-    let idx = info.session_count - 1;
     let (a, b) = checkpoint_dir_parts(&summary.checkpoint_id);
-    let meta_path = format!("{a}/{b}/{idx}/{}", paths::METADATA_FILE_NAME);
-    let Ok(raw) = git_show_file(repo_root, read_ref, &meta_path) else {
-        return info;
-    };
+    let latest_session_index = info.session_count - 1;
 
-    if let Ok(meta) = serde_json::from_str::<CommittedMetadata>(&raw) {
-        info.session_id = meta.session_id;
-        info.agent = canonicalize_agent_type(&meta.agent);
-        info.created_at = meta.created_at;
-        info.is_task = meta.is_task;
-        info.tool_use_id = meta.tool_use_id;
-        return info;
+    for idx in 0..info.session_count {
+        let meta_path = format!("{a}/{b}/{idx}/{}", paths::METADATA_FILE_NAME);
+        let Ok(raw) = git_show_file(repo_root, read_ref, &meta_path) else {
+            continue;
+        };
+
+        if let Ok(meta) = serde_json::from_str::<CommittedMetadata>(&raw) {
+            push_unique_agent(&mut info.agents, &meta.agent);
+            if idx == latest_session_index {
+                info.session_id = meta.session_id;
+                info.agent = canonicalize_agent_type(&meta.agent);
+                info.created_at = meta.created_at;
+                info.is_task = meta.is_task;
+                info.tool_use_id = meta.tool_use_id;
+            }
+            continue;
+        }
+
+        // Keep list/read behavior resilient to legacy metadata with partial fields.
+        if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&raw) {
+            push_unique_agent(
+                &mut info.agents,
+                meta.get("agent")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+            );
+
+            if idx == latest_session_index {
+                info.session_id = meta
+                    .get("session_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                info.agent = canonicalize_agent_type(
+                    meta.get("agent")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default(),
+                );
+                info.created_at = meta
+                    .get("created_at")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                info.is_task = meta
+                    .get("is_task")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                info.tool_use_id = meta
+                    .get("tool_use_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+            }
+        }
     }
 
-    // Keep list/read behavior resilient to legacy metadata with partial fields.
-    if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&raw) {
-        info.session_id = meta
-            .get("session_id")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .to_string();
-        info.agent = canonicalize_agent_type(
-            meta.get("agent")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default(),
-        );
-        info.created_at = meta
-            .get("created_at")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .to_string();
-        info.is_task = meta
-            .get("is_task")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-        info.tool_use_id = meta
-            .get("tool_use_id")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .to_string();
+    if info.agent.is_empty()
+        && let Some(last) = info.agents.last()
+    {
+        info.agent = last.clone();
+    }
+
+    let first_prompt_path = format!("{a}/{b}/0/{}", paths::PROMPT_FILE_NAME);
+    if let Ok(raw_prompts) = git_show_file(repo_root, read_ref, &first_prompt_path) {
+        info.first_prompt_preview = first_prompt_preview(&raw_prompts);
     }
 
     info
+}
+
+fn push_unique_agent(agents: &mut Vec<String>, agent: &str) {
+    let normalized = canonicalize_agent_type(agent);
+    if normalized.is_empty() || agents.iter().any(|existing| existing == &normalized) {
+        return;
+    }
+    agents.push(normalized);
+}
+
+fn first_prompt_preview(prompts_blob: &str) -> String {
+    let first_prompt = prompts_blob
+        .split("\n\n---\n\n")
+        .next()
+        .unwrap_or_default()
+        .trim();
+    first_prompt.chars().take(160).collect()
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -671,4 +718,3 @@ fn redact_jsonl_bytes_with_fallback(input: &[u8]) -> Vec<u8> {
 fn redact_text(input: &str) -> String {
     redact::string(input)
 }
-

--- a/bitloops_cli/src/engine/strategy/manual_commit/checkpoint_views.rs
+++ b/bitloops_cli/src/engine/strategy/manual_commit/checkpoint_views.rs
@@ -193,12 +193,43 @@ fn push_unique_agent(agents: &mut Vec<String>, agent: &str) {
 }
 
 fn first_prompt_preview(prompts_blob: &str) -> String {
-    let first_prompt = prompts_blob
-        .split("\n\n---\n\n")
-        .next()
-        .unwrap_or_default()
-        .trim();
-    first_prompt.chars().take(160).collect()
+    let first_prompt = prompts_blob.split("\n\n---\n\n").next().unwrap_or_default();
+    let stripped = strip_leading_wrapped_tags(first_prompt).trim_start();
+    stripped.chars().take(160).collect()
+}
+
+fn strip_leading_wrapped_tags(input: &str) -> &str {
+    let mut rest = input.trim_start();
+    loop {
+        let Some((tag_name, after_open)) = parse_leading_open_tag(rest) else {
+            return rest;
+        };
+        let closing_tag = format!("</{tag_name}>");
+        let Some(close_idx) = after_open.find(&closing_tag) else {
+            return rest;
+        };
+        rest = after_open[close_idx + closing_tag.len()..].trim_start();
+    }
+}
+
+fn parse_leading_open_tag(input: &str) -> Option<(String, &str)> {
+    let trimmed = input.trim_start();
+    if !trimmed.starts_with('<') || trimmed.starts_with("</") {
+        return None;
+    }
+
+    let open_end = trimmed.find('>')?;
+    let inside = trimmed.get(1..open_end)?.trim();
+    if inside.is_empty() || inside.ends_with('/') {
+        return None;
+    }
+
+    let tag_name = inside.split_whitespace().next()?.trim();
+    if tag_name.is_empty() {
+        return None;
+    }
+
+    Some((tag_name.to_string(), trimmed.get(open_end + 1..)?))
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/bitloops_cli/src/engine/strategy/manual_commit_tests.rs
+++ b/bitloops_cli/src/engine/strategy/manual_commit_tests.rs
@@ -2642,6 +2642,7 @@ fn list_committed_multi_session_info() {
 
     let mut one = idle_state("list-session-1", &head, vec!["file0.rs".to_string()], 1);
     let mut two = idle_state("list-session-2", &head, vec!["file1.rs".to_string()], 2);
+    two.agent_type = "gemini-cli".to_string();
     condense_with_transcript(&strategy, &mut one, checkpoint_id, &head, r#"{"i": 0}"#);
     condense_with_transcript(&strategy, &mut two, checkpoint_id, &head, r#"{"i": 1}"#);
 
@@ -2657,8 +2658,13 @@ fn list_committed_multi_session_info() {
         "latest session id should be exposed"
     );
     assert_eq!(
-        found.agent, AGENT_TYPE_CLAUDE_CODE,
+        found.agent, "gemini-cli",
         "agent should come from latest session metadata"
+    );
+    assert_eq!(
+        found.agents,
+        vec![AGENT_TYPE_CLAUDE_CODE.to_string(), "gemini-cli".to_string()],
+        "agents should include all unique session agents in order"
     );
 }
 

--- a/bitloops_cli/src/server/dashboard/dto.rs
+++ b/bitloops_cli/src/server/dashboard/dto.rs
@@ -4,7 +4,6 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use utoipa::{IntoParams, OpenApi, ToSchema};
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -90,11 +89,13 @@ pub(super) struct ApiCheckpointDto {
     pub(super) strategy: String,
     pub(super) branch: String,
     pub(super) checkpoints_count: u32,
-    pub(super) files_touched: Vec<String>,
+    pub(super) files_touched: Vec<ApiCommitFileDiffDto>,
     pub(super) session_count: usize,
     pub(super) token_usage: Option<ApiTokenUsageDto>,
     pub(super) session_id: String,
     pub(super) agent: String,
+    pub(super) agents: Vec<String>,
+    pub(super) first_prompt_preview: String,
     pub(super) created_at: String,
     pub(super) is_task: bool,
     pub(super) tool_use_id: String,
@@ -103,6 +104,7 @@ pub(super) struct ApiCheckpointDto {
 #[derive(Debug, Clone, Serialize, ToSchema, Default)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct ApiCommitFileDiffDto {
+    pub(super) filepath: String,
     pub(super) additions_count: u64,
     pub(super) deletions_count: u64,
 }
@@ -115,7 +117,7 @@ pub(super) struct ApiCommitDto {
     pub(super) author_email: String,
     pub(super) timestamp: i64,
     pub(super) message: String,
-    pub(super) files_touched: HashMap<String, ApiCommitFileDiffDto>,
+    pub(super) files_touched: Vec<ApiCommitFileDiffDto>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -196,7 +198,7 @@ pub(super) struct ApiCheckpointDetailResponse {
     pub(super) strategy: String,
     pub(super) branch: String,
     pub(super) checkpoints_count: u32,
-    pub(super) files_touched: Vec<String>,
+    pub(super) files_touched: Vec<ApiCommitFileDiffDto>,
     pub(super) session_count: usize,
     pub(super) token_usage: Option<ApiTokenUsageDto>,
     pub(super) sessions: Vec<ApiCheckpointSessionDetailDto>,

--- a/bitloops_cli/src/server/dashboard/dto.rs
+++ b/bitloops_cli/src/server/dashboard/dto.rs
@@ -93,7 +93,6 @@ pub(super) struct ApiCheckpointDto {
     pub(super) session_count: usize,
     pub(super) token_usage: Option<ApiTokenUsageDto>,
     pub(super) session_id: String,
-    pub(super) agent: String,
     pub(super) agents: Vec<String>,
     pub(super) first_prompt_preview: String,
     pub(super) created_at: String,

--- a/bitloops_cli/src/server/dashboard/handlers.rs
+++ b/bitloops_cli/src/server/dashboard/handlers.rs
@@ -21,6 +21,7 @@ use axum::{
     http::StatusCode,
 };
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use utoipa::OpenApi;
 
 #[utoipa::path(
@@ -97,25 +98,14 @@ pub(crate) async fn handle_api_commits(
     let mut result = Vec::with_capacity(rows.len());
     for pair in rows {
         let files_touched = match read_commit_numstat(&state.repo_root, &pair.commit.sha) {
-            Ok(stats) => stats
-                .into_iter()
-                .map(|(path, (adds, dels))| {
-                    (
-                        path,
-                        ApiCommitFileDiffDto {
-                            additions_count: adds,
-                            deletions_count: dels,
-                        },
-                    )
-                })
-                .collect(),
+            Ok(stats) => api_file_diff_list_from_numstat(stats),
             Err(err) => {
                 log::warn!(
                     "dashboard commits endpoint: failed to read numstat for {}: {:#}",
                     pair.commit.sha,
                     err
                 );
-                HashMap::new()
+                api_zeroed_file_diff_list(&pair.checkpoint.files_touched)
             }
         };
         result.push(api_commit_row_from_pair(pair, files_touched));
@@ -251,17 +241,12 @@ pub(crate) async fn handle_api_agents(
     let pairs = query_commit_checkpoint_pairs_all(&state.repo_root, &filter)
         .map_err(|err| ApiError::internal(format!("Failed to query dashboard agents: {err:#}")))?;
 
-    let mut agents: Vec<ApiAgentDto> = pairs
-        .into_iter()
-        .filter_map(|pair| {
-            let key = canonical_agent_key(&pair.checkpoint.agent);
-            if key.is_empty() {
-                None
-            } else {
-                Some(ApiAgentDto { key })
-            }
-        })
-        .collect();
+    let mut agents: Vec<ApiAgentDto> = Vec::new();
+    for pair in pairs {
+        for key in checkpoint_agent_keys(&pair.checkpoint) {
+            agents.push(ApiAgentDto { key });
+        }
+    }
     agents.sort_by(|left, right| left.key.cmp(&right.key));
     agents.dedup_by(|left, right| left.key == right.key);
 
@@ -348,13 +333,19 @@ pub(crate) async fn handle_api_checkpoint(
         });
     }
 
+    let files_touched = resolve_checkpoint_files_touched(
+        &state.repo_root,
+        &info.branch,
+        &info.checkpoint_id,
+        &info.files_touched,
+    );
     let token_usage = api_token_usage_from_committed(&info);
     Ok(Json(ApiCheckpointDetailResponse {
         checkpoint_id: info.checkpoint_id,
         strategy: info.strategy,
         branch: info.branch,
         checkpoints_count: info.checkpoints_count,
-        files_touched: info.files_touched,
+        files_touched,
         session_count: info.session_count,
         token_usage,
         sessions,
@@ -655,8 +646,7 @@ fn build_kpis_response(pairs: &[CommitCheckpointPair]) -> ApiKpisResponse {
             continue;
         }
 
-        let agent_key = canonical_agent_key(&pair.checkpoint.agent);
-        if !agent_key.is_empty() {
+        for agent_key in checkpoint_agent_keys(&pair.checkpoint) {
             unique_agents.insert(agent_key);
         }
         total_sessions += pair.checkpoint.session_count;
@@ -702,6 +692,27 @@ fn build_kpis_response(pairs: &[CommitCheckpointPair]) -> ApiKpisResponse {
     }
 }
 
+fn checkpoint_agent_keys(info: &CommittedInfo) -> Vec<String> {
+    let mut keys: Vec<String> = Vec::new();
+
+    if info.agents.is_empty() {
+        let key = canonical_agent_key(&info.agent);
+        if !key.is_empty() {
+            keys.push(key);
+        }
+        return keys;
+    }
+
+    for agent in &info.agents {
+        let key = canonical_agent_key(agent);
+        if key.is_empty() || keys.iter().any(|existing| existing == &key) {
+            continue;
+        }
+        keys.push(key);
+    }
+    keys
+}
+
 fn api_token_usage_from_committed(info: &CommittedInfo) -> Option<ApiTokenUsageDto> {
     info.token_usage.as_ref().map(|usage| ApiTokenUsageDto {
         input_tokens: usage.input_tokens,
@@ -712,19 +723,101 @@ fn api_token_usage_from_committed(info: &CommittedInfo) -> Option<ApiTokenUsageD
     })
 }
 
-fn api_checkpoint_from_committed(info: CommittedInfo) -> ApiCheckpointDto {
+fn api_file_diff_list_from_numstat(
+    stats: HashMap<String, (u64, u64)>,
+) -> Vec<ApiCommitFileDiffDto> {
+    let mut files_touched: Vec<ApiCommitFileDiffDto> = stats
+        .into_iter()
+        .map(|(filepath, (adds, dels))| ApiCommitFileDiffDto {
+            filepath,
+            additions_count: adds,
+            deletions_count: dels,
+        })
+        .collect();
+    files_touched.sort_by(|left, right| left.filepath.cmp(&right.filepath));
+    files_touched
+}
+
+fn api_zeroed_file_diff_list(files_touched: &[String]) -> Vec<ApiCommitFileDiffDto> {
+    let mut files_touched: Vec<ApiCommitFileDiffDto> = files_touched
+        .iter()
+        .cloned()
+        .map(|filepath| ApiCommitFileDiffDto {
+            filepath,
+            additions_count: 0,
+            deletions_count: 0,
+        })
+        .collect();
+    files_touched.sort_by(|left, right| left.filepath.cmp(&right.filepath));
+    files_touched
+}
+
+fn resolve_checkpoint_files_touched(
+    repo_root: &Path,
+    branch: &str,
+    checkpoint_id: &str,
+    fallback_files_touched: &[String],
+) -> Vec<ApiCommitFileDiffDto> {
+    let branch_commits = match walk_branch_commits_with_checkpoints(
+        repo_root,
+        branch,
+        None,
+        None,
+        API_GIT_SCAN_LIMIT,
+    ) {
+        Ok(commits) => commits,
+        Err(err) => {
+            log::warn!(
+                "dashboard checkpoint endpoint: failed to walk branch {} while resolving files_touched for {}: {:#}",
+                branch,
+                checkpoint_id,
+                err
+            );
+            return api_zeroed_file_diff_list(fallback_files_touched);
+        }
+    };
+
+    let Some(commit_sha) = branch_commits
+        .into_iter()
+        .find(|commit| commit.checkpoint_id == checkpoint_id)
+        .map(|commit| commit.sha)
+    else {
+        return api_zeroed_file_diff_list(fallback_files_touched);
+    };
+
+    match read_commit_numstat(repo_root, &commit_sha) {
+        Ok(stats) => api_file_diff_list_from_numstat(stats),
+        Err(err) => {
+            log::warn!(
+                "dashboard checkpoint endpoint: failed to read numstat for {} (checkpoint {}): {:#}",
+                commit_sha,
+                checkpoint_id,
+                err
+            );
+            api_zeroed_file_diff_list(fallback_files_touched)
+        }
+    }
+}
+
+fn api_checkpoint_from_committed(
+    info: CommittedInfo,
+    files_touched: Vec<ApiCommitFileDiffDto>,
+) -> ApiCheckpointDto {
     let token_usage = api_token_usage_from_committed(&info);
+    let agents = checkpoint_agent_keys(&info);
 
     ApiCheckpointDto {
         checkpoint_id: info.checkpoint_id,
         strategy: info.strategy,
         branch: info.branch,
         checkpoints_count: info.checkpoints_count,
-        files_touched: info.files_touched,
+        files_touched,
         session_count: info.session_count,
         token_usage,
         session_id: info.session_id,
         agent: info.agent,
+        agents,
+        first_prompt_preview: info.first_prompt_preview,
         created_at: info.created_at,
         is_task: info.is_task,
         tool_use_id: info.tool_use_id,
@@ -733,8 +826,9 @@ fn api_checkpoint_from_committed(info: CommittedInfo) -> ApiCheckpointDto {
 
 fn api_commit_row_from_pair(
     pair: CommitCheckpointPair,
-    files_touched: HashMap<String, ApiCommitFileDiffDto>,
+    files_touched: Vec<ApiCommitFileDiffDto>,
 ) -> ApiCommitRowDto {
+    let checkpoint_files_touched = files_touched.clone();
     ApiCommitRowDto {
         commit: ApiCommitDto {
             sha: pair.commit.sha,
@@ -745,6 +839,6 @@ fn api_commit_row_from_pair(
             message: pair.commit.message,
             files_touched,
         },
-        checkpoint: api_checkpoint_from_committed(pair.checkpoint),
+        checkpoint: api_checkpoint_from_committed(pair.checkpoint, checkpoint_files_touched),
     }
 }

--- a/bitloops_cli/src/server/dashboard/handlers.rs
+++ b/bitloops_cli/src/server/dashboard/handlers.rs
@@ -815,7 +815,6 @@ fn api_checkpoint_from_committed(
         session_count: info.session_count,
         token_usage,
         session_id: info.session_id,
-        agent: info.agent,
         agents,
         first_prompt_preview: info.first_prompt_preview,
         created_at: info.created_at,

--- a/bitloops_cli/src/server/dashboard/mod.rs
+++ b/bitloops_cli/src/server/dashboard/mod.rs
@@ -345,6 +345,14 @@ fn agent_matches_filter(info: &CommittedInfo, agent_filter: Option<&str>) -> boo
         return true;
     }
 
+    if !info.agents.is_empty() {
+        return info
+            .agents
+            .iter()
+            .map(|agent| canonical_agent_key(agent))
+            .any(|agent| agent == normalized);
+    }
+
     canonical_agent_key(&info.agent) == normalized
 }
 

--- a/bitloops_cli/src/server/dashboard/tests.rs
+++ b/bitloops_cli/src/server/dashboard/tests.rs
@@ -256,7 +256,10 @@ fn seed_dashboard_repo_multi_session() -> TempDir {
     )
     .expect("write transcript");
 
-    let first_prompt = "A".repeat(200);
+    let first_prompt_core = "A".repeat(200);
+    let first_prompt = format!(
+        "<file_bundle>\nfoo.txt\nbar.md\n</file_bundle>\n<context_block>\nrepo-index\n</context_block>\n   \n\t{first_prompt_core}"
+    );
     fs::write(
         checkpoint_bucket.join("0").join("prompt.txt"),
         format!("{first_prompt}\n\n---\n\nSecond prompt in first session"),
@@ -668,12 +671,7 @@ async fn api_commits_filters_by_user_agent_and_time() {
     let commits = commits_payload.as_array().expect("commits array");
     assert_eq!(commits.len(), 1);
     assert_eq!(commits[0]["checkpoint"]["checkpoint_id"], "aabbccddeeff");
-    assert_eq!(
-        commits[0]["checkpoint"]["agent"]
-            .as_str()
-            .map(super::canonical_agent_key),
-        Some("claude-code".to_string())
-    );
+    assert!(commits[0]["checkpoint"].get("agent").is_none());
     assert_eq!(
         commits[0]["checkpoint"]["agents"].as_array().map(Vec::len),
         Some(1)
@@ -747,7 +745,6 @@ async fn api_commits_includes_all_checkpoint_agents_and_first_prompt_preview() {
 
     let checkpoint = &commits[0]["checkpoint"];
     assert_eq!(checkpoint["checkpoint_id"], "112233445566");
-    assert_eq!(checkpoint["agent"], "gemini-cli");
     assert_eq!(
         checkpoint["agents"].as_array().cloned().unwrap_or_default(),
         vec![json!("claude-code"), json!("gemini-cli")]
@@ -757,6 +754,7 @@ async fn api_commits_includes_all_checkpoint_agents_and_first_prompt_preview() {
         checkpoint["first_prompt_preview"].as_str(),
         Some(expected_preview.as_str())
     );
+    assert!(checkpoint.get("agent").is_none());
 
     let (status, claude_filtered) =
         request_json(app.clone(), "/api/commits?branch=main&agent=claude-code").await;

--- a/bitloops_cli/src/server/dashboard/tests.rs
+++ b/bitloops_cli/src/server/dashboard/tests.rs
@@ -140,6 +140,151 @@ fn seed_dashboard_repo() -> TempDir {
     dir
 }
 
+fn seed_dashboard_repo_multi_session() -> TempDir {
+    let dir = TempDir::new().expect("temp dir");
+    let repo_root = dir.path();
+
+    git_ok(repo_root, &["init"]);
+    git_ok(repo_root, &["checkout", "-B", "main"]);
+    git_ok(repo_root, &["config", "user.name", "Alice"]);
+    git_ok(repo_root, &["config", "user.email", "alice@example.com"]);
+
+    fs::write(repo_root.join("app.rs"), "fn main() {}\n").expect("write app.rs");
+    git_ok(repo_root, &["add", "app.rs"]);
+    git_ok(repo_root, &["commit", "-m", "Initial commit"]);
+
+    fs::write(
+        repo_root.join("app.rs"),
+        "fn main() { println!(\"ok\"); }\n",
+    )
+    .expect("update app.rs");
+    git_ok(repo_root, &["add", "app.rs"]);
+    git_ok(
+        repo_root,
+        &[
+            "commit",
+            "-m",
+            "Checkpoint commit",
+            "-m",
+            &format!("{CHECKPOINT_TRAILER_KEY}: 112233445566"),
+        ],
+    );
+
+    git_ok(
+        repo_root,
+        &["checkout", "--orphan", "bitloops/checkpoints/v1"],
+    );
+    let checkpoint_bucket = repo_root.join("11").join("2233445566");
+    fs::create_dir_all(checkpoint_bucket.join("0")).expect("create checkpoint directories");
+    fs::create_dir_all(checkpoint_bucket.join("1")).expect("create checkpoint directories");
+
+    let top_metadata = json!({
+        "checkpoint_id": "112233445566",
+        "strategy": "manual-commit",
+        "branch": "main",
+        "checkpoints_count": 3,
+        "files_touched": ["app.rs"],
+        "sessions": [{
+            "metadata": "/11/2233445566/0/metadata.json",
+            "transcript": "/11/2233445566/0/full.jsonl",
+            "context": "/11/2233445566/0/context.md",
+            "content_hash": "/11/2233445566/0/content_hash.txt",
+            "prompt": "/11/2233445566/0/prompt.txt"
+        }, {
+            "metadata": "/11/2233445566/1/metadata.json",
+            "transcript": "/11/2233445566/1/full.jsonl",
+            "context": "/11/2233445566/1/context.md",
+            "content_hash": "/11/2233445566/1/content_hash.txt",
+            "prompt": "/11/2233445566/1/prompt.txt"
+        }],
+        "token_usage": {
+            "input_tokens": 200,
+            "output_tokens": 80,
+            "cache_creation_tokens": 20,
+            "cache_read_tokens": 10,
+            "api_call_count": 6
+        }
+    });
+    let session_zero_metadata = json!({
+        "checkpoint_id": "112233445566",
+        "session_id": "session-1",
+        "checkpoints_count": 1,
+        "strategy": "manual-commit",
+        "agent": "claude-code",
+        "created_at": "2026-02-27T12:00:00Z",
+        "cli_version": "0.0.3",
+        "files_touched": ["app.rs"],
+        "is_task": false,
+        "tool_use_id": ""
+    });
+    let session_one_metadata = json!({
+        "checkpoint_id": "112233445566",
+        "session_id": "session-2",
+        "checkpoints_count": 2,
+        "strategy": "manual-commit",
+        "agent": "gemini-cli",
+        "created_at": "2026-02-27T12:10:00Z",
+        "cli_version": "0.0.3",
+        "files_touched": ["app.rs"],
+        "is_task": false,
+        "tool_use_id": ""
+    });
+
+    fs::write(
+        checkpoint_bucket.join("metadata.json"),
+        serde_json::to_string_pretty(&top_metadata).expect("serialize top metadata"),
+    )
+    .expect("write top metadata");
+    fs::write(
+        checkpoint_bucket.join("0").join("metadata.json"),
+        serde_json::to_string_pretty(&session_zero_metadata).expect("serialize session metadata"),
+    )
+    .expect("write session metadata");
+    fs::write(
+        checkpoint_bucket.join("1").join("metadata.json"),
+        serde_json::to_string_pretty(&session_one_metadata).expect("serialize session metadata"),
+    )
+    .expect("write session metadata");
+    fs::write(
+        checkpoint_bucket.join("0").join("full.jsonl"),
+        "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"A\"}]}}\n",
+    )
+    .expect("write transcript");
+    fs::write(
+        checkpoint_bucket.join("1").join("full.jsonl"),
+        "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"B\"}]}}\n",
+    )
+    .expect("write transcript");
+
+    let first_prompt = "A".repeat(200);
+    fs::write(
+        checkpoint_bucket.join("0").join("prompt.txt"),
+        format!("{first_prompt}\n\n---\n\nSecond prompt in first session"),
+    )
+    .expect("write prompt");
+    fs::write(
+        checkpoint_bucket.join("1").join("prompt.txt"),
+        "Second session prompt",
+    )
+    .expect("write prompt");
+    fs::write(
+        checkpoint_bucket.join("0").join("context.md"),
+        "Context one",
+    )
+    .expect("write context");
+    fs::write(
+        checkpoint_bucket.join("1").join("context.md"),
+        "Context two",
+    )
+    .expect("write context");
+
+    git_ok(repo_root, &["add", "11"]);
+    git_ok(repo_root, &["commit", "-m", "checkpoint metadata"]);
+    git_ok(repo_root, &["checkout", "main"]);
+
+    dir
+}
+
 async fn request_json(app: axum::Router, uri: &str) -> (StatusCode, Value) {
     request_json_with_method(app, Method::GET, uri, Body::empty()).await
 }
@@ -530,11 +675,36 @@ async fn api_commits_filters_by_user_agent_and_time() {
         Some("claude-code".to_string())
     );
     assert_eq!(
-        commits[0]["commit"]["files_touched"]["app.rs"]["additionsCount"].as_u64(),
+        commits[0]["checkpoint"]["agents"].as_array().map(Vec::len),
         Some(1)
     );
     assert_eq!(
-        commits[0]["commit"]["files_touched"]["app.rs"]["deletionsCount"].as_u64(),
+        commits[0]["checkpoint"]["agents"][0].as_str(),
+        Some("claude-code")
+    );
+    assert_eq!(
+        commits[0]["checkpoint"]["first_prompt_preview"].as_str(),
+        Some("Build dashboard API")
+    );
+    let commit_files_touched = commits[0]["commit"]["files_touched"]
+        .as_array()
+        .expect("commit files_touched array");
+    assert_eq!(commit_files_touched.len(), 1);
+    assert_eq!(commit_files_touched[0]["filepath"], "app.rs");
+    assert_eq!(commit_files_touched[0]["additionsCount"].as_u64(), Some(1));
+    assert_eq!(commit_files_touched[0]["deletionsCount"].as_u64(), Some(1));
+
+    let checkpoint_files_touched = commits[0]["checkpoint"]["files_touched"]
+        .as_array()
+        .expect("checkpoint files_touched array");
+    assert_eq!(checkpoint_files_touched.len(), 1);
+    assert_eq!(checkpoint_files_touched[0]["filepath"], "app.rs");
+    assert_eq!(
+        checkpoint_files_touched[0]["additionsCount"].as_u64(),
+        Some(1)
+    );
+    assert_eq!(
+        checkpoint_files_touched[0]["deletionsCount"].as_u64(),
         Some(1)
     );
 
@@ -559,6 +729,51 @@ async fn api_commits_filters_by_user_agent_and_time() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(time_filtered.as_array().map(Vec::len), Some(0));
+}
+
+#[tokio::test]
+async fn api_commits_includes_all_checkpoint_agents_and_first_prompt_preview() {
+    let repo = seed_dashboard_repo_multi_session();
+    let app = build_dashboard_router(test_state(
+        repo.path().to_path_buf(),
+        ServeMode::HelloWorld,
+        repo.path().to_path_buf(),
+    ));
+
+    let (status, commits_payload) = request_json(app.clone(), "/api/commits?branch=main").await;
+    assert_eq!(status, StatusCode::OK);
+    let commits = commits_payload.as_array().expect("commits array");
+    assert_eq!(commits.len(), 1);
+
+    let checkpoint = &commits[0]["checkpoint"];
+    assert_eq!(checkpoint["checkpoint_id"], "112233445566");
+    assert_eq!(checkpoint["agent"], "gemini-cli");
+    assert_eq!(
+        checkpoint["agents"].as_array().cloned().unwrap_or_default(),
+        vec![json!("claude-code"), json!("gemini-cli")]
+    );
+    let expected_preview = "A".repeat(160);
+    assert_eq!(
+        checkpoint["first_prompt_preview"].as_str(),
+        Some(expected_preview.as_str())
+    );
+
+    let (status, claude_filtered) =
+        request_json(app.clone(), "/api/commits?branch=main&agent=claude-code").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(claude_filtered.as_array().map(Vec::len), Some(1));
+
+    let (status, gemini_filtered) =
+        request_json(app.clone(), "/api/commits?branch=main&agent=gemini-cli").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(gemini_filtered.as_array().map(Vec::len), Some(1));
+
+    let (status, agents_payload) = request_json(app, "/api/agents?branch=main").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        agents_payload.as_array().cloned().unwrap_or_default(),
+        vec![json!({"key": "claude-code"}), json!({"key": "gemini-cli"})]
+    );
 }
 
 #[tokio::test]
@@ -590,6 +805,13 @@ async fn api_checkpoint_returns_detailed_session_payload() {
     assert_eq!(payload["checkpoint_id"], "aabbccddeeff");
     assert_eq!(payload["session_count"].as_u64(), Some(1));
     assert_eq!(payload["token_usage"]["input_tokens"].as_u64(), Some(100));
+    let files_touched = payload["files_touched"]
+        .as_array()
+        .expect("files_touched array");
+    assert_eq!(files_touched.len(), 1);
+    assert_eq!(files_touched[0]["filepath"], "app.rs");
+    assert_eq!(files_touched[0]["additionsCount"].as_u64(), Some(1));
+    assert_eq!(files_touched[0]["deletionsCount"].as_u64(), Some(1));
 
     let sessions = payload["sessions"].as_array().expect("sessions array");
     assert_eq!(sessions.len(), 1);


### PR DESCRIPTION
## Summary

This pull request significantly improves the dashboard API to better support checkpoints with multiple session agents and provides richer, more consistent data for consumers. The most important changes are grouped below by theme:

- Dashboard `/api/commits` now returns all checkpoint session agents via `checkpoint.agents` and no longer exposes a singular `checkpoint.agent` value.
- Dashboard `/api/commits` now includes `checkpoint.first_prompt_preview` with the first 160 characters from the first prompt of the first checkpoint session, after stripping leading `<tag>...</tag>` blocks and trimming leading whitespace.
- Dashboard agent filtering/aggregation now evaluates all session agents per checkpoint, so `/api/commits` agent filters, `/api/agents`, and KPI agent counts reflect multi-session checkpoints correctly.
- Dashboard `files_touched` payloads in `/api/commits` (`commit.files_touched` and `checkpoint.files_touched`) and `/api/checkpoints/{checkpoint_id}` now return arrays of objects (`[{ filepath, additionsCount, deletionsCount }]`) instead of path-keyed maps or plain path arrays.

**API Data Model and Response Improvements**

* The `/api/commits` endpoint now returns all checkpoint session agents via `checkpoint.agents` (previously only a singular `checkpoint.agent` was exposed), and includes a new `checkpoint.first_prompt_preview` field with a sanitized preview of the first prompt. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R15) [[2]](diffhunk://#diff-e07573451624cab268dc9e8adb0d31ee16278cda6f3d73d57ef80dc9c3dfafaaR78-R81) [[3]](diffhunk://#diff-e07573451624cab268dc9e8adb0d31ee16278cda6f3d73d57ef80dc9c3dfafaaR170-R234) [[4]](diffhunk://#diff-6c620ac5555be7abb8bba644b75625719e6fd7edd725d30183c9ba1680ebcd30L93-R97)
* The `files_touched` payloads in `/api/commits`, `/api/checkpoints/{checkpoint_id}`, and related DTOs have been changed from path-keyed maps or arrays to arrays of objects containing `filepath`, `additionsCount`, and `deletionsCount`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R15) [[2]](diffhunk://#diff-6c620ac5555be7abb8bba644b75625719e6fd7edd725d30183c9ba1680ebcd30L93-R97) [[3]](diffhunk://#diff-6c620ac5555be7abb8bba644b75625719e6fd7edd725d30183c9ba1680ebcd30R106) [[4]](diffhunk://#diff-6c620ac5555be7abb8bba644b75625719e6fd7edd725d30183c9ba1680ebcd30L118-R119) [[5]](diffhunk://#diff-6c620ac5555be7abb8bba644b75625719e6fd7edd725d30183c9ba1680ebcd30L199-R200)

**Multi-Agent Support and Filtering**

* Agent filtering and aggregation now evaluates all session agents per checkpoint, ensuring `/api/commits` agent filters, `/api/agents`, and KPI agent counts accurately reflect multi-session checkpoints. Helper functions and filtering logic have been updated to handle multiple agents. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R15) [[2]](diffhunk://#diff-e07573451624cab268dc9e8adb0d31ee16278cda6f3d73d57ef80dc9c3dfafaaL110-R144) [[3]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29L254-L264) [[4]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29L658-R649) [[5]](diffhunk://#diff-cab336a9b36e888b74e9c1659238107983688b807ed8bd7d84c497bf90766f57R348-R355)
* Test coverage was updated to verify that multi-session agent lists and latest session agent selection behave as expected. [[1]](diffhunk://#diff-20f937e1341735d1918ef83569ba5d530c9da01942fb106a3d4f5506f8f0f539R2645) [[2]](diffhunk://#diff-20f937e1341735d1918ef83569ba5d530c9da01942fb106a3d4f5506f8f0f539L2660-R2668)

**Prompt Preview Extraction**

* Added logic to extract and sanitize the first prompt preview from the first session of a checkpoint, stripping leading tag blocks and whitespace, and truncating to 160 characters.

**File Diff Handling and Consistency**

* Refactored file diff handling so that all endpoints consistently return arrays of file diff objects, and added fallback logic for cases where file stats cannot be read. [[1]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29L100-R108) [[2]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29R336-R348) [[3]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29L715-R819) [[4]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29L736-R830) [[5]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29L748-R841)

**Internal Refactoring and Cleanup**

* Removed unused imports and simplified code for agent key normalization, file diff object creation, and prompt preview extraction. [[1]](diffhunk://#diff-6c620ac5555be7abb8bba644b75625719e6fd7edd725d30183c9ba1680ebcd30L7) [[2]](diffhunk://#diff-e07573451624cab268dc9e8adb0d31ee16278cda6f3d73d57ef80dc9c3dfafaaL674) [[3]](diffhunk://#diff-178381352c996df7241797d3c4ddf0b83ba11f4fc7c9c6749b8fa9858efe8e29R24)

These changes ensure dashboard APIs accurately reflect multi-session checkpoints, provide richer metadata, and deliver more consistent and structured responses for downstream consumers.

## Validation

- [X] I ran the relevant tests locally.
- [X] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

