### PR TITLE
Improve the code quality be removing dead code comments

### DIFF
--- a/bitloops_cli/src/engine/hooks/runtime/agent_runtime.rs
+++ b/bitloops_cli/src/engine/hooks/runtime/agent_runtime.rs
@@ -78,7 +78,6 @@ pub struct UserPromptSubmitInput {
 
 /// Used by pre-task.
 ///
-#[allow(dead_code)] // fields reserved for future transcript handling
 #[derive(Debug, Deserialize)]
 pub struct TaskHookInput {
     #[serde(default)]
@@ -93,7 +92,6 @@ pub struct TaskHookInput {
 
 /// Used by post-task.
 ///
-#[allow(dead_code)] // fields reserved for future transcript handling
 #[derive(Debug, Deserialize)]
 pub struct PostTaskInput {
     #[serde(default)]
@@ -116,7 +114,6 @@ pub struct TaskToolResponse {
 
 /// Used by post-todo.
 ///
-#[allow(dead_code)] // fields reserved for future transcript handling
 #[derive(Debug, Deserialize)]
 pub struct PostTodoInput {
     #[serde(default)]

--- a/bitloops_cli/src/engine/strategy/mod.rs
+++ b/bitloops_cli/src/engine/strategy/mod.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 
 /// Context passed to `save_step` when a turn ends.
 ///
-#[allow(dead_code)] // fields consumed by ManualCommitStrategy
 #[derive(Debug, Clone, Default)]
 pub struct StepContext {
     pub session_id: String,
@@ -42,7 +41,6 @@ pub struct StepContext {
 
 /// Context passed to `save_task_step` for subagent / incremental checkpoints.
 ///
-#[allow(dead_code)] // fields consumed by ManualCommitStrategy
 #[derive(Debug, Clone, Default)]
 pub struct TaskStepContext {
     pub session_id: String,

--- a/bitloops_cli/src/test_support/logger_lock.rs
+++ b/bitloops_cli/src/test_support/logger_lock.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::sync::{Mutex, OnceLock};
 
 fn logger_test_lock() -> &'static Mutex<()> {
@@ -12,4 +10,15 @@ pub(crate) fn with_logger_test_lock<T>(f: impl FnOnce() -> T) -> T {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     f()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::with_logger_test_lock;
+
+    #[test]
+    fn lock_wrapper_executes_closure() {
+        let value = with_logger_test_lock(|| 42);
+        assert_eq!(value, 42);
+    }
 }

--- a/bitloops_cli/src/test_support/process_state.rs
+++ b/bitloops_cli/src/test_support/process_state.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
-#[allow(dead_code)]
 pub(crate) const GIT_ENV_KEYS: [&str; 6] = [
     "GIT_DIR",
     "GIT_WORK_TREE",
@@ -19,14 +18,12 @@ fn process_state_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-#[allow(dead_code)]
 pub(crate) fn strip_inherited_git_env(cmd: &mut Command) {
     for key in GIT_ENV_KEYS {
         cmd.env_remove(key);
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn git_command() -> Command {
     let mut cmd = Command::new("git");
     strip_inherited_git_env(&mut cmd);
@@ -129,7 +126,6 @@ pub(crate) fn with_cwd<T>(path: &Path, f: impl FnOnce() -> T) -> T {
     with_process_state(Some(path), &[], f)
 }
 
-#[allow(dead_code)]
 pub(crate) fn with_env_var<T>(key: &str, value: Option<&str>, f: impl FnOnce() -> T) -> T {
     with_process_state(None, &[(key, value)], f)
 }
@@ -138,7 +134,6 @@ pub(crate) fn with_env_vars<T>(vars: &[(&str, Option<&str>)], f: impl FnOnce() -
     with_process_state(None, vars, f)
 }
 
-#[allow(dead_code)]
 pub(crate) fn with_git_env_cleared<T>(f: impl FnOnce() -> T) -> T {
     let mut updates = Vec::with_capacity(GIT_ENV_KEYS.len());
     for key in GIT_ENV_KEYS {
@@ -150,6 +145,8 @@ pub(crate) fn with_git_env_cleared<T>(f: impl FnOnce() -> T) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
     fn strip_inherited_git_env_removes_poisoned_git_dir_from_child() {
@@ -174,5 +171,20 @@ mod tests {
             "expected sanitized child git command to succeed"
         );
         assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), ".git");
+    }
+
+    #[test]
+    fn git_command_sets_program_to_git() {
+        let cmd = git_command();
+        assert_eq!(cmd.get_program(), OsStr::new("git"));
+    }
+
+    #[test]
+    fn with_git_env_cleared_runs_closure() {
+        let called = AtomicBool::new(false);
+        with_git_env_cleared(|| {
+            called.store(true, Ordering::SeqCst);
+        });
+        assert!(called.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
## Summary
This PR removes `#[allow(dead_code)]` usage for the resolved CLI-1193 cases while keeping behavior unchanged.  
Cases 1-4 are completed. Case 5 (`devql`) is intentionally deferred and keeps a documented temporary `#[allow(dead_code)]`.

## What changed
- Removed module-level dead-code suppression from `bitloops_cli/src/test_support/logger_lock.rs`.
- Removed 5 item-level dead-code suppressions from `bitloops_cli/src/test_support/process_state.rs`.
- Removed 2 struct-level dead-code suppressions from `bitloops_cli/src/engine/strategy/mod.rs`.
- Removed 3 struct-level dead-code suppressions from `bitloops_cli/src/engine/hooks/runtime/agent_runtime.rs`.
- Kept `#[allow(dead_code)]` in `bitloops_cli/src/commands/devql.rs` (intentional, deferred case).
- Added minimal local tests in test-support helpers to satisfy target-level dead-code checks without reintroducing broad allows.
- Updated `CLI-1193.md` with per-case status/evidence (cases 1-4 resolved, case 5 deferred).
- Added `CLI-1193-process_state-best-practice.md` with long-term recommended fix (thin binary + library-first module wiring).

## Why tests were added in test_support
Rust checks `dead_code` per target (`lib`, `bin`, `bin test`, etc.), not globally.  
Some helpers were used in one target but still reported as dead in another, so minimal unit tests were added to create real usage in those targets.

## Validation performed
- `cargo check --all-targets` (from `bitloops_cli/`) after each step.
- Focused strategy tests:
  - `cargo test engine::strategy::auto_commit::tests::auto_commit_save_step_commit_has_metadata_ref -- --nocapture`
  - `cargo test engine::strategy::manual_commit::tests::save_step_creates_shadow_branch -- --nocapture`
- Focused runtime hook tests:
  - `cargo test pre_task_creates_marker -- --nocapture`
  - `cargo test post_task_saves_task_step_when_changes_exist -- --nocapture`
- Focused helper tests:
  - `cargo test lock_wrapper_executes_closure -- --nocapture`
  - `cargo test with_git_env_cleared_runs_closure -- --nocapture`
- Final scan confirms only intentional remaining suppression:
  - `bitloops_cli/src/commands/devql.rs` (`#[allow(dead_code)]` retained by decision)

## Notes
- No functional behavior changes intended.
- DevQL case remains documented and deferred for a future structural cleanup.
