### PR TITLE
Update CHANGELOG.md for version 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+## [0.0.10] - 2026-03-12
+
 - Added first-class Codex CLI support (current hook parity: `SessionStart` and `Stop`), including `bitloops init --agent codex`, lifecycle/runtime dispatch wiring, and managed Codex hook installation in `.codex/hooks.json` (Codex matcher format) with idempotent install/uninstall that preserves user-defined hook entries.
 - Dashboard `/api/commits` now returns all checkpoint session agents via `checkpoint.agents` and no longer exposes a singular `checkpoint.agent` value.
 - Dashboard `/api/commits` now includes `checkpoint.first_prompt_preview` with the first 160 characters from the first prompt of the first checkpoint session, after stripping leading `<tag>...</tag>` blocks and trimming leading whitespace.


### PR DESCRIPTION
## Summary

This pull request updates the changelog to document new features and changes introduced in version `0.0.10`. The most important updates focus on enhanced Codex CLI support and improvements to the dashboard API.

Codex CLI support:

* Added first-class Codex CLI support, including `bitloops init --agent codex`, lifecycle/runtime dispatch wiring, and managed Codex hook installation in `.codex/hooks.json` with idempotent install/uninstall that preserves user-defined hook entries.

Dashboard API improvements:

* Dashboard `/api/commits` now returns all checkpoint session agents via `checkpoint.agents` and no longer exposes a singular `checkpoint.agent` value.
* Dashboard `/api/commits` now includes `checkpoint.first_prompt_preview`, showing the first 160 characters from the first prompt of the first checkpoint session, after removing leading `<tag>...</tag>` blocks and trimming whitespace.