### PR TITLE
Fix rust file size to non gitignore files

### DIFF
--- a/scripts/check-rust-file-size.sh
+++ b/scripts/check-rust-file-size.sh
@@ -5,11 +5,13 @@ set -euo pipefail
 # - default max applies to non-test files
 # - known legacy outliers can use a per-file budget
 # - test files are ignored by default (set INCLUDE_TESTS=1 to include)
+# - gitignored files are skipped
 
 ROOT="${1:-bitloops_cli}"
 WARN_LINES="${RUST_FILE_WARN_LINES:-500}"
 MAX_LINES="${RUST_FILE_MAX_LINES:-1000}"
 INCLUDE_TESTS="${INCLUDE_TESTS:-0}"
+GIT_TOPLEVEL="$(git -C "$ROOT" rev-parse --show-toplevel 2>/dev/null || true)"
 
 declare -A LEGACY_MAX_LINES=()
 
@@ -32,6 +34,12 @@ declare -a size_index=()
 is_test_file() {
   local path="$1"
   [[ "$path" == */tests/* || "$path" == *_test.rs || "$path" == *tests.rs || "$path" == *_tests.rs ]]
+}
+
+is_gitignored_file() {
+  local path="$1"
+  [[ -z "$GIT_TOPLEVEL" ]] && return 1
+  git -C "$GIT_TOPLEVEL" check-ignore -q -- "$path"
 }
 
 resolve_legacy_max_for_file() {
@@ -57,6 +65,10 @@ resolve_legacy_max_for_file() {
 
 for file in "${rust_files[@]}"; do
   if [[ "$INCLUDE_TESTS" != "1" ]] && is_test_file "$file"; then
+    continue
+  fi
+
+  if is_gitignored_file "$file"; then
     continue
   fi
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

