### PR TITLE
Remove configuration for Linux arm64 linker from CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,6 @@ jobs:
         if: contains(matrix.target, 'unknown-linux-musl')
         run: sudo apt-get install -y musl-tools
 
-      - name: Configure Linux arm64 linker
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld" >> "$GITHUB_ENV"
-
       - name: Install qemu for Linux arm64 smoke test
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Configure Linux arm64 linker
-        if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld" >> "$GITHUB_ENV"
-
       - name: Install qemu for Linux arm64 smoke test
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: |


### PR DESCRIPTION
Remove configuration for Linux arm64 linker from CI and release workflows

## Summary

This pull request makes a small change to the CI and release workflows by removing the step that configures the Linux arm64 linker for the `aarch64-unknown-linux-musl` target. This step is no longer needed and has been removed from both `.github/workflows/ci.yml` and `.github/workflows/release.yml`.

