### PR TITLE
Add --no-verify option to git push in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,7 +60,7 @@ git tag "$VERSION"
 
 echo ""
 echo "Pushing tag $VERSION to origin..."
-git push origin "$VERSION"
+git push origin "$VERSION" --no-verify
 
 echo ""
 echo "Done. Watch the build at:"


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

