### PR TITLE
Update GitHub Actions to use self-hosted runners for all workflows

### DIFF
--- a/.github/workflows/allow-main-only-via-develop.yml
+++ b/.github/workflows/allow-main-only-via-develop.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-source-branch:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Check PR source branch
         run: |

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   changelog:
     name: Changelog updated
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Skip if labeled
         if: contains(github.event.pull_request.labels.*.name, 'skip-changelog')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
     paths:
-      - 'bitloops_cli/**'
-      - 'scripts/check-rust-file-size.sh'
-      - '.github/workflows/ci.yml'
+      - "bitloops_cli/**"
+      - "scripts/check-rust-file-size.sh"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ permissions:
 jobs:
   rust-file-size:
     name: Rust File Size
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Install ripgrep
@@ -24,7 +24,7 @@ jobs:
         run: bash scripts/check-rust-file-size.sh
   test:
     name: Test compile (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
 
   publish:
     name: Publish release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     steps:
       - name: Download packaged artifacts
@@ -140,7 +140,7 @@ jobs:
 
   update-homebrew-tap:
     name: Update Homebrew tap formula
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: publish
     environment: "Production CLI"
     steps:
@@ -226,7 +226,7 @@ jobs:
 
   verify:
     name: Verify published release artifacts
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: publish
     steps:
       - name: Download assets from published release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- Added self-hosted runners
+
 ## [0.0.10] - 2026-03-12
 
 - Added first-class Codex CLI support (current hook parity: `SessionStart` and `Stop`), including `bitloops init --agent codex`, lifecycle/runtime dispatch wiring, and managed Codex hook installation in `.codex/hooks.json` (Codex matcher format) with idempotent install/uninstall that preserves user-defined hook entries.


### PR DESCRIPTION
## Summary

This pull request updates several GitHub Actions workflow files to use self-hosted runners instead of the default `ubuntu-latest` runners. This change affects CI, release, and changelog workflows, and ensures that all jobs now run on self-hosted infrastructure. Additionally, minor formatting changes were made to path patterns in the CI workflow.

Runner migration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL8-R18): Changed `runs-on` for both `rust-file-size` and `test` jobs to `self-hosted` instead of `ubuntu-latest`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL8-R18) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL27-R27)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L119-R119): Updated `runs-on` for `publish`, `update-homebrew-tap`, and `verify` jobs to use `self-hosted`. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L119-R119) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L143-R143) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L229-R229)
* [`.github/workflows/allow-main-only-via-develop.yml`](diffhunk://#diff-d4fdabeaf8cce17b913b065d665a7dee205fe1a3375a4c7dd9f886542efa1547L10-R10): Changed `runs-on` for `check-source-branch` job to `self-hosted`.
* [`.github/workflows/changelog-check.yml`](diffhunk://#diff-2108dec535bb905ed27733615bcb17ffa3c7e0e51dc5b433f5f8970cae0d2b73L15-R15): Updated `runs-on` for `changelog` job to `self-hosted`.

Minor formatting:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL8-R18): Standardized path patterns to use double quotes for consistency.