### PR TITLE
Enhance cli ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - DevQL maintains both a **current snapshot** and full **historical record** of artefacts and edges, allowing point-in-time queries over the evolution of a codebase.
 - Tree-sitter is now used as the parsing backend for all DevQL code extraction, providing accurate language-aware symbol resolution.
 - Updated DevQL Getting Started documentation with expanded field references and query examples.
+- Improved the version command and added a `bitloops --version --check` flag to check for the latest version.
+- Cut down the `bitloops dashboard` loading time by moving the host name detection from the DNS probe to the .bitloops/config.json file.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Tree-sitter is now used as the parsing backend for all DevQL code extraction, providing accurate language-aware symbol resolution.
 - Updated DevQL Getting Started documentation with expanded field references and query examples.
 - Improved the version command and added a `bitloops --version --check` flag to check for the latest version.
-- Cut down the `bitloops dashboard` loading time by moving the host name detection from the DNS probe to the .bitloops/config.json file.
+- Cut down the `bitloops dashboard` loading time by moving the host name detection from the DNS probe to the user-home config file (`~/.bitloops/config.json`).
 
 ### Changed
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,175 @@
+# Configuration Reference
+
+This file documents the user-facing configuration values used by Bitloops CLI.
+
+Scope:
+- Runtime config files
+- Repository settings
+- Supported `BITLOOPS_*` environment variables
+- Build-time dashboard URL config
+
+Test-only env vars are intentionally excluded.
+
+## 1) Global user config (`~/.bitloops/config.json`)
+
+Primary use:
+- DevQL backend/provider selection
+- Dashboard host preference
+
+DevQL precedence:
+1. Environment variables
+2. `~/.bitloops/config.json`
+3. Built-in defaults
+
+### Recommended DevQL shape
+
+```json
+{
+  "devql": {
+    "relational": {
+      "provider": "sqlite",
+      "sqlite_path": "~/.bitloops/devql/relational.db"
+    },
+    "events": {
+      "provider": "duckdb",
+      "duckdb_path": "~/.bitloops/devql/events.duckdb"
+    }
+  },
+  "dashboard": {
+    "use_bitloops_local": false
+  }
+}
+```
+
+### DevQL keys
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `devql.relational.provider` | `sqlite` \| `postgres` | `sqlite` | If omitted and Postgres DSN is present, provider is inferred as `postgres`. |
+| `devql.relational.sqlite_path` | string | `~/.bitloops/devql/relational.db` | `~` is expanded to the user home directory. |
+| `devql.relational.postgres_dsn` | string | none | Required when using `postgres` relational provider. |
+| `devql.events.provider` | `duckdb` \| `clickhouse` | `duckdb` | If omitted and any ClickHouse key is present, provider is inferred as `clickhouse`. |
+| `devql.events.duckdb_path` | string | `~/.bitloops/devql/events.duckdb` | `~` is expanded to the user home directory. |
+| `devql.events.clickhouse_url` | string | none | For legacy `devql` command paths, fallback is `http://localhost:8123` if unset. |
+| `devql.events.clickhouse_user` | string | none | Optional. |
+| `devql.events.clickhouse_password` | string | none | Optional. |
+| `devql.events.clickhouse_database` | string | none | For legacy `devql` command paths, fallback is `default` if unset. |
+
+### Legacy/alias keys still accepted
+
+The parser still accepts these aliases for backwards compatibility:
+- `postgres_dsn` or `pg_dsn`
+- `clickhouse_url` or `ch_url`
+- `clickhouse_user` or `ch_user`
+- `clickhouse_password` or `ch_password`
+- `clickhouse_database` or `ch_database`
+- `relational_provider`
+- `events_provider`
+- `sqlite_path`
+- `duckdb_path`
+
+These can appear under `devql`, and top-level fallback keys are also supported if `devql` is not present.
+
+### Dashboard key
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `dashboard.use_bitloops_local` | boolean | `false` | When `true`, dashboard defaults to host `bitloops.local` (unless `--host` is provided). |
+
+## 2) Repository settings (`.bitloops/settings*.json`)
+
+Files:
+- Project settings: `<repo>/.bitloops/settings.json`
+- Local override: `<repo>/.bitloops/settings.local.json`
+
+Merge behaviour:
+1. Load `settings.json` (or defaults if missing)
+2. Overlay `settings.local.json` (if present)
+3. Apply defaults for missing/empty values
+
+Unknown keys are rejected in these files.
+
+### Settings keys
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `strategy` | string | `manual-commit` | Valid built-ins: `manual-commit`, `auto-commit`. |
+| `enabled` | boolean | `true` | Global enable/disable switch for Bitloops in the repo. |
+| `local_dev` | boolean | `false` | Uses local dev hook commands (`cargo run ...`) for agent hook wiring. |
+| `log_level` | string | empty | Stored in settings; runtime logger level is controlled by env var `BITLOOPS_LOG_LEVEL`. |
+| `strategy_options` | object | `{}` | Strategy-specific options map. |
+| `telemetry` | boolean or null | `null` | `null` means consent not captured yet. |
+
+Known `strategy_options` in code:
+- `summarize.enabled` (boolean): enables auto-summary generation for manual-commit checkpoints.
+- `push_sessions` (boolean): only explicit `false` is currently interpreted as disabled by settings helpers.
+
+## 3) Runtime environment variables
+
+### DevQL override env vars
+
+| Variable | Purpose |
+| --- | --- |
+| `BITLOOPS_DEVQL_RELATIONAL_PROVIDER` | Overrides relational provider (`sqlite`/`postgres`). |
+| `BITLOOPS_DEVQL_EVENTS_PROVIDER` | Overrides events provider (`duckdb`/`clickhouse`). |
+| `BITLOOPS_DEVQL_SQLITE_PATH` | Overrides SQLite DB path. |
+| `BITLOOPS_DEVQL_DUCKDB_PATH` | Overrides DuckDB DB path. |
+| `BITLOOPS_DEVQL_PG_DSN` | Postgres DSN. |
+| `BITLOOPS_DEVQL_CH_URL` | ClickHouse URL. |
+| `BITLOOPS_DEVQL_CH_USER` | ClickHouse username. |
+| `BITLOOPS_DEVQL_CH_PASSWORD` | ClickHouse password. |
+| `BITLOOPS_DEVQL_CH_DATABASE` | ClickHouse database name. |
+
+### Dashboard runtime env vars
+
+| Variable | Purpose |
+| --- | --- |
+| `BITLOOPS_DASHBOARD_MANIFEST_URL` | Explicit manifest URL; highest precedence. |
+| `BITLOOPS_DASHBOARD_CDN_BASE_URL` | Base URL used to derive manifest and relative bundle asset URLs. |
+| `BITLOOPS_DEV` | Enables extra dashboard startup output for development. |
+
+Manifest resolution order:
+1. `BITLOOPS_DASHBOARD_MANIFEST_URL`
+2. `BITLOOPS_DASHBOARD_CDN_BASE_URL` + `/bundle_versions.json`
+3. Compiled `dashboard_manifest_url`
+4. Compiled `dashboard_cdn_base_url` + `/bundle_versions.json`
+
+### Logging env var
+
+| Variable | Purpose |
+| --- | --- |
+| `BITLOOPS_LOG_LEVEL` | Logger level (`DEBUG`, `INFO`, `WARN`/`WARNING`, `ERROR`). Invalid values fall back to `INFO`. |
+
+### Telemetry env vars
+
+| Variable | Purpose |
+| --- | --- |
+| `BITLOOPS_TELEMETRY_OPTOUT` | Any non-empty value disables telemetry dispatch. |
+| `BITLOOPS_POSTHOG_API_KEY` | Overrides telemetry API key. |
+| `BITLOOPS_POSTHOG_ENDPOINT` | Overrides telemetry endpoint (default: `https://eu.i.posthog.com`). |
+| `BITLOOPS_TELEMETRY_DISTINCT_ID` | Explicit distinct ID override. |
+| `BITLOOPS_TELEMETRY_FORCE_NO_DISTINCT_ID` | Any non-empty value disables distinct ID generation. |
+
+## 4) Build-time dashboard URL config (`bitloops_cli/config/dashboard_urls.json`)
+
+Used at build time by `bitloops_cli/build.rs` to compile dashboard bundle URL defaults into the binary.
+
+Expected keys:
+
+| Key | Required | Rules |
+| --- | --- | --- |
+| `dashboard_cdn_base_url` | yes | Non-empty, valid `http://` or `https://` URL |
+| `dashboard_manifest_url` | yes | Non-empty, valid `http://` or `https://` URL |
+
+Template file:
+- `bitloops_cli/config/dashboard_urls.template.json`
+
+If this file is missing or invalid, `cargo check`/`cargo build` in `bitloops_cli/` fails fast with guidance.
+
+## 5) Optional build metadata env vars
+
+These are consumed by `bitloops_cli/build.rs` and embedded into CLI version output:
+- `BITLOOPS_BUILD_VERSION`
+- `BITLOOPS_BUILD_COMMIT`
+- `BITLOOPS_BUILD_TARGET`
+- `BITLOOPS_BUILD_DATE`

--- a/DevQL-Getting_Started.md
+++ b/DevQL-Getting_Started.md
@@ -363,4 +363,4 @@ The branch adds dependency traversal on top of artefact selection.
 
 Why it matters:
 
-- Blast-radius analysis is now a first-class query path rather than an inferred or post-processed capabilit
+- Blast-radius analysis is now a first-class query path rather than an inferred or post-processed capability

--- a/DevQL-Getting_Started.md
+++ b/DevQL-Getting_Started.md
@@ -102,7 +102,7 @@ What this does:
 Example output:
 
 ```text
-DB Status
+
 +------------+-----------------------+
 | DB         | Status                |
 +------------+-----------------------+

--- a/bitloops_cli/Cargo.lock
+++ b/bitloops_cli/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "tar",
  "tempfile",
  "terminal_size 0.2.6",
+ "time",
  "tokio",
  "tokio-postgres",
  "tower",
@@ -791,6 +792,15 @@ dependencies = [
  "nom_locate",
  "regex",
  "regex-syntax",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1870,6 +1880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2105,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2964,6 +2986,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/bitloops_cli/Cargo.toml
+++ b/bitloops_cli/Cargo.toml
@@ -47,3 +47,4 @@ tower = { version = "0.5", features = ["util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+time = { version = "0.3", features = ["formatting", "macros"] }

--- a/bitloops_cli/build.rs
+++ b/bitloops_cli/build.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 use std::env;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
+use time::{OffsetDateTime, macros::format_description};
 
 const DASHBOARD_CONFIG_PATH: &str = "config/dashboard_urls.json";
 const EXAMPLE_CONFIG_PATH: &str = "config/dashboard_urls.template.json";
@@ -29,9 +31,63 @@ fn validate_url(name: &str, value: &str) {
     }
 }
 
+fn read_non_empty_env(key: &str) -> Option<String> {
+    env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn git_short_commit() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn today_utc_iso_date() -> String {
+    let format = format_description!("[year]-[month]-[day]");
+    OffsetDateTime::now_utc()
+        .format(&format)
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn emit_build_metadata() {
+    if let Some(version) = read_non_empty_env("BITLOOPS_BUILD_VERSION") {
+        println!("cargo:rustc-env=BITLOOPS_BUILD_VERSION={version}");
+    }
+
+    let commit = read_non_empty_env("BITLOOPS_BUILD_COMMIT")
+        .or_else(git_short_commit)
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=BITLOOPS_BUILD_COMMIT={commit}");
+
+    let target = read_non_empty_env("BITLOOPS_BUILD_TARGET")
+        .or_else(|| read_non_empty_env("TARGET"))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=BITLOOPS_BUILD_TARGET={target}");
+
+    let build_date = read_non_empty_env("BITLOOPS_BUILD_DATE").unwrap_or_else(today_utc_iso_date);
+    println!("cargo:rustc-env=BITLOOPS_BUILD_DATE={build_date}");
+}
+
 fn main() {
     println!("cargo:rerun-if-changed={DASHBOARD_CONFIG_PATH}");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_VERSION");
+    println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_COMMIT");
+    println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_TARGET");
+    println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_DATE");
+
+    emit_build_metadata();
 
     let raw = fs::read_to_string(DASHBOARD_CONFIG_PATH).unwrap_or_else(|err| {
         panic!(

--- a/bitloops_cli/build.rs
+++ b/bitloops_cli/build.rs
@@ -82,6 +82,8 @@ fn emit_build_metadata() {
 fn main() {
     println!("cargo:rerun-if-changed={DASHBOARD_CONFIG_PATH}");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
     println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_VERSION");
     println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_COMMIT");
     println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_TARGET");

--- a/bitloops_cli/src/branding.rs
+++ b/bitloops_cli/src/branding.rs
@@ -1,0 +1,44 @@
+use figlet_rs::FIGfont;
+use std::env;
+
+pub const BITLOOPS_PURPLE_HEX: &str = "#7404e4";
+
+pub fn should_use_color_output() -> bool {
+    env::var_os("NO_COLOR").is_none() && env::var("ACCESSIBLE").is_err()
+}
+
+pub fn color_hex(text: &str, hex: &str) -> String {
+    let hex = hex.trim_start_matches('#');
+    let r = u8::from_str_radix(hex.get(0..2).unwrap_or("00"), 16).unwrap_or(0);
+    let g = u8::from_str_radix(hex.get(2..4).unwrap_or("00"), 16).unwrap_or(0);
+    let b = u8::from_str_radix(hex.get(4..6).unwrap_or("00"), 16).unwrap_or(0);
+    format!("\x1b[38;2;{r};{g};{b}m{text}\x1b[0m")
+}
+
+pub fn color_hex_if_enabled(text: &str, hex: &str) -> String {
+    if should_use_color_output() {
+        color_hex(text, hex)
+    } else {
+        text.to_string()
+    }
+}
+
+pub fn squared_capital(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            'A'..='Z' => char::from_u32(0x1F170 + (c as u32 - 'A' as u32)).unwrap_or(c),
+            'a'..='z' => char::from_u32(0x1F170 + (c as u32 - 'a' as u32)).unwrap_or(c),
+            _ => c,
+        })
+        .collect()
+}
+
+pub fn bitloops_wordmark() -> String {
+    if let Ok(font) = FIGfont::standard()
+        && let Some(figure) = font.convert("bitloops")
+    {
+        return figure.to_string().trim_end().to_string();
+    }
+
+    squared_capital("Bitloops")
+}

--- a/bitloops_cli/src/commands/dashboard.rs
+++ b/bitloops_cli/src/commands/dashboard.rs
@@ -23,12 +23,67 @@ pub struct DashboardArgs {
     pub bundle_dir: Option<PathBuf>,
 }
 
-pub async fn run(args: DashboardArgs) -> Result<()> {
-    crate::server::dashboard::run(crate::server::dashboard::DashboardServerConfig {
+fn build_server_config(args: DashboardArgs) -> crate::server::dashboard::DashboardServerConfig {
+    crate::server::dashboard::DashboardServerConfig {
         host: args.host,
         port: args.port,
         no_open: args.no_open,
         bundle_dir: args.bundle_dir,
-    })
-    .await
+    }
+}
+
+pub async fn run(args: DashboardArgs) -> Result<()> {
+    crate::server::dashboard::run(build_server_config(args)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{Cli, Commands};
+    use clap::Parser;
+
+    #[test]
+    fn dashboard_cli_maps_bundle_alias_into_server_config() {
+        let parsed = Cli::try_parse_from([
+            "bitloops",
+            "dashboard",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "6100",
+            "--no-open",
+            "--bundle",
+            "/tmp/custom-bundle",
+        ])
+        .expect("dashboard invocation should parse");
+
+        let Some(Commands::Dashboard(args)) = parsed.command else {
+            panic!("expected dashboard command");
+        };
+
+        let config = build_server_config(args);
+        assert_eq!(config.host.as_deref(), Some("0.0.0.0"));
+        assert_eq!(config.port, 6100);
+        assert!(config.no_open);
+        assert_eq!(config.bundle_dir, Some(PathBuf::from("/tmp/custom-bundle")));
+    }
+
+    #[test]
+    fn dashboard_cli_defaults_track_server_defaults() {
+        let parsed = Cli::try_parse_from(["bitloops", "dashboard"])
+            .expect("dashboard invocation should parse");
+
+        let Some(Commands::Dashboard(args)) = parsed.command else {
+            panic!("expected dashboard command");
+        };
+
+        assert_eq!(args.port, DEFAULT_DASHBOARD_PORT);
+        assert_eq!(
+            DEFAULT_DASHBOARD_PORT,
+            crate::server::dashboard::DEFAULT_DASHBOARD_PORT
+        );
+        assert!(args.host.is_none());
+        assert!(args.bundle_dir.is_none());
+        assert!(!args.no_open);
+    }
 }

--- a/bitloops_cli/src/commands/devql.rs
+++ b/bitloops_cli/src/commands/devql.rs
@@ -6,6 +6,8 @@ use crate::engine::paths;
 
 pub use crate::engine::devql::run_connection_status;
 
+const MISSING_SUBCOMMAND_MESSAGE: &str = "missing subcommand. Use one of: `bitloops devql init`, `bitloops devql ingest`, `bitloops devql query`, `bitloops devql connection-status`";
+
 #[derive(Args, Debug, Clone, Default)]
 pub struct DevqlArgs {
     #[command(subcommand)]
@@ -53,9 +55,7 @@ pub struct DevqlConnectionStatusArgs {}
 
 pub async fn run(args: DevqlArgs) -> Result<()> {
     let Some(command) = args.command else {
-        bail!(
-            "missing subcommand. Use one of: `bitloops devql init`, `bitloops devql ingest`, `bitloops devql query`, `bitloops devql connection-status`"
-        );
+        bail!(MISSING_SUBCOMMAND_MESSAGE);
     };
 
     if matches!(&command, DevqlCommand::ConnectionStatus(_)) {
@@ -71,5 +71,127 @@ pub async fn run(args: DevqlArgs) -> Result<()> {
         DevqlCommand::Ingest(args) => run_ingest(&cfg, args.init, args.max_checkpoints).await,
         DevqlCommand::Query(args) => run_query(&cfg, &args.query, args.compact).await,
         DevqlCommand::ConnectionStatus(_) => unreachable!("handled before repo setup"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::{Cli, Commands};
+    use crate::test_support::process_state::{enter_process_state, git_command};
+    use clap::Parser;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn git_ok(repo_root: &Path, args: &[&str]) {
+        let out = git_command()
+            .args(args)
+            .current_dir(repo_root)
+            .output()
+            .unwrap_or_else(|err| panic!("failed to start git {:?}: {err}", args));
+        assert!(
+            out.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn seed_git_repo() -> TempDir {
+        let dir = TempDir::new().expect("temp dir");
+        git_ok(dir.path(), &["init"]);
+        git_ok(dir.path(), &["checkout", "-B", "main"]);
+        git_ok(dir.path(), &["config", "user.name", "Bitloops Test"]);
+        git_ok(
+            dir.path(),
+            &["config", "user.email", "bitloops-test@example.com"],
+        );
+        dir
+    }
+
+    fn test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime")
+    }
+
+    #[test]
+    fn devql_cli_parses_ingest_defaults() {
+        let parsed = Cli::try_parse_from(["bitloops", "devql", "ingest"])
+            .expect("devql ingest should parse");
+
+        let Some(Commands::Devql(args)) = parsed.command else {
+            panic!("expected devql command");
+        };
+        let Some(DevqlCommand::Ingest(ingest)) = args.command else {
+            panic!("expected devql ingest command");
+        };
+
+        assert!(ingest.init);
+        assert_eq!(ingest.max_checkpoints, 500);
+    }
+
+    #[test]
+    fn devql_cli_parses_query_compact_flag() {
+        let parsed = Cli::try_parse_from([
+            "bitloops",
+            "devql",
+            "query",
+            "repo(\"bitloops-cli\")",
+            "--compact",
+        ])
+        .expect("devql query should parse");
+
+        let Some(Commands::Devql(args)) = parsed.command else {
+            panic!("expected devql command");
+        };
+        let Some(DevqlCommand::Query(query)) = args.command else {
+            panic!("expected devql query command");
+        };
+
+        assert_eq!(query.query, "repo(\"bitloops-cli\")");
+        assert!(query.compact);
+    }
+
+    #[test]
+    fn devql_run_requires_subcommand() {
+        let err = test_runtime()
+            .block_on(run(DevqlArgs::default()))
+            .expect_err("missing subcommand should error");
+
+        assert!(err.to_string().contains(MISSING_SUBCOMMAND_MESSAGE));
+    }
+
+    #[test]
+    fn devql_run_init_requires_pg_dsn_after_repo_resolution() {
+        let repo = seed_git_repo();
+        let home = TempDir::new().expect("home dir");
+        let home_path = home.path().to_string_lossy().to_string();
+        let _guard = enter_process_state(
+            Some(repo.path()),
+            &[
+                ("HOME", Some(home_path.as_str())),
+                ("USERPROFILE", Some(home_path.as_str())),
+                ("BITLOOPS_DEVQL_PG_DSN", None),
+                ("BITLOOPS_DEVQL_CH_URL", None),
+                ("BITLOOPS_DEVQL_CH_USER", None),
+                ("BITLOOPS_DEVQL_CH_PASSWORD", None),
+                ("BITLOOPS_DEVQL_CH_DATABASE", None),
+            ],
+        );
+
+        let err = test_runtime()
+            .block_on(run(DevqlArgs {
+                command: Some(DevqlCommand::Init(DevqlInitArgs::default())),
+            }))
+            .expect_err("missing PG DSN should error before DB setup");
+
+        assert!(
+            err.to_string()
+                .contains("BITLOOPS_DEVQL_PG_DSN is required"),
+            "unexpected error: {err:#}"
+        );
     }
 }

--- a/bitloops_cli/src/commands/enable.rs
+++ b/bitloops_cli/src/commands/enable.rs
@@ -11,7 +11,7 @@ use clap::Args;
 use crate::engine::agent::HookSupport;
 use crate::engine::agent::claude_code::git_hooks;
 use crate::engine::agent::claude_code::hooks as claude_hooks;
-use crate::engine::agent::codex::agent::CodexAgent;
+use crate::engine::agent::codex::hooks as codex_hooks;
 use crate::engine::agent::cursor::agent::CursorAgent;
 use crate::engine::agent::gemini_cli::agent::GeminiCliAgent;
 use crate::engine::agent::open_code::agent::OpenCodeAgent;
@@ -167,7 +167,7 @@ pub fn initialized_agents(repo_root: &Path) -> Vec<String> {
     if HookSupport::are_hooks_installed(&CursorAgent) {
         agents.push("cursor".to_string());
     }
-    if HookSupport::are_hooks_installed(&CodexAgent) {
+    if codex_hooks::are_hooks_installed_at(repo_root) {
         agents.push("codex".to_string());
     }
     if HookSupport::are_hooks_installed(&GeminiCliAgent) {
@@ -264,7 +264,7 @@ pub fn run_uninstall(
     let shadow_branch_count = count_shadow_branches(repo_root);
     let git_hooks_installed = git_hooks::is_git_hook_installed(repo_root);
     let claude_hooks_installed = claude_hooks::are_hooks_installed(repo_root);
-    let codex_hooks_installed = HookSupport::are_hooks_installed(&CodexAgent);
+    let codex_hooks_installed = codex_hooks::are_hooks_installed_at(repo_root);
     let cursor_hooks_installed = HookSupport::are_hooks_installed(&CursorAgent);
     let gemini_hooks_installed = HookSupport::are_hooks_installed(&GeminiCliAgent);
     let opencode_hooks_installed = HookSupport::are_hooks_installed(&OpenCodeAgent);
@@ -466,9 +466,8 @@ fn remove_agent_hooks(repo_root: &Path, out: &mut dyn Write) -> Result<()> {
         writeln!(out, "  Removed Cursor hooks")?;
     }
 
-    let codex = CodexAgent;
-    if HookSupport::are_hooks_installed(&codex) {
-        HookSupport::uninstall_hooks(&codex)?;
+    if codex_hooks::are_hooks_installed_at(repo_root) {
+        codex_hooks::uninstall_hooks_at(repo_root)?;
         writeln!(out, "  Removed Codex CLI hooks")?;
     }
 
@@ -504,7 +503,7 @@ pub fn is_fully_enabled(repo_root: &Path) -> (bool, String, String) {
         return (false, String::new(), String::new());
     }
     let claude_enabled = claude_hooks::are_hooks_installed(repo_root);
-    let codex_enabled = HookSupport::are_hooks_installed(&CodexAgent);
+    let codex_enabled = codex_hooks::are_hooks_installed_at(repo_root);
     let cursor_enabled = HookSupport::are_hooks_installed(&CursorAgent);
     let gemini_enabled = HookSupport::are_hooks_installed(&GeminiCliAgent);
     let opencode_enabled = HookSupport::are_hooks_installed(&OpenCodeAgent);

--- a/bitloops_cli/src/commands/enable_tests.rs
+++ b/bitloops_cli/src/commands/enable_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::commands::{Cli, Commands};
+use crate::engine::agent::codex::hooks as codex_hooks;
 use crate::engine::settings::{SETTINGS_DIR, settings_local_path, settings_path};
 use crate::test_support::process_state::{git_command, with_cwd, with_env_var, with_env_vars};
 use clap::Parser;
@@ -417,25 +418,23 @@ fn run_uninstall_force_removes_codex_hooks() {
     setup_git_repo(&dir);
     setup_settings(&dir, r#"{"enabled":true}"#);
 
-    with_repo_cwd(dir.path(), || {
-        HookSupport::install_hooks(&CodexAgent, false, false).unwrap();
-        assert!(
-            HookSupport::are_hooks_installed(&CodexAgent),
-            "codex hooks should be installed before uninstall"
-        );
+    codex_hooks::install_hooks_at(dir.path(), false, false).unwrap();
+    assert!(
+        codex_hooks::are_hooks_installed_at(dir.path()),
+        "codex hooks should be installed before uninstall"
+    );
 
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        run_uninstall(dir.path(), &mut out, &mut err, true).unwrap();
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    run_uninstall(dir.path(), &mut out, &mut err, true).unwrap();
 
-        assert!(
-            !HookSupport::are_hooks_installed(&CodexAgent),
-            "codex hooks should be removed"
-        );
+    assert!(
+        !codex_hooks::are_hooks_installed_at(dir.path()),
+        "codex hooks should be removed"
+    );
 
-        let output = String::from_utf8(out).unwrap();
-        assert!(output.contains("Removed Codex CLI hooks"), "{output}");
-    });
+    let output = String::from_utf8(out).unwrap();
+    assert!(output.contains("Removed Codex CLI hooks"), "{output}");
 }
 
 #[test]
@@ -818,7 +817,7 @@ fn initialized_agents_detects_claude_and_cursor() {
     with_repo_cwd(dir.path(), || {
         claude_hooks::install_hooks(dir.path(), false).unwrap();
         HookSupport::install_hooks(&CursorAgent, false, false).unwrap();
-        HookSupport::install_hooks(&CodexAgent, false, false).unwrap();
+        codex_hooks::install_hooks_at(dir.path(), false, false).unwrap();
 
         let agents = initialized_agents(dir.path());
         assert!(agents.contains(&"claude-code".to_string()));

--- a/bitloops_cli/src/commands/init.rs
+++ b/bitloops_cli/src/commands/init.rs
@@ -10,7 +10,7 @@ use clap::Args;
 use crate::commands::enable::{find_repo_root, initialized_agents};
 use crate::engine::agent::HookSupport;
 use crate::engine::agent::claude_code::hooks as claude_hooks;
-use crate::engine::agent::codex::agent::CodexAgent;
+use crate::engine::agent::codex::hooks as codex_hooks;
 use crate::engine::agent::cursor::agent::CursorAgent;
 use crate::engine::agent::gemini_cli::agent::GeminiCliAgent;
 use crate::engine::agent::open_code::agent::OpenCodeAgent;
@@ -99,7 +99,7 @@ fn install_agent_hooks(
         )),
         AGENT_CODEX => Ok((
             "Codex CLI".to_string(),
-            HookSupport::install_hooks(&CodexAgent, local_dev, force)?,
+            codex_hooks::install_hooks_at(repo_root, local_dev, force)?,
         )),
         AGENT_CURSOR => Ok((
             "Cursor".to_string(),

--- a/bitloops_cli/src/commands/mod.rs
+++ b/bitloops_cli/src/commands/mod.rs
@@ -23,9 +23,18 @@ pub mod versioncheck;
     version,
     about = root::ROOT_SHORT_ABOUT,
     long_about = root::ROOT_LONG_ABOUT,
+    disable_version_flag = true,
     disable_help_subcommand = true
 )]
 pub struct Cli {
+    /// Show build information.
+    #[arg(long = "version", short = 'V', default_value_t = false)]
+    pub version: bool,
+
+    /// Check for updates (only valid with --version).
+    #[arg(long = "check", requires = "version", default_value_t = false)]
+    pub check: bool,
+
     /// Check backend connectivity for configured relational/events providers.
     #[arg(long = "connection-status", global = true, default_value_t = false)]
     pub connection_status: bool,
@@ -58,7 +67,7 @@ pub enum Commands {
     #[command(hide = true)]
     Hooks(crate::engine::hooks::dispatcher::HooksArgs),
     /// Show build information.
-    Version,
+    Version(root::VersionArgs),
     /// Explain a session, commit, or checkpoint
     Explain(explain::ExplainArgs),
     /// Hidden debug commands for troubleshooting.
@@ -97,6 +106,19 @@ impl std::error::Error for SilentError {}
 pub async fn run(cli: Cli) -> Result<()> {
     let strategy_registry = crate::engine::strategy::registry::StrategyRegistry::builtin();
 
+    if cli.version {
+        if cli.command.is_some() {
+            bail!("`--version` cannot be combined with a subcommand");
+        }
+        if cli.connection_status {
+            bail!("`--version` cannot be combined with `--connection-status`");
+        }
+
+        let result = root::run_version_command(cli.check);
+        root::run_persistent_post_run(&[], "version");
+        return result;
+    }
+
     if cli.connection_status {
         if cli.command.is_some() {
             bail!("`--connection-status` cannot be combined with a subcommand");
@@ -126,7 +148,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::Hooks(args) => {
             crate::engine::hooks::dispatcher::run(args, &strategy_registry).await
         }
-        Commands::Version => root::run_version_command(),
+        Commands::Version(args) => root::run_version_command(args.check),
         Commands::Explain(args) => explain::run(args).await,
         Commands::Debug(args) => debug::run(&args),
         Commands::Devql(args) => devql::run(args).await,

--- a/bitloops_cli/src/commands/root.rs
+++ b/bitloops_cli/src/commands/root.rs
@@ -9,8 +9,8 @@ use std::env;
 use std::io::BufRead;
 use std::io::{self, Write};
 use std::path::Path;
-use std::process::Command as ProcessCommand;
 
+use crate::branding::{BITLOOPS_PURPLE_HEX, bitloops_wordmark, color_hex_if_enabled};
 use crate::commands::{clean, doctor, enable, reset, resume, versioncheck};
 use crate::engine::settings::{self, BitloopsSettings};
 
@@ -104,6 +104,13 @@ pub struct CompletionArgs {
     pub shell: CompletionShell,
 }
 
+#[derive(Args, Debug, Clone, Default)]
+pub struct VersionArgs {
+    /// Check for updates now.
+    #[arg(long, default_value_t = false)]
+    pub check: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TelemetryEvent {
     pub command: String,
@@ -119,6 +126,16 @@ pub(crate) fn build_version() -> &'static str {
 
 pub(crate) fn build_commit() -> &'static str {
     option_env!("BITLOOPS_BUILD_COMMIT").unwrap_or("unknown")
+}
+
+pub(crate) fn build_target() -> &'static str {
+    option_env!("BITLOOPS_BUILD_TARGET")
+        .or(option_env!("TARGET"))
+        .unwrap_or("unknown")
+}
+
+pub(crate) fn build_date() -> &'static str {
+    option_env!("BITLOOPS_BUILD_DATE").unwrap_or("unknown")
 }
 
 /// Returns true when the executed command or any ancestor is hidden.
@@ -210,7 +227,7 @@ pub(crate) fn command_name(command: &crate::commands::Commands) -> &'static str 
         crate::commands::Commands::Status(_) => "status",
         crate::commands::Commands::Dashboard(_) => "dashboard",
         crate::commands::Commands::Hooks(_) => "hooks",
-        crate::commands::Commands::Version => "version",
+        crate::commands::Commands::Version(_) => "version",
         crate::commands::Commands::Explain(_) => "explain",
         crate::commands::Commands::Debug(_) => "debug",
         crate::commands::Commands::Devql(_) => "devql",
@@ -369,18 +386,27 @@ pub fn run_completion_command(args: &CompletionArgs) -> Result<()> {
     write_completion(&mut out, args.shell)
 }
 
-pub fn run_version_command() -> Result<()> {
-    let runtime = runtime_version_string();
+pub fn run_version_command(check_for_updates: bool) -> Result<()> {
     let stdout = io::stdout();
     let mut out = stdout.lock();
     write_version(
         &mut out,
         build_version(),
         build_commit(),
-        &runtime,
-        std::env::consts::OS,
-        std::env::consts::ARCH,
-    )
+        build_target(),
+        build_date(),
+    )?;
+
+    if check_for_updates {
+        versioncheck::check_now(&mut out, version_for_update_check());
+    } else {
+        writeln!(
+            out,
+            "Run `bitloops --version --check` to check for updates."
+        )?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -475,32 +501,58 @@ fn write_node(w: &mut dyn Write, cmd: &Command, indent: &str, is_last: bool) -> 
     write_children(w, cmd, &child_indent)
 }
 
-fn runtime_version_string() -> String {
-    let output = ProcessCommand::new("rustc").arg("--version").output();
-    let Ok(output) = output else {
+const VERSION_DIVIDER: &str = "───────────────────";
+
+fn pretty_version(version: &str) -> String {
+    let trimmed = version.trim();
+    if trimmed.is_empty() {
         return "unknown".to_string();
-    };
-    if !output.status.success() {
+    }
+    if trimmed == "dev" {
+        return format!("v{}", env!("CARGO_PKG_VERSION"));
+    }
+    if trimmed.starts_with('v') {
+        return trimmed.to_string();
+    }
+    format!("v{trimmed}")
+}
+
+fn short_commit(commit: &str) -> String {
+    let trimmed = commit.trim();
+    if trimmed.is_empty() {
         return "unknown".to_string();
     }
 
-    String::from_utf8(output.stdout)
-        .map(|value| value.trim().to_string())
-        .ok()
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "unknown".to_string())
+    trimmed.chars().take(7).collect()
+}
+
+fn version_for_update_check() -> &'static str {
+    let version = build_version();
+    if version == "dev" {
+        env!("CARGO_PKG_VERSION")
+    } else {
+        version
+    }
 }
 
 pub(crate) fn write_version(
     w: &mut dyn Write,
     version: &str,
     commit: &str,
-    runtime: &str,
-    os: &str,
-    arch: &str,
+    target: &str,
+    built: &str,
 ) -> Result<()> {
-    writeln!(w, "Bitloops CLI {version} ({commit})")?;
-    writeln!(w, "Rust version: {runtime}")?;
-    writeln!(w, "OS/Arch: {os}/{arch}")?;
+    writeln!(w)?;
+    writeln!(
+        w,
+        "{}",
+        color_hex_if_enabled(&bitloops_wordmark(), BITLOOPS_PURPLE_HEX)
+    )?;
+    writeln!(w, "Bitloops CLI {}", pretty_version(version))?;
+    writeln!(w, "{VERSION_DIVIDER}")?;
+    writeln!(w, "commit: {}", short_commit(commit))?;
+    writeln!(w, "target: {}", target.trim())?;
+    writeln!(w, "built: {}", built.trim())?;
+    writeln!(w)?;
     Ok(())
 }

--- a/bitloops_cli/src/commands/root_test.rs
+++ b/bitloops_cli/src/commands/root_test.rs
@@ -3,6 +3,7 @@ use super::root::{
     run_curl_bash_post_install_command_with_io, write_completion, write_help, write_version,
 };
 use super::{Cli, Commands};
+use crate::branding::bitloops_wordmark;
 use crate::test_support::process_state::with_env_vars;
 use clap::{Command, CommandFactory, Parser};
 use std::io::Cursor;
@@ -210,6 +211,55 @@ fn TestRootCommand_ParseConnectionStatusFlag() {
 
 #[test]
 #[allow(non_snake_case)]
+fn TestRootCommand_ParseVersionFlag() {
+    let parsed = Cli::try_parse_from(["bitloops", "--version"])
+        .expect("root invocation with --version should parse");
+    assert!(parsed.version, "--version should set the version flag");
+    assert!(
+        !parsed.check,
+        "--check should remain false when not explicitly provided"
+    );
+    assert!(
+        parsed.command.is_none(),
+        "--version should work without subcommands"
+    );
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn TestRootCommand_ParseVersionFlagWithCheck() {
+    let parsed = Cli::try_parse_from(["bitloops", "--version", "--check"])
+        .expect("root invocation with --version --check should parse");
+    assert!(parsed.version, "--version should be set");
+    assert!(parsed.check, "--check should be set");
+    assert!(
+        parsed.command.is_none(),
+        "--version --check should not require a subcommand"
+    );
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn TestRootCommand_CheckFlagRequiresVersionFlag() {
+    assert!(
+        Cli::try_parse_from(["bitloops", "--check"]).is_err(),
+        "--check should be rejected without --version"
+    );
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn TestRootCommand_VersionSubcommandSupportsCheckFlag() {
+    let parsed = Cli::try_parse_from(["bitloops", "version", "--check"])
+        .expect("version subcommand should parse with --check");
+    let Some(Commands::Version(args)) = parsed.command else {
+        panic!("expected version subcommand");
+    };
+    assert!(args.check, "version subcommand should capture --check");
+}
+
+#[test]
+#[allow(non_snake_case)]
 fn TestRootCommand_ConnectionStatusFlagCannotBeCombinedWithSubcommand() {
     let parsed = Cli::try_parse_from(["bitloops", "--connection-status", "status"])
         .expect("parser should allow global flag before subcommands");
@@ -403,22 +453,47 @@ fn TestRootCommand_CurlBashPostInstall_UnsupportedShellIsBestEffort() {
 #[test]
 #[allow(non_snake_case)]
 fn TestRootCommand_VersionOutput() {
-    let mut out = Vec::new();
-    write_version(
-        &mut out,
-        "dev",
-        "unknown",
-        "rustc 1.89.0 (example)",
-        "darwin",
-        "arm64",
-    )
-    .expect("version output should render");
+    with_env_vars(&[("NO_COLOR", Some("1"))], || {
+        let mut out = Vec::new();
+        write_version(
+            &mut out,
+            "0.0.10",
+            "8f3c9c2abcdef",
+            "aarch64-apple-darwin",
+            "2026-03-11",
+        )
+        .expect("version output should render");
 
-    let rendered = String::from_utf8(out).expect("version output utf8");
-    assert_eq!(
-        rendered,
-        "Bitloops CLI dev (unknown)\nRust version: rustc 1.89.0 (example)\nOS/Arch: darwin/arm64\n"
-    );
+        let rendered = String::from_utf8(out).expect("version output utf8");
+        assert!(
+            !rendered.contains("\u{1b}["),
+            "NO_COLOR should disable ANSI colour output"
+        );
+        assert!(
+            rendered.contains(&bitloops_wordmark()),
+            "version output should include the brand mark"
+        );
+        assert!(
+            rendered.contains("Bitloops CLI v0.0.10\n"),
+            "version output should include the formatted version header"
+        );
+        assert!(
+            rendered.contains("───────────────────\n"),
+            "version output should include the divider line"
+        );
+        assert!(
+            rendered.contains("commit: 8f3c9c2\n"),
+            "version output should print the short commit hash"
+        );
+        assert!(
+            rendered.contains("target: aarch64-apple-darwin\n"),
+            "version output should include the full target triple"
+        );
+        assert!(
+            rendered.contains("built: 2026-03-11\n"),
+            "version output should include build date"
+        );
+    });
 }
 
 #[test]

--- a/bitloops_cli/src/commands/versioncheck.rs
+++ b/bitloops_cli/src/commands/versioncheck.rs
@@ -243,6 +243,40 @@ pub fn check_and_notify(w: &mut dyn Write, current_version: &str) {
     }
 }
 
+pub fn check_now(w: &mut dyn Write, current_version: &str) {
+    if current_version.trim().is_empty() {
+        let _ = writeln!(
+            w,
+            "Unable to check for updates: current version is unknown."
+        );
+        return;
+    }
+
+    if let Err(err) = ensure_global_config_dir() {
+        let _ = writeln!(w, "Unable to check for updates: {err}");
+        return;
+    }
+
+    let latest_version = match fetch_latest_version() {
+        Ok(version) => version,
+        Err(err) => {
+            let _ = writeln!(w, "Unable to check for updates: {err}");
+            return;
+        }
+    };
+
+    let cache = VersionCache {
+        last_check_time_secs: current_time_secs(),
+    };
+    let _ = save_cache(&cache);
+
+    if is_outdated(current_version, &latest_version) {
+        print_notification(w, current_version, &latest_version);
+    } else {
+        let _ = writeln!(w, "Bitloops CLI is up to date (v{current_version}).");
+    }
+}
+
 fn print_notification(w: &mut dyn Write, current: &str, latest: &str) {
     let _ = write!(
         w,

--- a/bitloops_cli/src/devql_config.rs
+++ b/bitloops_cli/src/devql_config.rs
@@ -22,6 +22,8 @@ const ENV_CLICKHOUSE_URL: &str = "BITLOOPS_DEVQL_CH_URL";
 const ENV_CLICKHOUSE_USER: &str = "BITLOOPS_DEVQL_CH_USER";
 const ENV_CLICKHOUSE_PASSWORD: &str = "BITLOOPS_DEVQL_CH_PASSWORD";
 const ENV_CLICKHOUSE_DATABASE: &str = "BITLOOPS_DEVQL_CH_DATABASE";
+const DASHBOARD_CONFIG_KEY: &str = "dashboard";
+const DASHBOARD_USE_BITLOOPS_LOCAL_KEY: &str = "use_bitloops_local";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RelationalProvider {
@@ -83,19 +85,6 @@ pub struct EventsBackendConfig {
 }
 
 impl EventsBackendConfig {
-    pub fn clickhouse_endpoint(&self) -> String {
-        let base = self
-            .clickhouse_url
-            .clone()
-            .unwrap_or_else(|| "http://localhost:8123".to_string());
-        let database = self
-            .clickhouse_database
-            .clone()
-            .unwrap_or_else(|| "default".to_string());
-        let base = base.trim_end_matches('/');
-        format!("{base}/?database={database}")
-    }
-
     pub fn duckdb_path_or_default(&self) -> PathBuf {
         match self.duckdb_path.as_deref() {
             // For an explicitly configured path, preserve existing behavior:
@@ -133,6 +122,11 @@ pub struct DevqlFileConfig {
     pub(crate) clickhouse_user: Option<String>,
     pub(crate) clickhouse_password: Option<String>,
     pub(crate) clickhouse_database: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DashboardFileConfig {
+    pub use_bitloops_local: Option<bool>,
 }
 
 impl DevqlFileConfig {
@@ -218,6 +212,44 @@ impl DevqlFileConfig {
             }),
         }
     }
+}
+
+impl DashboardFileConfig {
+    /// Load dashboard config from `$HOME/.bitloops/config.json` (or `$USERPROFILE` on Windows).
+    /// Returns default if the file is missing or invalid.
+    pub fn load() -> Self {
+        let Some(path) = user_home_config_path() else {
+            return Self::default();
+        };
+
+        let data = match fs::read(&path) {
+            Ok(data) => data,
+            Err(_) => return Self::default(),
+        };
+        let value: Value = match serde_json::from_slice(&data) {
+            Ok(value) => value,
+            Err(_) => return Self::default(),
+        };
+        Self::from_json_value(&value)
+    }
+
+    /// Parse dashboard config from a JSON value.
+    /// Reads the nested `"dashboard"` object.
+    pub fn from_json_value(value: &Value) -> Self {
+        let Some(root) = value.get(DASHBOARD_CONFIG_KEY).and_then(Value::as_object) else {
+            return Self::default();
+        };
+
+        Self {
+            use_bitloops_local: read_any_bool(root, &[DASHBOARD_USE_BITLOOPS_LOCAL_KEY]),
+        }
+    }
+}
+
+pub fn dashboard_use_bitloops_local() -> bool {
+    DashboardFileConfig::load()
+        .use_bitloops_local
+        .unwrap_or(false)
 }
 
 pub fn resolve_devql_backend_config() -> Result<DevqlBackendConfig> {
@@ -358,6 +390,25 @@ fn read_any_string(root: &Map<String, Value>, keys: &[&str]) -> Option<String> {
 
 fn read_any_string_opt(root: Option<&Map<String, Value>>, keys: &[&str]) -> Option<String> {
     root.and_then(|map| read_any_string(map, keys))
+}
+
+fn read_any_bool(root: &Map<String, Value>, keys: &[&str]) -> Option<bool> {
+    for key in keys {
+        let Some(value) = root.get(*key) else {
+            continue;
+        };
+        if let Some(boolean) = value.as_bool() {
+            return Some(boolean);
+        }
+        if let Some(raw) = value.as_str() {
+            match raw.trim().to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" | "on" => return Some(true),
+                "false" | "0" | "no" | "off" => return Some(false),
+                _ => {}
+            }
+        }
+    }
+    None
 }
 
 fn read_non_empty_env<F>(env_lookup: &F, key: &str) -> Option<String>
@@ -586,5 +637,41 @@ mod tests {
             PathBuf::from(expanded),
             windows_home.join(r".bitloops\devql\relational.db")
         );
+    }
+
+    #[test]
+    fn dashboard_file_config_reads_use_bitloops_local_flag() {
+        let value = serde_json::json!({
+            "dashboard": {
+                "use_bitloops_local": true
+            }
+        });
+
+        let cfg = DashboardFileConfig::from_json_value(&value);
+        assert_eq!(cfg.use_bitloops_local, Some(true));
+    }
+
+    #[test]
+    fn dashboard_file_config_defaults_when_dashboard_block_missing() {
+        let value = serde_json::json!({
+            "devql": {
+                "relational_provider": "sqlite"
+            }
+        });
+
+        let cfg = DashboardFileConfig::from_json_value(&value);
+        assert_eq!(cfg, DashboardFileConfig::default());
+    }
+
+    #[test]
+    fn dashboard_file_config_accepts_boolean_like_strings() {
+        let value = serde_json::json!({
+            "dashboard": {
+                "use_bitloops_local": "yes"
+            }
+        });
+
+        let cfg = DashboardFileConfig::from_json_value(&value);
+        assert_eq!(cfg.use_bitloops_local, Some(true));
     }
 }

--- a/bitloops_cli/src/engine/agent/agent_test.rs
+++ b/bitloops_cli/src/engine/agent/agent_test.rs
@@ -1,9 +1,12 @@
 use super::*;
 use serde_json::json;
 use std::collections::HashMap;
+use std::io::Cursor;
 
 const MOCK_AGENT_NAME: &str = "mock";
 const MOCK_AGENT_TYPE: &str = "Mock Agent";
+const MINIMAL_AGENT_NAME: &str = "minimal";
+const MINIMAL_AGENT_TYPE: &str = "Minimal Agent";
 
 #[derive(Default)]
 struct MockAgent;
@@ -108,6 +111,46 @@ impl Agent for MockFileWatcher {
 
 impl FileWatcher for MockFileWatcher {}
 
+struct MinimalAgent;
+
+impl Agent for MinimalAgent {
+    fn name(&self) -> String {
+        MINIMAL_AGENT_NAME.to_string()
+    }
+
+    fn agent_type(&self) -> String {
+        MINIMAL_AGENT_TYPE.to_string()
+    }
+}
+
+struct MinimalHookSupport;
+
+impl Agent for MinimalHookSupport {
+    fn name(&self) -> String {
+        MINIMAL_AGENT_NAME.to_string()
+    }
+
+    fn agent_type(&self) -> String {
+        MINIMAL_AGENT_TYPE.to_string()
+    }
+}
+
+impl HookSupport for MinimalHookSupport {}
+
+struct MinimalFileWatcher;
+
+impl Agent for MinimalFileWatcher {
+    fn name(&self) -> String {
+        MINIMAL_AGENT_NAME.to_string()
+    }
+
+    fn agent_type(&self) -> String {
+        MINIMAL_AGENT_TYPE.to_string()
+    }
+}
+
+impl FileWatcher for MinimalFileWatcher {}
+
 #[test]
 #[allow(non_snake_case)]
 fn TestAgentInterfaceCompliance() {
@@ -210,4 +253,102 @@ fn TestSessionChangeStructure() {
     assert_eq!(change.session_id, "test-session");
     assert_eq!(change.event_type, HookType::SessionStart);
     assert_eq!(change.event_type.as_str(), "session_start");
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn TestAgentDefaultMethodsAreSafeNoOps() {
+    let agent = MinimalAgent;
+    let mut stdin = Cursor::new(br#"{"ignored":true}"#);
+
+    assert_eq!(agent.description(), "TODO");
+    assert!(agent.is_preview());
+    assert!(
+        !agent
+            .detect_presence()
+            .expect("presence check should succeed")
+    );
+    assert_eq!(agent.get_session_id(&HookInput::default()), "");
+    assert!(agent.protected_dirs().is_empty());
+    assert!(agent.hook_names().is_empty());
+    assert!(
+        agent
+            .parse_hook_event("stop", &mut stdin)
+            .expect("hook parsing should succeed")
+            .is_none()
+    );
+    assert!(
+        agent
+            .read_transcript("session-ref")
+            .expect("transcript read should succeed")
+            .is_empty()
+    );
+    assert_eq!(
+        agent
+            .chunk_transcript(b"hello", 1)
+            .expect("chunking should succeed"),
+        vec![b"hello".to_vec()]
+    );
+    assert_eq!(
+        agent
+            .reassemble_transcript(&[b"he".to_vec(), b"llo".to_vec()])
+            .expect("reassembly should succeed"),
+        b"hello".to_vec()
+    );
+    assert_eq!(
+        agent
+            .get_session_dir("/tmp/repo")
+            .expect("session dir lookup should succeed"),
+        ""
+    );
+    assert_eq!(
+        agent.resolve_session_file("/tmp/sessions", "abc123"),
+        "/tmp/sessions/abc123.jsonl"
+    );
+    assert!(
+        agent
+            .read_session(&HookInput::default())
+            .expect("session read should succeed")
+            .is_none()
+    );
+    agent
+        .write_session(&AgentSession::default())
+        .expect("session write should succeed");
+    assert_eq!(agent.format_resume_command("abc123"), "");
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn TestHookSupportDefaultMethodsAreSafeNoOps() {
+    let agent = MinimalHookSupport;
+
+    assert_eq!(
+        agent
+            .install_hooks(false, false)
+            .expect("hook install should succeed"),
+        0
+    );
+    agent
+        .uninstall_hooks()
+        .expect("hook uninstall should succeed");
+    assert!(!agent.are_hooks_installed());
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn TestFileWatcherDefaultMethodsAreSafeNoOps() {
+    let watcher = MinimalFileWatcher;
+
+    assert!(
+        watcher
+            .get_watch_paths()
+            .expect("watch path lookup should succeed")
+            .is_empty()
+    );
+    assert!(
+        watcher
+            .on_file_change("src/main.rs")
+            .expect("file change handler should succeed")
+            .is_none()
+    );
 }

--- a/bitloops_cli/src/engine/agent/codex/agent_tests.rs
+++ b/bitloops_cli/src/engine/agent/codex/agent_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::engine::agent::{Agent, HookSupport};
+use crate::engine::agent::Agent;
 use crate::test_support::process_state::with_cwd;
 
 fn init_repo(path: &std::path::Path) {
@@ -57,15 +57,14 @@ fn read_and_write_session_roundtrip() {
 }
 
 #[test]
-fn hook_support_wires_to_hook_manager() {
+fn path_based_hooks_api_manages_hooks_without_cwd() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
-    with_cwd(dir.path(), || {
-        let agent = CodexAgent;
-        let installed = HookSupport::install_hooks(&agent, false, false).expect("install");
-        assert_eq!(installed, 2);
-        assert!(HookSupport::are_hooks_installed(&agent));
-        HookSupport::uninstall_hooks(&agent).expect("uninstall");
-        assert!(!HookSupport::are_hooks_installed(&agent));
-    });
+
+    let installed = super::hooks::install_hooks_at(dir.path(), false, false).expect("install");
+    assert_eq!(installed, 2);
+    assert!(super::hooks::are_hooks_installed_at(dir.path()));
+
+    super::hooks::uninstall_hooks_at(dir.path()).expect("uninstall");
+    assert!(!super::hooks::are_hooks_installed_at(dir.path()));
 }

--- a/bitloops_cli/src/engine/agent/codex/hooks.rs
+++ b/bitloops_cli/src/engine/agent/codex/hooks.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use serde_json::{Map, Value, json};
@@ -47,11 +47,14 @@ fn hook_commands(local_dev: bool) -> [(&'static str, String, &'static str); 2] {
     ]
 }
 
-fn hooks_file_path() -> Result<PathBuf> {
-    let repo_root = crate::engine::paths::repo_root().or_else(|_| {
+fn resolve_repo_root() -> Result<PathBuf> {
+    crate::engine::paths::repo_root().or_else(|_| {
         std::env::current_dir().map_err(|err| anyhow!("failed to get current directory: {err}"))
-    })?;
-    Ok(repo_root.join(".codex").join(HOOKS_FILE_NAME))
+    })
+}
+
+fn hooks_file_path_for(repo_root: &Path) -> PathBuf {
+    repo_root.join(".codex").join(HOOKS_FILE_NAME)
 }
 
 fn parse_top_level_map(data: &[u8]) -> Result<Map<String, Value>> {
@@ -63,7 +66,7 @@ fn parse_top_level_map(data: &[u8]) -> Result<Map<String, Value>> {
     Ok(map.clone())
 }
 
-fn write_hooks_file(path: &PathBuf, root: &Map<String, Value>) -> Result<()> {
+fn write_hooks_file(path: &Path, root: &Map<String, Value>) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .map_err(|err| anyhow!("failed to create .codex directory: {err}"))?;
@@ -212,8 +215,8 @@ fn normalize_entries_for_install(
     (*entries != before, inserted)
 }
 
-pub fn install_hooks(local_dev: bool, force: bool) -> Result<usize> {
-    let path = hooks_file_path()?;
+pub fn install_hooks_at(repo_root: &Path, local_dev: bool, force: bool) -> Result<usize> {
+    let path = hooks_file_path_for(repo_root);
     let existing_data = fs::read(&path).ok();
 
     let mut raw_file = match existing_data {
@@ -254,8 +257,13 @@ pub fn install_hooks(local_dev: bool, force: bool) -> Result<usize> {
     Ok(installed)
 }
 
-pub fn uninstall_hooks() -> Result<()> {
-    let path = hooks_file_path()?;
+pub fn install_hooks(local_dev: bool, force: bool) -> Result<usize> {
+    let repo_root = resolve_repo_root()?;
+    install_hooks_at(&repo_root, local_dev, force)
+}
+
+pub fn uninstall_hooks_at(repo_root: &Path) -> Result<()> {
+    let path = hooks_file_path_for(repo_root);
     let data = match fs::read(&path) {
         Ok(data) => data,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -298,12 +306,13 @@ pub fn uninstall_hooks() -> Result<()> {
     write_hooks_file(&path, &raw_file)
 }
 
-pub fn are_hooks_installed() -> bool {
-    let path = match hooks_file_path() {
-        Ok(path) => path,
-        Err(_) => return false,
-    };
+pub fn uninstall_hooks() -> Result<()> {
+    let repo_root = resolve_repo_root()?;
+    uninstall_hooks_at(&repo_root)
+}
 
+pub fn are_hooks_installed_at(repo_root: &Path) -> bool {
+    let path = hooks_file_path_for(repo_root);
     let Ok(data) = fs::read(&path) else {
         return false;
     };
@@ -325,6 +334,14 @@ pub fn are_hooks_installed() -> bool {
                 .any(|hook| is_bitloops_hook(hook.command.as_str()))
         })
     })
+}
+
+pub fn are_hooks_installed() -> bool {
+    let repo_root = match resolve_repo_root() {
+        Ok(repo_root) => repo_root,
+        Err(_) => return false,
+    };
+    are_hooks_installed_at(&repo_root)
 }
 
 #[cfg(test)]

--- a/bitloops_cli/src/engine/agent/codex/hooks_cmd.rs
+++ b/bitloops_cli/src/engine/agent/codex/hooks_cmd.rs
@@ -30,3 +30,166 @@ pub fn handle_stop_codex(
         CODEX_HOOK_AGENT_PROFILE,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::agent::{AGENT_NAME_CODEX, AGENT_TYPE_CODEX};
+    use crate::engine::session::backend::SessionBackend;
+    use crate::engine::session::local_backend::LocalFileBackend;
+    use crate::engine::session::phase::SessionPhase;
+    use crate::engine::session::state::PrePromptState;
+    use crate::engine::strategy::{StepContext, TaskStepContext};
+    use crate::test_support::process_state::git_command;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    #[derive(Default)]
+    struct RecordingStrategy {
+        step_calls: Mutex<Vec<StepContext>>,
+    }
+
+    impl Strategy for RecordingStrategy {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        fn save_step(&self, ctx: &StepContext) -> Result<()> {
+            self.step_calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(ctx.clone());
+            Ok(())
+        }
+
+        fn save_task_step(&self, _ctx: &TaskStepContext) -> Result<()> {
+            Ok(())
+        }
+
+        fn prepare_commit_msg(&self, _commit_msg_file: &Path, _source: Option<&str>) -> Result<()> {
+            Ok(())
+        }
+
+        fn commit_msg(&self, _commit_msg_file: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        fn post_commit(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn pre_push(&self, _remote: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn git_ok(repo_root: &Path, args: &[&str]) {
+        let out = git_command()
+            .args(args)
+            .current_dir(repo_root)
+            .output()
+            .unwrap_or_else(|err| panic!("failed to start git {:?}: {err}", args));
+        assert!(
+            out.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn seed_git_repo() -> TempDir {
+        let dir = TempDir::new().expect("temp dir");
+        let repo_root = dir.path();
+
+        git_ok(repo_root, &["init"]);
+        git_ok(repo_root, &["checkout", "-B", "main"]);
+        git_ok(repo_root, &["config", "user.name", "Bitloops Test"]);
+        git_ok(
+            repo_root,
+            &["config", "user.email", "bitloops-test@example.com"],
+        );
+
+        fs::write(repo_root.join("tracked.txt"), "one\n").expect("write tracked file");
+        git_ok(repo_root, &["add", "tracked.txt"]);
+        git_ok(repo_root, &["commit", "-m", "initial"]);
+
+        dir
+    }
+
+    #[test]
+    fn session_start_codex_persists_shared_session_state() {
+        let dir = TempDir::new().expect("temp dir");
+        fs::create_dir_all(dir.path().join(".git")).expect("create git dir");
+        let backend = LocalFileBackend::new(dir.path());
+
+        handle_session_start_codex(
+            SessionInfoInput {
+                session_id: "codex-session".to_string(),
+                transcript_path: "/tmp/codex.jsonl".to_string(),
+            },
+            &backend,
+            None,
+        )
+        .expect("session-start should succeed");
+
+        let state = backend
+            .load_session("codex-session")
+            .expect("load session")
+            .expect("saved session");
+        assert_eq!(state.phase, SessionPhase::Idle);
+        assert_eq!(state.transcript_path, "/tmp/codex.jsonl");
+    }
+
+    #[test]
+    fn stop_codex_uses_codex_profile_when_checkpointing() {
+        let repo = seed_git_repo();
+        let backend = LocalFileBackend::new(repo.path());
+        let strategy = RecordingStrategy::default();
+        let session_id = "codex-session";
+        let transcript_path = repo.path().join("codex.jsonl");
+        fs::write(&transcript_path, "").expect("write transcript");
+
+        backend
+            .save_pre_prompt(&PrePromptState {
+                session_id: session_id.to_string(),
+                prompt: "Refactor tracked file".to_string(),
+                transcript_path: transcript_path.to_string_lossy().to_string(),
+                ..Default::default()
+            })
+            .expect("save pre-prompt");
+
+        fs::write(repo.path().join("tracked.txt"), "two\n").expect("modify tracked file");
+
+        handle_stop_codex(
+            SessionInfoInput {
+                session_id: session_id.to_string(),
+                transcript_path: transcript_path.to_string_lossy().to_string(),
+            },
+            &backend,
+            &strategy,
+            Some(repo.path()),
+        )
+        .expect("stop should succeed");
+
+        let step_calls = strategy
+            .step_calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(step_calls.len(), 1);
+        assert_eq!(step_calls[0].agent_type, AGENT_NAME_CODEX);
+        assert_eq!(
+            step_calls[0].modified_files,
+            vec!["tracked.txt".to_string()]
+        );
+        drop(step_calls);
+
+        let state = backend
+            .load_session(session_id)
+            .expect("load session")
+            .expect("saved session");
+        assert_eq!(state.agent_type, AGENT_TYPE_CODEX);
+    }
+}

--- a/bitloops_cli/src/engine/agent/codex/hooks_tests.rs
+++ b/bitloops_cli/src/engine/agent/codex/hooks_tests.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use super::*;
-use crate::test_support::process_state::with_cwd;
 
 fn init_repo(path: &Path) {
     let output = std::process::Command::new("git")
@@ -69,44 +68,42 @@ fn install_hooks_fresh_and_idempotent() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        let installed = install_hooks(false, false).expect("install");
-        assert_eq!(installed, 2);
-        assert!(are_hooks_installed());
+    let installed = install_hooks_at(dir.path(), false, false).expect("install");
+    assert_eq!(installed, 2);
+    assert!(are_hooks_installed_at(dir.path()));
 
-        let second = install_hooks(false, false).expect("install second");
-        assert_eq!(second, 0);
+    let second = install_hooks_at(dir.path(), false, false).expect("install second");
+    assert_eq!(second, 0);
 
-        let output = read_hooks_json(dir.path());
-        let session_commands = commands_for_hook(&output, "SessionStart");
-        let stop_commands = commands_for_hook(&output, "Stop");
+    let output = read_hooks_json(dir.path());
+    let session_commands = commands_for_hook(&output, "SessionStart");
+    let stop_commands = commands_for_hook(&output, "Stop");
 
-        assert_eq!(
-            session_commands,
-            vec!["bitloops hooks codex session-start".to_string()]
-        );
-        assert_eq!(stop_commands, vec!["bitloops hooks codex stop".to_string()]);
+    assert_eq!(
+        session_commands,
+        vec!["bitloops hooks codex session-start".to_string()]
+    );
+    assert_eq!(stop_commands, vec!["bitloops hooks codex stop".to_string()]);
 
-        let start_hook = output
-            .get("hooks")
-            .and_then(|hooks| hooks.get("SessionStart"))
-            .and_then(Value::as_array)
-            .and_then(|entries| entries.first())
-            .and_then(|entry| entry.get("hooks"))
-            .and_then(Value::as_array)
-            .and_then(|entries| entries.first())
-            .expect("SessionStart hook command");
+    let start_hook = output
+        .get("hooks")
+        .and_then(|hooks| hooks.get("SessionStart"))
+        .and_then(Value::as_array)
+        .and_then(|entries| entries.first())
+        .and_then(|entry| entry.get("hooks"))
+        .and_then(Value::as_array)
+        .and_then(|entries| entries.first())
+        .expect("SessionStart hook command");
 
-        assert_eq!(
-            start_hook.get("type").and_then(Value::as_str),
-            Some("command")
-        );
-        assert_eq!(
-            start_hook.get("statusMessage").and_then(Value::as_str),
-            Some("Initializing session...")
-        );
-        assert_eq!(start_hook.get("timeout").and_then(Value::as_i64), Some(10));
-    });
+    assert_eq!(
+        start_hook.get("type").and_then(Value::as_str),
+        Some("command")
+    );
+    assert_eq!(
+        start_hook.get("statusMessage").and_then(Value::as_str),
+        Some("Initializing session...")
+    );
+    assert_eq!(start_hook.get("timeout").and_then(Value::as_i64), Some(10));
 }
 
 #[test]
@@ -114,15 +111,13 @@ fn install_hooks_local_dev_writes_cargo_run_commands() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        let installed = install_hooks(true, false).expect("install local-dev");
-        assert_eq!(installed, 2);
+    let installed = install_hooks_at(dir.path(), true, false).expect("install local-dev");
+    assert_eq!(installed, 2);
 
-        let output = read_hooks(dir.path());
-        assert!(output.contains("cargo run -- hooks codex session-start"));
-        assert!(output.contains("cargo run -- hooks codex stop"));
-        assert!(!output.contains("bitloops hooks codex session-start"));
-    });
+    let output = read_hooks(dir.path());
+    assert!(output.contains("cargo run -- hooks codex session-start"));
+    assert!(output.contains("cargo run -- hooks codex stop"));
+    assert!(!output.contains("bitloops hooks codex session-start"));
 }
 
 #[test]
@@ -130,16 +125,14 @@ fn install_hooks_force_reinstalls_managed_hooks() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        install_hooks(false, false).expect("initial install");
+    install_hooks_at(dir.path(), false, false).expect("initial install");
 
-        let installed = install_hooks(false, true).expect("force install");
-        assert_eq!(installed, 2);
+    let installed = install_hooks_at(dir.path(), false, true).expect("force install");
+    assert_eq!(installed, 2);
 
-        let output = read_hooks(dir.path());
-        let count = output.matches("bitloops hooks codex stop").count();
-        assert_eq!(count, 1, "force should keep one managed stop hook");
-    });
+    let output = read_hooks(dir.path());
+    let count = output.matches("bitloops hooks codex stop").count();
+    assert_eq!(count, 1, "force should keep one managed stop hook");
 }
 
 #[test]
@@ -147,12 +140,11 @@ fn install_hooks_preserves_unknown_fields() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        let codex_dir = dir.path().join(".codex");
-        fs::create_dir_all(&codex_dir).expect("create .codex");
-        fs::write(
-            codex_dir.join("hooks.json"),
-            r#"
+    let codex_dir = dir.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create .codex");
+    fs::write(
+        codex_dir.join("hooks.json"),
+        r#"
 {
   "profile": "strict",
   "hooks": {
@@ -169,15 +161,14 @@ fn install_hooks_preserves_unknown_fields() {
   }
 }
 "#,
-        )
-        .expect("seed config");
+    )
+    .expect("seed config");
 
-        install_hooks(false, false).expect("install");
+    install_hooks_at(dir.path(), false, false).expect("install");
 
-        let output = read_hooks(dir.path());
-        assert!(output.contains("\"profile\": \"strict\""));
-        assert!(output.contains("echo future"));
-    });
+    let output = read_hooks(dir.path());
+    assert!(output.contains("\"profile\": \"strict\""));
+    assert!(output.contains("echo future"));
 }
 
 #[test]
@@ -185,12 +176,11 @@ fn uninstall_preserves_non_bitloops_hooks() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        let codex_dir = dir.path().join(".codex");
-        fs::create_dir_all(&codex_dir).expect("create .codex");
-        fs::write(
-            codex_dir.join("hooks.json"),
-            r#"
+    let codex_dir = dir.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create .codex");
+    fs::write(
+        codex_dir.join("hooks.json"),
+        r#"
 {
   "hooks": {
     "SessionStart": [
@@ -220,15 +210,14 @@ fn uninstall_preserves_non_bitloops_hooks() {
   }
 }
 "#,
-        )
-        .expect("seed config");
+    )
+    .expect("seed config");
 
-        uninstall_hooks().expect("uninstall");
-        let output = read_hooks(dir.path());
-        assert!(output.contains("echo custom"));
-        assert!(!output.contains("bitloops hooks codex session-start"));
-        assert!(!output.contains("bitloops hooks codex stop"));
-    });
+    uninstall_hooks_at(dir.path()).expect("uninstall");
+    let output = read_hooks(dir.path());
+    assert!(output.contains("echo custom"));
+    assert!(!output.contains("bitloops hooks codex session-start"));
+    assert!(!output.contains("bitloops hooks codex stop"));
 }
 
 #[test]
@@ -236,12 +225,11 @@ fn install_hooks_migrates_local_dev_commands_without_force() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        let codex_dir = dir.path().join(".codex");
-        fs::create_dir_all(&codex_dir).expect("create .codex");
-        fs::write(
-            codex_dir.join("hooks.json"),
-            r#"
+    let codex_dir = dir.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create .codex");
+    fs::write(
+        codex_dir.join("hooks.json"),
+        r#"
 {
   "hooks": {
     "SessionStart": [
@@ -267,18 +255,17 @@ fn install_hooks_migrates_local_dev_commands_without_force() {
   }
 }
 "#,
-        )
-        .expect("seed config");
+    )
+    .expect("seed config");
 
-        let installed = install_hooks(false, false).expect("install");
-        assert_eq!(installed, 2);
+    let installed = install_hooks_at(dir.path(), false, false).expect("install");
+    assert_eq!(installed, 2);
 
-        let output = read_hooks(dir.path());
-        assert!(!output.contains("cargo run -- hooks codex session-start"));
-        assert!(!output.contains("cargo run -- hooks codex stop"));
-        assert!(output.contains("bitloops hooks codex session-start"));
-        assert!(output.contains("bitloops hooks codex stop"));
-    });
+    let output = read_hooks(dir.path());
+    assert!(!output.contains("cargo run -- hooks codex session-start"));
+    assert!(!output.contains("cargo run -- hooks codex stop"));
+    assert!(output.contains("bitloops hooks codex session-start"));
+    assert!(output.contains("bitloops hooks codex stop"));
 }
 
 #[test]
@@ -286,9 +273,7 @@ fn uninstall_hooks_without_config_is_noop() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        uninstall_hooks().expect("uninstall noop");
-    });
+    uninstall_hooks_at(dir.path()).expect("uninstall noop");
 }
 
 #[test]
@@ -296,12 +281,11 @@ fn are_hooks_installed_requires_session_start_and_stop() {
     let dir = tempfile::tempdir().expect("tempdir");
     init_repo(dir.path());
 
-    with_cwd(dir.path(), || {
-        let codex_dir = dir.path().join(".codex");
-        fs::create_dir_all(&codex_dir).expect("create .codex");
-        fs::write(
-            codex_dir.join("hooks.json"),
-            r#"
+    let codex_dir = dir.path().join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create .codex");
+    fs::write(
+        codex_dir.join("hooks.json"),
+        r#"
 {
   "hooks": {
     "SessionStart": [
@@ -317,14 +301,13 @@ fn are_hooks_installed_requires_session_start_and_stop() {
   }
 }
 "#,
-        )
-        .expect("seed config");
+    )
+    .expect("seed config");
 
-        assert!(
-            !are_hooks_installed(),
-            "missing stop hook should be treated as incomplete install"
-        );
-    });
+    assert!(
+        !are_hooks_installed_at(dir.path()),
+        "missing stop hook should be treated as incomplete install"
+    );
 }
 
 #[test]

--- a/bitloops_cli/src/engine/devql/ingestion/extraction_js_ts.rs
+++ b/bitloops_cli/src/engine/devql/ingestion/extraction_js_ts.rs
@@ -73,11 +73,12 @@ fn collect_js_ts_nodes_recursive(
                     seen,
                     node,
                     content,
-                    path,
-                    node.kind(),
-                    name,
-                    format!("{path}::{name}"),
-                    None,
+                    JsTsArtefactDescriptor {
+                        language_kind: node.kind(),
+                        name,
+                        symbol_fqn: format!("{path}::{name}"),
+                        parent_symbol_fqn: None,
+                    },
                 );
             }
         }
@@ -91,11 +92,12 @@ fn collect_js_ts_nodes_recursive(
                     seen,
                     node,
                     content,
-                    path,
-                    "class_declaration",
-                    name,
-                    class_fqn.clone(),
-                    None,
+                    JsTsArtefactDescriptor {
+                        language_kind: "class_declaration",
+                        name,
+                        symbol_fqn: class_fqn.clone(),
+                        parent_symbol_fqn: None,
+                    },
                 );
                 if let Some(body) = node.child_by_field_name("body") {
                     let mut cur = body.walk();
@@ -115,11 +117,12 @@ fn collect_js_ts_nodes_recursive(
                                         seen,
                                         child,
                                         content,
-                                        path,
-                                        language_kind,
-                                        name,
-                                        format!("{class_fqn}::{name}"),
-                                        Some(class_fqn.clone()),
+                                        JsTsArtefactDescriptor {
+                                            language_kind,
+                                            name,
+                                            symbol_fqn: format!("{class_fqn}::{name}"),
+                                            parent_symbol_fqn: Some(class_fqn.clone()),
+                                        },
                                     );
                                 }
                             }
@@ -132,11 +135,12 @@ fn collect_js_ts_nodes_recursive(
                                         seen,
                                         child,
                                         content,
-                                        path,
-                                        "public_field_definition",
-                                        name,
-                                        format!("{class_fqn}::{name}"),
-                                        Some(class_fqn.clone()),
+                                        JsTsArtefactDescriptor {
+                                            language_kind: "public_field_definition",
+                                            name,
+                                            symbol_fqn: format!("{class_fqn}::{name}"),
+                                            parent_symbol_fqn: Some(class_fqn.clone()),
+                                        },
                                     );
                                 }
                             }
@@ -156,11 +160,12 @@ fn collect_js_ts_nodes_recursive(
                     seen,
                     node,
                     content,
-                    path,
-                    "variable_declarator",
-                    name,
-                    format!("{path}::{name}"),
-                    None,
+                    JsTsArtefactDescriptor {
+                        language_kind: "variable_declarator",
+                        name,
+                        symbol_fqn: format!("{path}::{name}"),
+                        parent_symbol_fqn: None,
+                    },
                 );
             }
         }
@@ -172,11 +177,12 @@ fn collect_js_ts_nodes_recursive(
                 seen,
                 node,
                 content,
-                path,
-                "import_statement",
-                &import_name,
-                format!("{path}::import::{import_name}"),
-                None,
+                JsTsArtefactDescriptor {
+                    language_kind: "import_statement",
+                    name: &import_name,
+                    symbol_fqn: format!("{path}::import::{import_name}"),
+                    parent_symbol_fqn: None,
+                },
             );
         }
         _ => {}
@@ -188,17 +194,27 @@ fn collect_js_ts_nodes_recursive(
     }
 }
 
+struct JsTsArtefactDescriptor<'a> {
+    language_kind: &'a str,
+    name: &'a str,
+    symbol_fqn: String,
+    parent_symbol_fqn: Option<String>,
+}
+
 fn push_js_ts_artefact(
     out: &mut Vec<JsTsArtefact>,
     seen: &mut HashSet<(String, String, i32)>,
     node: tree_sitter::Node,
     content: &str,
-    _path: &str,
-    language_kind: &str,
-    name: &str,
-    symbol_fqn: String,
-    parent_symbol_fqn: Option<String>,
+    descriptor: JsTsArtefactDescriptor<'_>,
 ) {
+    let JsTsArtefactDescriptor {
+        language_kind,
+        name,
+        symbol_fqn,
+        parent_symbol_fqn,
+    } = descriptor;
+
     if name.is_empty() || !js_ts_supports_language_kind(language_kind) {
         return;
     }

--- a/bitloops_cli/src/engine/devql/ingestion/extraction_rust.rs
+++ b/bitloops_cli/src/engine/devql/ingestion/extraction_rust.rs
@@ -317,7 +317,7 @@ fn extract_rust_docstring(node: tree_sitter::Node, content: &str) -> Option<Stri
     let inner = node.child_by_field_name("body").and_then(|body| {
         extract_rust_inner_docstring_from_lines(
             &content.lines().collect::<Vec<_>>(),
-            body.start_position().row as usize + 1,
+            body.start_position().row + 1,
         )
     });
 

--- a/bitloops_cli/src/engine/devql/mod.rs
+++ b/bitloops_cli/src/engine/devql/mod.rs
@@ -11,7 +11,8 @@ use sha2::{Digest, Sha256};
 use tokio_postgres::{NoTls, config::SslMode};
 
 use crate::devql_config::{
-    DevqlFileConfig, EventsProvider, RelationalProvider, resolve_devql_backend_config,
+    DevqlBackendConfig, DevqlFileConfig, EventsBackendConfig, EventsProvider,
+    RelationalBackendConfig, RelationalProvider, resolve_devql_backend_config,
 };
 use crate::engine::db_status::{
     DatabaseConnectionStatus, DatabaseStatusRow, classify_connection_error,
@@ -94,79 +95,7 @@ const EVENTS_CLICKHOUSE_LABEL: &str = "Events (ClickHouse)";
 
 pub async fn run_connection_status() -> Result<()> {
     let cfg = resolve_devql_backend_config()?;
-    let mut rows = Vec::new();
-
-    let relational_status = match cfg.relational.provider {
-        RelationalProvider::Sqlite => {
-            let sqlite_path = cfg.relational.resolve_sqlite_db_path();
-            match sqlite_path {
-                Ok(path) => match check_sqlite_connection(&path).await {
-                    Ok(_) => DatabaseConnectionStatus::Connected,
-                    Err(err) => classify_connection_error(&err.to_string()),
-                },
-                Err(err) => classify_connection_error(&err.to_string()),
-            }
-        }
-        RelationalProvider::Postgres => match cfg.relational.postgres_dsn.as_deref() {
-            Some(dsn) => match check_postgres_connection(dsn).await {
-                Ok(_) => DatabaseConnectionStatus::Connected,
-                Err(err) => classify_connection_error(&err.to_string()),
-            },
-            None => DatabaseConnectionStatus::NotConfigured,
-        },
-    };
-
-    let relational_label = match cfg.relational.provider {
-        RelationalProvider::Sqlite => RELATIONAL_SQLITE_LABEL,
-        RelationalProvider::Postgres => RELATIONAL_POSTGRES_LABEL,
-    };
-    rows.push(DatabaseStatusRow {
-        db: relational_label,
-        status: relational_status,
-    });
-
-    let events_status = match cfg.events.provider {
-        EventsProvider::DuckDb => {
-            let duckdb_path = cfg.events.duckdb_path_or_default();
-            match check_duckdb_connection(&duckdb_path).await {
-                Ok(_) => DatabaseConnectionStatus::Connected,
-                Err(err) => classify_connection_error(&err.to_string()),
-            }
-        }
-        EventsProvider::ClickHouse => {
-            let clickhouse_url = cfg
-                .events
-                .clickhouse_url
-                .clone()
-                .unwrap_or_else(|| "http://localhost:8123".to_string());
-            let clickhouse_database = cfg
-                .events
-                .clickhouse_database
-                .clone()
-                .unwrap_or_else(|| "default".to_string());
-            let clickhouse_endpoint = clickhouse_endpoint(&clickhouse_url, &clickhouse_database);
-            match run_clickhouse_sql_http(
-                &clickhouse_endpoint,
-                cfg.events.clickhouse_user.as_deref(),
-                cfg.events.clickhouse_password.as_deref(),
-                "SELECT 1 FORMAT TabSeparated",
-            )
-            .await
-            {
-                Ok(_) => DatabaseConnectionStatus::Connected,
-                Err(err) => classify_connection_error(&err.to_string()),
-            }
-        }
-    };
-
-    let events_label = match cfg.events.provider {
-        EventsProvider::DuckDb => EVENTS_DUCKDB_LABEL,
-        EventsProvider::ClickHouse => EVENTS_CLICKHOUSE_LABEL,
-    };
-    rows.push(DatabaseStatusRow {
-        db: events_label,
-        status: events_status,
-    });
+    let rows = collect_connection_status_rows(&cfg).await;
 
     print_db_status_table(&rows);
 
@@ -176,6 +105,86 @@ pub async fn run_connection_status() -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn collect_connection_status_rows(cfg: &DevqlBackendConfig) -> Vec<DatabaseStatusRow> {
+    vec![
+        DatabaseStatusRow {
+            db: relational_status_label(&cfg.relational),
+            status: relational_connection_status(&cfg.relational).await,
+        },
+        DatabaseStatusRow {
+            db: events_status_label(&cfg.events),
+            status: events_connection_status(&cfg.events).await,
+        },
+    ]
+}
+
+fn relational_status_label(cfg: &RelationalBackendConfig) -> &'static str {
+    match cfg.provider {
+        RelationalProvider::Sqlite => RELATIONAL_SQLITE_LABEL,
+        RelationalProvider::Postgres => RELATIONAL_POSTGRES_LABEL,
+    }
+}
+
+fn events_status_label(cfg: &EventsBackendConfig) -> &'static str {
+    match cfg.provider {
+        EventsProvider::DuckDb => EVENTS_DUCKDB_LABEL,
+        EventsProvider::ClickHouse => EVENTS_CLICKHOUSE_LABEL,
+    }
+}
+
+async fn relational_connection_status(cfg: &RelationalBackendConfig) -> DatabaseConnectionStatus {
+    match cfg.provider {
+        RelationalProvider::Sqlite => match cfg.resolve_sqlite_db_path() {
+            Ok(path) => match check_sqlite_connection(&path).await {
+                Ok(_) => DatabaseConnectionStatus::Connected,
+                Err(err) => classify_connection_error(&err.to_string()),
+            },
+            Err(err) => classify_connection_error(&err.to_string()),
+        },
+        RelationalProvider::Postgres => match cfg.postgres_dsn.as_deref() {
+            Some(dsn) => match check_postgres_connection(dsn).await {
+                Ok(_) => DatabaseConnectionStatus::Connected,
+                Err(err) => classify_connection_error(&err.to_string()),
+            },
+            None => DatabaseConnectionStatus::NotConfigured,
+        },
+    }
+}
+
+async fn events_connection_status(cfg: &EventsBackendConfig) -> DatabaseConnectionStatus {
+    match cfg.provider {
+        EventsProvider::DuckDb => {
+            let duckdb_path = cfg.duckdb_path_or_default();
+            match check_duckdb_connection(&duckdb_path).await {
+                Ok(_) => DatabaseConnectionStatus::Connected,
+                Err(err) => classify_connection_error(&err.to_string()),
+            }
+        }
+        EventsProvider::ClickHouse => {
+            let clickhouse_url = cfg
+                .clickhouse_url
+                .clone()
+                .unwrap_or_else(|| "http://localhost:8123".to_string());
+            let clickhouse_database = cfg
+                .clickhouse_database
+                .clone()
+                .unwrap_or_else(|| "default".to_string());
+            let clickhouse_endpoint = clickhouse_endpoint(&clickhouse_url, &clickhouse_database);
+            match run_clickhouse_sql_http(
+                &clickhouse_endpoint,
+                cfg.clickhouse_user.as_deref(),
+                cfg.clickhouse_password.as_deref(),
+                "SELECT 1 FORMAT TabSeparated",
+            )
+            .await
+            {
+                Ok(_) => DatabaseConnectionStatus::Connected,
+                Err(err) => classify_connection_error(&err.to_string()),
+            }
+        }
+    }
 }
 
 async fn check_postgres_connection(dsn: &str) -> Result<()> {

--- a/bitloops_cli/src/engine/devql/mod.rs
+++ b/bitloops_cli/src/engine/devql/mod.rs
@@ -10,7 +10,9 @@ use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use tokio_postgres::{NoTls, config::SslMode};
 
-use crate::devql_config::DevqlFileConfig;
+use crate::devql_config::{
+    DevqlFileConfig, EventsProvider, RelationalProvider, resolve_devql_backend_config,
+};
 use crate::engine::db_status::{
     DatabaseConnectionStatus, DatabaseStatusRow, classify_connection_error,
 };
@@ -85,81 +87,85 @@ impl DevqlConfig {
     }
 }
 
-#[derive(Debug, Clone)]
-struct DevqlConnectionConfig {
-    pg_dsn: Option<String>,
-    clickhouse_url: String,
-    clickhouse_user: Option<String>,
-    clickhouse_password: Option<String>,
-    clickhouse_database: String,
-}
-
-impl DevqlConnectionConfig {
-    fn from_env() -> Self {
-        let file_cfg = DevqlFileConfig::load();
-        Self {
-            pg_dsn: env::var("BITLOOPS_DEVQL_PG_DSN")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .or(file_cfg.pg_dsn),
-            clickhouse_url: env::var("BITLOOPS_DEVQL_CH_URL")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .or(file_cfg.clickhouse_url)
-                .unwrap_or_else(|| "http://localhost:8123".to_string()),
-            clickhouse_user: env::var("BITLOOPS_DEVQL_CH_USER")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .or(file_cfg.clickhouse_user),
-            clickhouse_password: env::var("BITLOOPS_DEVQL_CH_PASSWORD")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .or(file_cfg.clickhouse_password),
-            clickhouse_database: env::var("BITLOOPS_DEVQL_CH_DATABASE")
-                .ok()
-                .filter(|s| !s.trim().is_empty())
-                .or(file_cfg.clickhouse_database)
-                .unwrap_or_else(|| "default".to_string()),
-        }
-    }
-
-    fn clickhouse_endpoint(&self) -> String {
-        let base = self.clickhouse_url.trim_end_matches('/');
-        format!("{base}/?database={}", self.clickhouse_database)
-    }
-}
+const RELATIONAL_SQLITE_LABEL: &str = "Relational (SQLite)";
+const RELATIONAL_POSTGRES_LABEL: &str = "Relational (Postgres)";
+const EVENTS_DUCKDB_LABEL: &str = "Events (DuckDB)";
+const EVENTS_CLICKHOUSE_LABEL: &str = "Events (ClickHouse)";
 
 pub async fn run_connection_status() -> Result<()> {
-    let cfg = DevqlConnectionConfig::from_env();
+    let cfg = resolve_devql_backend_config()?;
     let mut rows = Vec::new();
 
-    let postgres_status = match cfg.pg_dsn.as_deref() {
-        Some(dsn) => match check_postgres_connection(dsn).await {
-            Ok(_) => DatabaseConnectionStatus::Connected,
-            Err(err) => classify_connection_error(&err.to_string()),
+    let relational_status = match cfg.relational.provider {
+        RelationalProvider::Sqlite => {
+            let sqlite_path = cfg.relational.resolve_sqlite_db_path();
+            match sqlite_path {
+                Ok(path) => match check_sqlite_connection(&path).await {
+                    Ok(_) => DatabaseConnectionStatus::Connected,
+                    Err(err) => classify_connection_error(&err.to_string()),
+                },
+                Err(err) => classify_connection_error(&err.to_string()),
+            }
+        }
+        RelationalProvider::Postgres => match cfg.relational.postgres_dsn.as_deref() {
+            Some(dsn) => match check_postgres_connection(dsn).await {
+                Ok(_) => DatabaseConnectionStatus::Connected,
+                Err(err) => classify_connection_error(&err.to_string()),
+            },
+            None => DatabaseConnectionStatus::NotConfigured,
         },
-        None => DatabaseConnectionStatus::NotConfigured,
+    };
+
+    let relational_label = match cfg.relational.provider {
+        RelationalProvider::Sqlite => RELATIONAL_SQLITE_LABEL,
+        RelationalProvider::Postgres => RELATIONAL_POSTGRES_LABEL,
     };
     rows.push(DatabaseStatusRow {
-        db: "Postgres",
-        status: postgres_status,
+        db: relational_label,
+        status: relational_status,
     });
 
-    let clickhouse_endpoint = cfg.clickhouse_endpoint();
-    let clickhouse_status = match run_clickhouse_sql_http(
-        &clickhouse_endpoint,
-        cfg.clickhouse_user.as_deref(),
-        cfg.clickhouse_password.as_deref(),
-        "SELECT 1 FORMAT TabSeparated",
-    )
-    .await
-    {
-        Ok(_) => DatabaseConnectionStatus::Connected,
-        Err(err) => classify_connection_error(&err.to_string()),
+    let events_status = match cfg.events.provider {
+        EventsProvider::DuckDb => {
+            let duckdb_path = cfg.events.duckdb_path_or_default();
+            match check_duckdb_connection(&duckdb_path).await {
+                Ok(_) => DatabaseConnectionStatus::Connected,
+                Err(err) => classify_connection_error(&err.to_string()),
+            }
+        }
+        EventsProvider::ClickHouse => {
+            let clickhouse_url = cfg
+                .events
+                .clickhouse_url
+                .clone()
+                .unwrap_or_else(|| "http://localhost:8123".to_string());
+            let clickhouse_database = cfg
+                .events
+                .clickhouse_database
+                .clone()
+                .unwrap_or_else(|| "default".to_string());
+            let clickhouse_endpoint = clickhouse_endpoint(&clickhouse_url, &clickhouse_database);
+            match run_clickhouse_sql_http(
+                &clickhouse_endpoint,
+                cfg.events.clickhouse_user.as_deref(),
+                cfg.events.clickhouse_password.as_deref(),
+                "SELECT 1 FORMAT TabSeparated",
+            )
+            .await
+            {
+                Ok(_) => DatabaseConnectionStatus::Connected,
+                Err(err) => classify_connection_error(&err.to_string()),
+            }
+        }
+    };
+
+    let events_label = match cfg.events.provider {
+        EventsProvider::DuckDb => EVENTS_DUCKDB_LABEL,
+        EventsProvider::ClickHouse => EVENTS_CLICKHOUSE_LABEL,
     };
     rows.push(DatabaseStatusRow {
-        db: "ClickHouse",
-        status: clickhouse_status,
+        db: events_label,
+        status: events_status,
     });
 
     print_db_status_table(&rows);
@@ -187,6 +193,46 @@ async fn check_postgres_connection(dsn: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn check_sqlite_connection(path: &Path) -> Result<()> {
+    let db_path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        let conn = rusqlite::Connection::open_with_flags(
+            &db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+        )
+        .with_context(|| format!("opening SQLite database at {}", db_path.display()))?;
+
+        let value: i32 = conn
+            .query_row("SELECT 1", [], |row| row.get(0))
+            .context("running SQLite health query `SELECT 1`")?;
+        if value != 1 {
+            bail!("unexpected SQLite health query result: {value}");
+        }
+
+        Ok(())
+    })
+    .await
+    .context("joining SQLite health query task")?
+}
+
+async fn check_duckdb_connection(path: &Path) -> Result<()> {
+    let db_path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        let conn = duckdb::Connection::open(&db_path)
+            .with_context(|| format!("opening DuckDB events database at {}", db_path.display()))?;
+        conn.execute_batch("SELECT 1")
+            .context("running DuckDB health query `SELECT 1`")?;
+        Ok(())
+    })
+    .await
+    .context("joining DuckDB health query task")?
+}
+
+fn clickhouse_endpoint(url: &str, database: &str) -> String {
+    let base = url.trim_end_matches('/');
+    format!("{base}/?database={database}")
 }
 
 pub async fn run_init(cfg: &DevqlConfig) -> Result<()> {

--- a/bitloops_cli/src/engine/devql/tests/devql_tests.rs
+++ b/bitloops_cli/src/engine/devql/tests/devql_tests.rs
@@ -1,9 +1,11 @@
 use super::*;
 use crate::commands::devql::DevqlCommand;
+use crate::test_support::process_state::git_command;
 use clap::Parser;
 use serde_json::json;
 use std::env;
-use tempfile::tempdir;
+use std::path::Path;
+use tempfile::{TempDir, tempdir};
 
 fn test_cfg() -> DevqlConfig {
     DevqlConfig {
@@ -58,6 +60,35 @@ fn create_duckdb_db(path: &Path) {
     let conn = duckdb::Connection::open(path).expect("create duckdb db");
     conn.execute_batch("SELECT 1")
         .expect("validate duckdb db file");
+}
+
+fn git_ok(repo_root: &Path, args: &[&str]) -> String {
+    let out = git_command()
+        .args(args)
+        .current_dir(repo_root)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to start git {:?}: {err}", args));
+    assert!(
+        out.status.success(),
+        "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn seed_git_repo() -> TempDir {
+    let dir = TempDir::new().expect("temp dir");
+    git_ok(dir.path(), &["init"]);
+    git_ok(dir.path(), &["checkout", "-B", "main"]);
+    git_ok(dir.path(), &["config", "user.name", "Bitloops Test"]);
+    git_ok(
+        dir.path(),
+        &["config", "user.email", "bitloops-test@example.com"],
+    );
+    git_ok(dir.path(), &["commit", "--allow-empty", "-m", "initial"]);
+    dir
 }
 
 fn status_for(rows: &[DatabaseStatusRow], label: &'static str) -> DatabaseConnectionStatus {
@@ -140,6 +171,300 @@ fn test_unresolved_call_edge(
         end_line: Some(line),
         metadata: json!({ "resolution": "unresolved" }),
     }
+}
+
+#[test]
+fn sql_helpers_escape_nullable_and_json_values() {
+    assert_eq!(sql_nullable_text(None), "NULL");
+    assert_eq!(sql_nullable_text(Some("O'Reilly")), "'O''Reilly'");
+    assert_eq!(
+        sql_jsonb_text_array(&["O'Reilly".to_string(), "plain".to_string()]),
+        r#"'["O''Reilly","plain"]'::jsonb"#
+    );
+}
+
+#[test]
+fn supported_symbol_languages_are_whitelisted() {
+    for language in ["typescript", "javascript", "rust"] {
+        assert!(
+            is_supported_symbol_language(language),
+            "{language} should be supported"
+        );
+    }
+
+    for language in ["python", "go", ""] {
+        assert!(
+            !is_supported_symbol_language(language),
+            "{language} should not be supported"
+        );
+    }
+}
+
+#[test]
+fn build_file_current_record_preserves_file_metadata() {
+    let cfg = test_cfg();
+    let file = test_file_row(&cfg, "src/main.rs", "blob-1", 42, 420);
+    let record = build_file_current_record(
+        "src/main.rs",
+        "blob-1",
+        &file,
+        Some("Top-level docs".to_string()),
+    );
+
+    assert_eq!(record.symbol_id, file.symbol_id);
+    assert_eq!(record.artefact_id, file.artefact_id);
+    assert_eq!(record.canonical_kind.as_deref(), Some("file"));
+    assert_eq!(record.language_kind, "file");
+    assert_eq!(record.symbol_fqn, "src/main.rs");
+    assert_eq!(record.end_line, 42);
+    assert_eq!(record.end_byte, 420);
+    assert_eq!(record.docstring.as_deref(), Some("Top-level docs"));
+    assert_eq!(record.content_hash, "blob-1");
+}
+
+#[test]
+fn build_symbol_records_chain_file_and_nested_parent_links() {
+    let cfg = test_cfg();
+    let path = "src/ui.ts";
+    let blob_sha = "blob-ui";
+    let file = test_file_row(&cfg, path, blob_sha, 30, 300);
+    let items = vec![
+        JsTsArtefact {
+            canonical_kind: Some("class".to_string()),
+            language_kind: "class_declaration".to_string(),
+            name: "Widget".to_string(),
+            symbol_fqn: format!("{path}::Widget"),
+            parent_symbol_fqn: None,
+            start_line: 1,
+            end_line: 20,
+            start_byte: 0,
+            end_byte: 200,
+            signature: "export class Widget {}".to_string(),
+            modifiers: vec!["export".to_string()],
+            docstring: Some("Widget docs".to_string()),
+        },
+        JsTsArtefact {
+            canonical_kind: Some("method".to_string()),
+            language_kind: "method_definition".to_string(),
+            name: "render".to_string(),
+            symbol_fqn: format!("{path}::Widget::render"),
+            parent_symbol_fqn: Some(format!("{path}::Widget")),
+            start_line: 5,
+            end_line: 10,
+            start_byte: 40,
+            end_byte: 120,
+            signature: "render(): void {}".to_string(),
+            modifiers: vec![],
+            docstring: None,
+        },
+    ];
+
+    let records = build_symbol_records(&cfg, path, blob_sha, &file, &items);
+    assert_eq!(records.len(), 2);
+
+    let class_record = &records[0];
+    assert_eq!(class_record.parent_symbol_id, Some(file.symbol_id.clone()));
+    assert_eq!(
+        class_record.parent_artefact_id,
+        Some(file.artefact_id.clone())
+    );
+    assert_eq!(class_record.docstring.as_deref(), Some("Widget docs"));
+
+    let method_record = &records[1];
+    assert_eq!(
+        method_record.parent_symbol_id,
+        Some(class_record.symbol_id.clone())
+    );
+    assert_eq!(
+        method_record.parent_artefact_id,
+        Some(class_record.artefact_id.clone())
+    );
+    assert_eq!(
+        method_record.signature.as_deref(),
+        Some("render(): void {}")
+    );
+}
+
+#[test]
+fn build_historical_edge_records_keep_resolved_and_unresolved_targets() {
+    let cfg = test_cfg();
+    let path = "src/main.ts";
+    let blob_sha = "blob-2";
+    let from = test_symbol_record(&cfg, path, blob_sha, "from-symbol", "source", 1, 2);
+    let to = test_symbol_record(&cfg, path, blob_sha, "to-symbol", "target", 4, 5);
+    let current_by_fqn = [
+        (from.symbol_fqn.clone(), from.clone()),
+        (to.symbol_fqn.clone(), to.clone()),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+
+    let records = build_historical_edge_records(
+        &cfg,
+        blob_sha,
+        "typescript",
+        vec![
+            test_call_edge(&from.symbol_fqn, &to.symbol_fqn, 7),
+            test_unresolved_call_edge(&from.symbol_fqn, "remote::symbol", 9),
+            test_call_edge("missing::from", &to.symbol_fqn, 11),
+        ],
+        &current_by_fqn,
+    );
+
+    assert_eq!(records.len(), 2);
+    assert_eq!(
+        records[0].to_symbol_id.as_deref(),
+        Some(to.symbol_id.as_str())
+    );
+    assert_eq!(
+        records[0].to_artefact_id.as_deref(),
+        Some(to.artefact_id.as_str())
+    );
+    assert!(records[0].to_symbol_ref.is_none());
+    assert!(records[1].to_symbol_id.is_none());
+    assert!(records[1].to_artefact_id.is_none());
+    assert_eq!(records[1].to_symbol_ref.as_deref(), Some("remote::symbol"));
+}
+
+#[test]
+fn build_current_edge_records_resolve_local_and_external_targets() {
+    let cfg = test_cfg();
+    let path = "src/main.ts";
+    let blob_sha = "blob-3";
+    let from = test_symbol_record(&cfg, path, blob_sha, "from-symbol", "source", 1, 2);
+    let to = test_symbol_record(&cfg, path, blob_sha, "to-symbol", "target", 4, 5);
+    let current_by_fqn = [
+        (from.symbol_fqn.clone(), from.clone()),
+        (to.symbol_fqn.clone(), to.clone()),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+    let external_targets = [(
+        "pkg::remote".to_string(),
+        (
+            "external-symbol".to_string(),
+            "external-artefact".to_string(),
+        ),
+    )]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+
+    let records = build_current_edge_records(
+        &cfg,
+        "commit-3",
+        blob_sha,
+        "typescript",
+        vec![
+            test_call_edge(&from.symbol_fqn, &to.symbol_fqn, 7),
+            test_unresolved_call_edge(&from.symbol_fqn, "pkg::remote", 8),
+        ],
+        &current_by_fqn,
+        &external_targets,
+    );
+
+    assert_eq!(records.len(), 2);
+    assert_eq!(
+        records[0].to_symbol_id.as_deref(),
+        Some(to.symbol_id.as_str())
+    );
+    assert_eq!(
+        records[0].to_artefact_id.as_deref(),
+        Some(to.artefact_id.as_str())
+    );
+    assert_eq!(records[1].to_symbol_id.as_deref(), Some("external-symbol"));
+    assert_eq!(
+        records[1].to_artefact_id.as_deref(),
+        Some("external-artefact")
+    );
+    assert_eq!(records[1].to_symbol_ref.as_deref(), Some("pkg::remote"));
+}
+
+#[test]
+fn incoming_revision_is_newer_prefers_newer_timestamp_then_sha() {
+    assert!(incoming_revision_is_newer(None, "bbb", 10));
+    assert!(incoming_revision_is_newer(
+        Some(("aaa".to_string(), 9)),
+        "bbb",
+        10
+    ));
+    assert!(!incoming_revision_is_newer(
+        Some(("zzz".to_string(), 11)),
+        "bbb",
+        10
+    ));
+    assert!(incoming_revision_is_newer(
+        Some(("aaa".to_string(), 10)),
+        "bbb",
+        10
+    ));
+    assert!(!incoming_revision_is_newer(
+        Some(("ccc".to_string(), 10)),
+        "bbb",
+        10
+    ));
+}
+
+#[test]
+fn default_branch_name_uses_current_branch_and_falls_back_to_main() {
+    let repo = seed_git_repo();
+    git_ok(repo.path(), &["checkout", "-B", "feature/test-branch"]);
+
+    assert_eq!(default_branch_name(repo.path()), "feature/test-branch");
+    assert_eq!(
+        default_branch_name(tempdir().expect("temp dir").path()),
+        "main"
+    );
+}
+
+#[test]
+fn collect_checkpoint_commit_map_prefers_newest_valid_checkpoint_commit() {
+    let repo = seed_git_repo();
+    let checkpoint_id = "aabbccddeeff";
+
+    git_ok(
+        repo.path(),
+        &[
+            "commit",
+            "--allow-empty",
+            "-m",
+            "older checkpoint",
+            "-m",
+            &format!("{CHECKPOINT_TRAILER_KEY}: {checkpoint_id}"),
+        ],
+    );
+    git_ok(
+        repo.path(),
+        &[
+            "commit",
+            "--allow-empty",
+            "-m",
+            "ignored invalid checkpoint",
+            "-m",
+            &format!("{CHECKPOINT_TRAILER_KEY}: not-valid"),
+        ],
+    );
+    git_ok(
+        repo.path(),
+        &[
+            "commit",
+            "--allow-empty",
+            "-m",
+            "newest checkpoint",
+            "-m",
+            &format!("{CHECKPOINT_TRAILER_KEY}: {checkpoint_id}"),
+        ],
+    );
+
+    let checkpoint_map =
+        collect_checkpoint_commit_map(repo.path()).expect("checkpoint commit map should build");
+
+    assert_eq!(checkpoint_map.len(), 1);
+    let info = checkpoint_map
+        .get(checkpoint_id)
+        .expect("checkpoint should be present");
+    assert_eq!(info.subject, "newest checkpoint");
+    assert!(!info.commit_sha.is_empty());
+    assert!(info.commit_unix > 0);
 }
 
 #[test]

--- a/bitloops_cli/src/engine/devql/tests/devql_tests.rs
+++ b/bitloops_cli/src/engine/devql/tests/devql_tests.rs
@@ -3,6 +3,7 @@ use crate::commands::devql::DevqlCommand;
 use clap::Parser;
 use serde_json::json;
 use std::env;
+use tempfile::tempdir;
 
 fn test_cfg() -> DevqlConfig {
     DevqlConfig {
@@ -27,6 +28,43 @@ fn test_cfg_with_repo_id(repo_suffix: &str, dsn: &str) -> DevqlConfig {
     cfg.pg_dsn = Some(dsn.to_string());
     cfg.repo.repo_id = deterministic_uuid(&format!("repo://{repo_suffix}"));
     cfg
+}
+
+fn backend_cfg(sqlite_path: Option<String>, duckdb_path: Option<String>) -> DevqlBackendConfig {
+    DevqlBackendConfig {
+        relational: RelationalBackendConfig {
+            provider: RelationalProvider::Sqlite,
+            sqlite_path,
+            postgres_dsn: None,
+        },
+        events: EventsBackendConfig {
+            provider: EventsProvider::DuckDb,
+            duckdb_path,
+            clickhouse_url: None,
+            clickhouse_user: None,
+            clickhouse_password: None,
+            clickhouse_database: None,
+        },
+    }
+}
+
+fn create_sqlite_db(path: &Path) {
+    let conn = rusqlite::Connection::open(path).expect("create sqlite db");
+    conn.execute_batch("SELECT 1")
+        .expect("validate sqlite db file");
+}
+
+fn create_duckdb_db(path: &Path) {
+    let conn = duckdb::Connection::open(path).expect("create duckdb db");
+    conn.execute_batch("SELECT 1")
+        .expect("validate duckdb db file");
+}
+
+fn status_for(rows: &[DatabaseStatusRow], label: &'static str) -> DatabaseConnectionStatus {
+    rows.iter()
+        .find(|row| row.db == label)
+        .map(|row| row.status)
+        .unwrap_or_else(|| panic!("missing status row for {label}"))
 }
 
 fn test_file_row(
@@ -415,6 +453,50 @@ fn devql_file_config_parses_top_level_env_keys() {
     assert_eq!(cfg.pg_dsn.as_deref(), Some("postgres://x/y"));
     assert_eq!(cfg.clickhouse_url.as_deref(), Some("http://ch:8123"));
     assert_eq!(cfg.clickhouse_database.as_deref(), Some("analytics"));
+}
+
+#[tokio::test]
+async fn connection_status_rows_report_connected_for_sqlite_and_duckdb_files() {
+    let temp = tempdir().expect("temp dir");
+    let sqlite_path = temp.path().join("relational.sqlite");
+    let duckdb_path = temp.path().join("events.duckdb");
+
+    create_sqlite_db(&sqlite_path);
+    create_duckdb_db(&duckdb_path);
+
+    let cfg = backend_cfg(
+        Some(sqlite_path.display().to_string()),
+        Some(duckdb_path.display().to_string()),
+    );
+
+    let rows = collect_connection_status_rows(&cfg).await;
+
+    assert_eq!(
+        status_for(&rows, RELATIONAL_SQLITE_LABEL),
+        DatabaseConnectionStatus::Connected
+    );
+    assert_eq!(
+        status_for(&rows, EVENTS_DUCKDB_LABEL),
+        DatabaseConnectionStatus::Connected
+    );
+}
+
+#[tokio::test]
+async fn connection_status_rows_report_error_for_invalid_sqlite_and_duckdb_paths() {
+    let temp = tempdir().expect("temp dir");
+    let invalid_path = temp.path().display().to_string();
+    let cfg = backend_cfg(Some(invalid_path.clone()), Some(invalid_path));
+
+    let rows = collect_connection_status_rows(&cfg).await;
+
+    assert_eq!(
+        status_for(&rows, RELATIONAL_SQLITE_LABEL),
+        DatabaseConnectionStatus::Error
+    );
+    assert_eq!(
+        status_for(&rows, EVENTS_DUCKDB_LABEL),
+        DatabaseConnectionStatus::Error
+    );
 }
 
 #[test]

--- a/bitloops_cli/src/engine/strategy/noop.rs
+++ b/bitloops_cli/src/engine/strategy/noop.rs
@@ -38,3 +38,33 @@ impl Strategy for NoOpStrategy {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_strategy_accepts_all_strategy_operations() {
+        let strategy = NoOpStrategy;
+
+        assert_eq!(strategy.name(), "noop");
+        strategy
+            .save_step(&StepContext::default())
+            .expect("save_step should be a no-op");
+        strategy
+            .save_task_step(&TaskStepContext::default())
+            .expect("save_task_step should be a no-op");
+        strategy
+            .prepare_commit_msg(Path::new("/tmp/ignored"), Some("message"))
+            .expect("prepare_commit_msg should be a no-op");
+        strategy
+            .commit_msg(Path::new("/tmp/ignored"))
+            .expect("commit_msg should be a no-op");
+        strategy
+            .post_commit()
+            .expect("post_commit should be a no-op");
+        strategy
+            .pre_push("origin")
+            .expect("pre_push should be a no-op");
+    }
+}

--- a/bitloops_cli/src/lib.rs
+++ b/bitloops_cli/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod branding;
 pub mod commands;
 pub mod devql_config;
 pub mod engine;

--- a/bitloops_cli/src/main.rs
+++ b/bitloops_cli/src/main.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 
 pub use bitloops_cli::engine;
+mod branding;
 mod commands;
 mod devql_config;
 mod server;
-mod terminal;
 
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/bitloops_cli/src/server/dashboard/mod.rs
+++ b/bitloops_cli/src/server/dashboard/mod.rs
@@ -5,17 +5,14 @@ mod dto;
 mod handlers;
 mod router;
 
-use crate::engine::db_status::{
-    DatabaseConnectionStatus, DatabaseStatusRow, classify_connection_error,
-};
+use crate::branding::{BITLOOPS_PURPLE_HEX, bitloops_wordmark, color_hex};
+use crate::devql_config::dashboard_use_bitloops_local;
 use crate::engine::paths;
 use crate::engine::strategy::manual_commit::{
     CommittedInfo, list_committed, read_committed_info, run_git,
 };
 use crate::engine::trailers::{CHECKPOINT_TRAILER_KEY, is_valid_checkpoint_id};
-use crate::terminal::db_status_table::print_db_status_table;
 use anyhow::{Context, Result, anyhow, bail};
-use figlet_rs::FIGfont;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
@@ -132,14 +129,16 @@ fn is_dev_mode() -> bool {
 
 pub async fn run(config: DashboardServerConfig) -> Result<()> {
     let db_init = db::init_dashboard_db().await;
-    print_dashboard_db_health(&db_init.startup_health);
     if db_init.startup_health.has_failures() {
-        bail!("dashboard database startup health check failed");
+        bail!(
+            "dashboard database startup health check failed; run `bitloops --connection-status` for details"
+        );
     }
 
-    let selected_host = select_host_with_probe(config.host.as_deref(), |candidate| {
-        host_resolves_to_loopback(candidate, config.port)
-    });
+    let selected_host = select_host_with_dashboard_preference(
+        config.host.as_deref(),
+        dashboard_use_bitloops_local(),
+    );
     let bind_addr = resolve_bind_addr(&selected_host, config.port)?;
 
     let listener = TcpListener::bind(bind_addr).await.with_context(|| {
@@ -166,16 +165,12 @@ pub async fn run(config: DashboardServerConfig) -> Result<()> {
     let url = format_dashboard_url(&browser_host, local_addr.port());
 
     println!();
-    if let Some(banner) = figlet_banner("bitloops") {
-        println!("{}", color_hex(banner.trim_end(), "#7404e4"));
-    } else {
-        println!("{}", color_hex(&squared_capital("Bitloops"), "#7404e4"));
-    }
+    println!("{}", color_hex(&bitloops_wordmark(), BITLOOPS_PURPLE_HEX));
     println!();
     print!("📊 Dashboard ");
     print!("{}", color_hex("ready ", "#22c55e"));
     print!("at ");
-    println!("{}", color_hex(&clickable_url(&url), "#7404e4"));
+    println!("{}", color_hex(&clickable_url(&url), BITLOOPS_PURPLE_HEX));
     match &serve_mode {
         ServeMode::HelloWorld => {
             println!(
@@ -211,28 +206,6 @@ pub async fn run(config: DashboardServerConfig) -> Result<()> {
     .await
 }
 
-fn print_dashboard_db_health(health: &db::DashboardDbHealth) {
-    let rows = [
-        DatabaseStatusRow {
-            db: "Relational",
-            status: map_backend_health_status(&health.relational),
-        },
-        DatabaseStatusRow {
-            db: "Events",
-            status: map_backend_health_status(&health.events),
-        },
-    ];
-    print_db_status_table(&rows);
-}
-
-fn map_backend_health_status(health: &db::BackendHealth) -> DatabaseConnectionStatus {
-    match health.kind {
-        db::BackendHealthKind::Ok => DatabaseConnectionStatus::Connected,
-        db::BackendHealthKind::Skip => DatabaseConnectionStatus::NotConfigured,
-        db::BackendHealthKind::Fail => classify_connection_error(&health.detail),
-    }
-}
-
 async fn serve_until_ctrl_c(listener: TcpListener, state: DashboardState) -> Result<()> {
     let app = router::build_dashboard_router(state);
 
@@ -247,32 +220,8 @@ async fn serve_until_ctrl_c(listener: TcpListener, state: DashboardState) -> Res
     Ok(())
 }
 
-fn figlet_banner(s: &str) -> Option<String> {
-    let font = FIGfont::standard().ok()?;
-    let figure = font.convert(s)?;
-    Some(figure.to_string())
-}
-
 fn clickable_url(url: &str) -> String {
     format!("\x1b]8;;{url}\x1b\\{url}\x1b]8;;\x1b\\")
-}
-
-fn squared_capital(s: &str) -> String {
-    s.chars()
-        .map(|c| match c {
-            'A'..='Z' => char::from_u32(0x1F170 + (c as u32 - 'A' as u32)).unwrap_or(c),
-            'a'..='z' => char::from_u32(0x1F170 + (c as u32 - 'a' as u32)).unwrap_or(c),
-            _ => c,
-        })
-        .collect()
-}
-
-fn color_hex(text: &str, hex: &str) -> String {
-    let hex = hex.trim_start_matches('#');
-    let r = u8::from_str_radix(hex.get(0..2).unwrap_or("00"), 16).unwrap_or(0);
-    let g = u8::from_str_radix(hex.get(2..4).unwrap_or("00"), 16).unwrap_or(0);
-    let b = u8::from_str_radix(hex.get(4..6).unwrap_or("00"), 16).unwrap_or(0);
-    format!("\x1b[38;2;{r};{g};{b}m{text}\x1b[0m")
 }
 
 fn canonical_user_key(name: &str, email: &str) -> String {
@@ -716,15 +665,15 @@ pub(super) fn expand_tilde_with_home(path: &Path, home: Option<&Path>) -> PathBu
     path.to_path_buf()
 }
 
-pub(super) fn select_host_with_probe<F>(explicit_host: Option<&str>, probe: F) -> String
-where
-    F: Fn(&str) -> bool,
-{
+pub(super) fn select_host_with_dashboard_preference(
+    explicit_host: Option<&str>,
+    use_bitloops_local: bool,
+) -> String {
     if let Some(host) = explicit_host.and_then(normalized_host) {
         return host.to_string();
     }
 
-    if probe(PREFERRED_LOCAL_HOST) {
+    if use_bitloops_local {
         PREFERRED_LOCAL_HOST.to_string()
     } else {
         FALLBACK_LOCAL_HOST.to_string()
@@ -734,13 +683,6 @@ where
 fn normalized_host(input: &str) -> Option<&str> {
     let host = input.trim();
     if host.is_empty() { None } else { Some(host) }
-}
-
-fn host_resolves_to_loopback(host: &str, port: u16) -> bool {
-    let Ok(addrs) = (host, port).to_socket_addrs() else {
-        return false;
-    };
-    addrs.into_iter().any(|addr| addr.ip().is_loopback())
 }
 
 fn resolve_bind_addr(host: &str, port: u16) -> Result<SocketAddr> {

--- a/bitloops_cli/src/server/dashboard/tests.rs
+++ b/bitloops_cli/src/server/dashboard/tests.rs
@@ -6,7 +6,7 @@ use super::{
     branch_is_excluded, browser_host_for_url, build_branch_commit_log_args, canonical_agent_key,
     dashboard_user, default_bundle_dir_from_home, expand_tilde_with_home, format_dashboard_url,
     has_bundle_index, paginate, parse_branch_commit_log, parse_numstat_output, resolve_bundle_file,
-    select_host_with_probe,
+    select_host_with_dashboard_preference,
 };
 use crate::engine::trailers::CHECKPOINT_TRAILER_KEY;
 use crate::test_support::process_state::{ProcessStateGuard, enter_env_vars, git_command};
@@ -441,20 +441,20 @@ async fn request_text(app: axum::Router, uri: &str) -> (StatusCode, String) {
 }
 
 #[test]
-fn select_host_prefers_bitloops_local_when_probe_succeeds() {
-    let selected = select_host_with_probe(None, |host| host == "bitloops.local");
+fn select_host_prefers_bitloops_local_when_config_enabled() {
+    let selected = select_host_with_dashboard_preference(None, true);
     assert_eq!(selected, "bitloops.local");
 }
 
 #[test]
-fn select_host_falls_back_to_localhost_when_probe_fails() {
-    let selected = select_host_with_probe(None, |_| false);
+fn select_host_falls_back_to_localhost_when_config_disabled() {
+    let selected = select_host_with_dashboard_preference(None, false);
     assert_eq!(selected, "127.0.0.1");
 }
 
 #[test]
 fn select_host_respects_explicit_host() {
-    let selected = select_host_with_probe(Some("localhost"), |_| false);
+    let selected = select_host_with_dashboard_preference(Some("localhost"), true);
     assert_eq!(selected, "localhost");
 }
 

--- a/bitloops_cli/src/terminal/db_status_table.rs
+++ b/bitloops_cli/src/terminal/db_status_table.rs
@@ -1,8 +1,13 @@
 use std::env;
+use std::fmt::Write as _;
 
 use crate::engine::db_status::{DatabaseConnectionStatus, DatabaseStatusRow};
 
 pub fn print_db_status_table(rows: &[DatabaseStatusRow]) {
+    print!("{}", render_db_status_table(rows));
+}
+
+fn render_db_status_table(rows: &[DatabaseStatusRow]) -> String {
     let db_width = rows
         .iter()
         .map(|row| row.db.len())
@@ -16,28 +21,35 @@ pub fn print_db_status_table(rows: &[DatabaseStatusRow]) {
         .unwrap_or(6)
         .max("Status".len());
 
-    println!();
-    println!(
+    let mut out = String::new();
+    out.push('\n');
+    writeln!(
+        &mut out,
         "+-{:-<db_width$}-+-{:-<status_width$}-+",
         "",
         "",
         db_width = db_width,
         status_width = status_width
-    );
-    println!(
+    )
+    .expect("writing to string should succeed");
+    writeln!(
+        &mut out,
         "| {:<db_width$} | {:<status_width$} |",
         "DB",
         "Status",
         db_width = db_width,
         status_width = status_width
-    );
-    println!(
+    )
+    .expect("writing to string should succeed");
+    writeln!(
+        &mut out,
         "+-{:-<db_width$}-+-{:-<status_width$}-+",
         "",
         "",
         db_width = db_width,
         status_width = status_width
-    );
+    )
+    .expect("writing to string should succeed");
 
     for row in rows {
         let raw_status = format!(
@@ -46,21 +58,26 @@ pub fn print_db_status_table(rows: &[DatabaseStatusRow]) {
             status_width = status_width
         );
         let colored_status = colorize_status_label(row.status, &raw_status);
-        println!(
+        writeln!(
+            &mut out,
             "| {:<db_width$} | {} |",
             row.db,
             colored_status,
             db_width = db_width
-        );
+        )
+        .expect("writing to string should succeed");
     }
 
-    println!(
+    writeln!(
+        &mut out,
         "+-{:-<db_width$}-+-{:-<status_width$}-+",
         "",
         "",
         db_width = db_width,
         status_width = status_width
-    );
+    )
+    .expect("writing to string should succeed");
+    out
 }
 
 fn colorize_status_label(status: DatabaseConnectionStatus, text: &str) -> String {
@@ -80,4 +97,64 @@ fn colorize_status_label(status: DatabaseConnectionStatus, text: &str) -> String
 
 fn should_use_color_output() -> bool {
     env::var_os("NO_COLOR").is_none() && env::var("ACCESSIBLE").is_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::process_state::with_env_vars;
+
+    fn test_rows() -> [DatabaseStatusRow; 2] {
+        [
+            DatabaseStatusRow {
+                db: "SQLite",
+                status: DatabaseConnectionStatus::Connected,
+            },
+            DatabaseStatusRow {
+                db: "ClickHouse",
+                status: DatabaseConnectionStatus::NotConfigured,
+            },
+        ]
+    }
+
+    #[test]
+    fn render_db_status_table_omits_ansi_when_colour_is_disabled() {
+        with_env_vars(&[("NO_COLOR", Some("1")), ("ACCESSIBLE", None)], || {
+            let rendered = render_db_status_table(&test_rows());
+
+            assert!(rendered.starts_with('\n'));
+            assert!(rendered.contains("| DB         | Status         |"));
+            assert!(rendered.contains("| SQLite     | Connected      |"));
+            assert!(rendered.contains("| ClickHouse | Not configured |"));
+            assert!(!rendered.contains("\x1b["));
+        });
+    }
+
+    #[test]
+    fn colorize_status_label_uses_expected_ansi_codes() {
+        with_env_vars(&[("NO_COLOR", None), ("ACCESSIBLE", None)], || {
+            assert_eq!(
+                colorize_status_label(DatabaseConnectionStatus::Connected, "Connected"),
+                "\x1b[32mConnected\x1b[0m"
+            );
+            assert_eq!(
+                colorize_status_label(DatabaseConnectionStatus::NotConfigured, "Not configured"),
+                "\x1b[33mNot configured\x1b[0m"
+            );
+            assert_eq!(
+                colorize_status_label(
+                    DatabaseConnectionStatus::CouldNotReachDb,
+                    "Could not reach DB"
+                ),
+                "\x1b[31mCould not reach DB\x1b[0m"
+            );
+        });
+    }
+
+    #[test]
+    fn accessible_mode_disables_colour_output() {
+        with_env_vars(&[("NO_COLOR", None), ("ACCESSIBLE", Some("1"))], || {
+            assert!(!should_use_color_output());
+        });
+    }
 }

--- a/bitloops_cli/src/terminal/db_status_table.rs
+++ b/bitloops_cli/src/terminal/db_status_table.rs
@@ -3,44 +3,54 @@ use std::env;
 use crate::engine::db_status::{DatabaseConnectionStatus, DatabaseStatusRow};
 
 pub fn print_db_status_table(rows: &[DatabaseStatusRow]) {
-    const DB_WIDTH: usize = 10;
-    const STATUS_WIDTH: usize = 23;
+    let db_width = rows
+        .iter()
+        .map(|row| row.db.len())
+        .max()
+        .unwrap_or(2)
+        .max("DB".len());
+    let status_width = rows
+        .iter()
+        .map(|row| row.status.label().len())
+        .max()
+        .unwrap_or(6)
+        .max("Status".len());
 
-    println!("DB Status");
+    println!();
     println!(
         "+-{:-<db_width$}-+-{:-<status_width$}-+",
         "",
         "",
-        db_width = DB_WIDTH,
-        status_width = STATUS_WIDTH
+        db_width = db_width,
+        status_width = status_width
     );
     println!(
         "| {:<db_width$} | {:<status_width$} |",
         "DB",
         "Status",
-        db_width = DB_WIDTH,
-        status_width = STATUS_WIDTH
+        db_width = db_width,
+        status_width = status_width
     );
     println!(
         "+-{:-<db_width$}-+-{:-<status_width$}-+",
         "",
         "",
-        db_width = DB_WIDTH,
-        status_width = STATUS_WIDTH
+        db_width = db_width,
+        status_width = status_width
     );
 
     for row in rows {
         let raw_status = format!(
             "{:<status_width$}",
             row.status.label(),
-            status_width = STATUS_WIDTH
+            status_width = status_width
         );
         let colored_status = colorize_status_label(row.status, &raw_status);
         println!(
             "| {:<db_width$} | {} |",
             row.db,
             colored_status,
-            db_width = DB_WIDTH
+            db_width = db_width
         );
     }
 
@@ -48,8 +58,8 @@ pub fn print_db_status_table(rows: &[DatabaseStatusRow]) {
         "+-{:-<db_width$}-+-{:-<status_width$}-+",
         "",
         "",
-        db_width = DB_WIDTH,
-        status_width = STATUS_WIDTH
+        db_width = db_width,
+        status_width = status_width
     );
 }
 


### PR DESCRIPTION
## Summary

This pull request introduces several improvements to the Bitloops CLI, focusing on enhanced version reporting, update checking, configuration documentation, and build metadata management. The most important changes are grouped below by theme.

### CLI version command improvements

* Added a new `--version` flag (with optional `--check`) to the Bitloops CLI root command, allowing users to display build information and check for updates directly from the command line. The version output is now visually enhanced with a wordmark and color, and includes commit, target, and build date details. [[1]](diffhunk://#diff-0252a40ba0cb66330a828178530661b0b70926889cce58ae8f116421f4ab0b03R26-R37) [[2]](diffhunk://#diff-0252a40ba0cb66330a828178530661b0b70926889cce58ae8f116421f4ab0b03R109-R121) [[3]](diffhunk://#diff-0252a40ba0cb66330a828178530661b0b70926889cce58ae8f116421f4ab0b03L129-R151) [[4]](diffhunk://#diff-79e57d715a0eb0e57f9b7cb8402a34f966157f906acd5058670bf7a31e135555R107-R113) [[5]](diffhunk://#diff-79e57d715a0eb0e57f9b7cb8402a34f966157f906acd5058670bf7a31e135555L372-R409) [[6]](diffhunk://#diff-79e57d715a0eb0e57f9b7cb8402a34f966157f906acd5058670bf7a31e135555L478-R556)
* Refactored version reporting to include build metadata (commit, target, date) and improved formatting for clarity and accessibility. [[1]](diffhunk://#diff-2e9c165663876b20c96734039e249f57c8182112f209acece0d2c221d588b2a9R34-R90) [[2]](diffhunk://#diff-79e57d715a0eb0e57f9b7cb8402a34f966157f906acd5058670bf7a31e135555R131-R140) [[3]](diffhunk://#diff-79e57d715a0eb0e57f9b7cb8402a34f966157f906acd5058670bf7a31e135555L213-R230)

### Update checking

* Added the ability to check for the latest CLI version using the `bitloops --version --check` flag, and improved user guidance in the version output. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16-R17) [[2]](diffhunk://#diff-79e57d715a0eb0e57f9b7cb8402a34f966157f906acd5058670bf7a31e135555L372-R409)

### Configuration and documentation enhancements

* Introduced a comprehensive `CONFIG.md` file documenting all user-facing configuration options, including environment variables, config files, and build-time settings. This clarifies precedence and supported keys for DevQL and dashboard configuration.
* Updated changelog and getting started documentation to reflect new features and improvements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16-R17) [[2]](diffhunk://#diff-9af4e8f15ef227c19dc8a0ec7270fd0628355125788eedcb8039901dfc61666bL105-R105)

### Build metadata and dependency updates

* Improved build metadata emission in `build.rs`, including automatic commit detection and build date generation, and added the `time` crate as a dependency for date formatting. [[1]](diffhunk://#diff-2e9c165663876b20c96734039e249f57c8182112f209acece0d2c221d588b2a9R5-R6) [[2]](diffhunk://#diff-2e9c165663876b20c96734039e249f57c8182112f209acece0d2c221d588b2a9R34-R90) [[3]](diffhunk://#diff-a62dabd26c6935ce3f5ac8df75af815ec32d4c1cdc06c51abd4faa627a73ae10R50)
* Added new branding utilities for color output and ASCII wordmark rendering in CLI version output. [[1]](diffhunk://#diff-f3f94d832e216b346042754383d6f38d76421f5278c9695064d5d68ae552045bR1-R44) [[2]](diffhunk://#diff-c7c61bda0109bcda0b8bcf985bbfdc0c75e38297511efb61feaecee81bbc3370R6)

These changes collectively make the CLI more user-friendly, provide clearer version and update information, and offer robust configuration documentation for both users and developers.

## Validation

- [X] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

