### PR TITLE
renamed semantic to structural identity

### DIFF
--- a/bitloops_cli/src/engine/devql/ingestion/artefact_identity.rs
+++ b/bitloops_cli/src/engine/devql/ingestion/artefact_identity.rs
@@ -50,7 +50,7 @@ fn identity_signature_for_artefact(item: &JsTsArtefact) -> String {
     signature
 }
 
-fn semantic_symbol_id_for_artefact(item: &JsTsArtefact, parent_symbol_id: Option<&str>) -> String {
+fn structural_symbol_id_for_artefact(item: &JsTsArtefact, parent_symbol_id: Option<&str>) -> String {
     deterministic_uuid(&format!(
         "{}|{}|{}|{}|{}|{}",
         source_path_from_symbol_fqn(&item.symbol_fqn),

--- a/bitloops_cli/src/engine/devql/ingestion/artefact_persistence.rs
+++ b/bitloops_cli/src/engine/devql/ingestion/artefact_persistence.rs
@@ -177,7 +177,7 @@ fn build_symbol_records(
             .as_ref()
             .and_then(|fqn| symbol_to_symbol_id.get(fqn))
             .map(String::as_str);
-        let symbol_id = semantic_symbol_id_for_artefact(item, semantic_parent_symbol_id);
+        let symbol_id = structural_symbol_id_for_artefact(item, semantic_parent_symbol_id);
         let artefact_id = revision_artefact_id(&cfg.repo.repo_id, blob_sha, &symbol_id);
         let content_hash = deterministic_uuid(&format!(
             "{}|{}|{}|{}|{}|{}",

--- a/bitloops_cli/src/engine/devql/mod.rs
+++ b/bitloops_cli/src/engine/devql/mod.rs
@@ -424,7 +424,7 @@ include!("db_utils.rs");
 
 #[cfg(test)]
 fn symbol_id_for_artefact(item: &JsTsArtefact) -> String {
-    semantic_symbol_id_for_artefact(item, None)
+    structural_symbol_id_for_artefact(item, None)
 }
 
 #[cfg(test)]

--- a/bitloops_cli/src/engine/devql/tests/devql_tests.rs
+++ b/bitloops_cli/src/engine/devql/tests/devql_tests.rs
@@ -1961,7 +1961,7 @@ fn factorial(n: u64) -> u64 {
 }
 
 #[test]
-fn semantic_symbol_id_is_stable_for_positional_impl_names() {
+fn symbol_id_is_stable_when_impl_block_moves_lines() {
     let original = JsTsArtefact {
         canonical_kind: None,
         language_kind: "impl_item".to_string(),
@@ -1985,8 +1985,8 @@ fn semantic_symbol_id_is_stable_for_positional_impl_names() {
     };
 
     assert_eq!(
-        semantic_symbol_id_for_artefact(&original, None),
-        semantic_symbol_id_for_artefact(&moved, None)
+        structural_symbol_id_for_artefact(&original, None),
+        structural_symbol_id_for_artefact(&moved, None)
     );
 }
 
@@ -2065,8 +2065,8 @@ impl Service for Repo {
         .iter()
         .find(|artefact| artefact.language_kind == "impl_item")
         .expect("expected impl artefact in moved ingest");
-    let original_impl_symbol_id = semantic_symbol_id_for_artefact(original_impl, None);
-    let moved_impl_symbol_id = semantic_symbol_id_for_artefact(moved_impl, None);
+    let original_impl_symbol_id = structural_symbol_id_for_artefact(original_impl, None);
+    let moved_impl_symbol_id = structural_symbol_id_for_artefact(moved_impl, None);
     assert_eq!(original_impl_symbol_id, moved_impl_symbol_id);
 
     let original_method = original_artefacts
@@ -2083,9 +2083,9 @@ impl Service for Repo {
         .expect("expected run method in moved ingest");
 
     let original_method_symbol_id =
-        semantic_symbol_id_for_artefact(original_method, Some(&original_impl_symbol_id));
+        structural_symbol_id_for_artefact(original_method, Some(&original_impl_symbol_id));
     let moved_method_symbol_id =
-        semantic_symbol_id_for_artefact(moved_method, Some(&moved_impl_symbol_id));
+        structural_symbol_id_for_artefact(moved_method, Some(&moved_impl_symbol_id));
 
     assert_eq!(original_method_symbol_id, moved_method_symbol_id);
     assert_ne!(


### PR DESCRIPTION
## Summary

Renamed semantic to structural identity to avoid confusion

## Validation

- [x] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

