### PR TITLE
Feature add dependencies to semantics

### DIFF
--- a/bitloops_cli/src/engine/devql/ingestion/semantic_clones_persistence.rs
+++ b/bitloops_cli/src/engine/devql/ingestion/semantic_clones_persistence.rs
@@ -105,6 +105,8 @@ async fn load_symbol_clone_candidate_inputs(
 ) -> Result<Vec<semantic_clones::SymbolCloneCandidateInput>> {
     let churn_by_symbol_id = load_symbol_churn_counts(relational, repo_id).await?;
     let call_targets_by_symbol_id = load_symbol_call_targets(relational, repo_id).await?;
+    let dependency_targets_by_symbol_id =
+        load_symbol_dependency_targets(relational, repo_id).await?;
     let rows = relational
         .query_rows(&build_symbol_clone_candidate_lookup_sql(repo_id))
         .await?;
@@ -171,6 +173,10 @@ async fn load_symbol_clone_candidate_inputs(
                 .get(symbol_id)
                 .cloned()
                 .unwrap_or_default(),
+            dependency_targets: dependency_targets_by_symbol_id
+                .get(symbol_id)
+                .cloned()
+                .unwrap_or_default(),
             churn_count: churn_by_symbol_id.get(symbol_id).copied().unwrap_or(0),
         });
     }
@@ -209,10 +215,12 @@ async fn load_symbol_call_targets(
     repo_id: &str,
 ) -> Result<HashMap<String, Vec<String>>> {
     let sql = format!(
-        "SELECT from_symbol_id, COALESCE(to_symbol_id, to_symbol_ref) AS target_ref \
-FROM artefact_edges_current \
-WHERE repo_id = '{}' AND edge_kind = 'calls'",
+        "SELECT e.from_symbol_id, COALESCE(target.symbol_fqn, target.path, e.to_symbol_ref, e.to_symbol_id, '') AS target_ref \
+FROM artefact_edges_current e \
+LEFT JOIN artefacts_current target ON target.repo_id = e.repo_id AND target.artefact_id = e.to_artefact_id \
+WHERE e.repo_id = '{}' AND e.edge_kind = '{}'",
         esc_pg(repo_id),
+        esc_pg(EDGE_KIND_CALLS),
     );
     let rows = relational.query_rows(&sql).await?;
     let mut out = HashMap::<String, HashSet<String>>::new();
@@ -229,6 +237,50 @@ WHERE repo_id = '{}' AND edge_kind = 'calls'",
         out.entry(from_symbol_id.to_string())
             .or_default()
             .insert(target_ref.to_string());
+    }
+
+    Ok(out
+        .into_iter()
+        .map(|(symbol_id, targets)| {
+            let mut targets = targets.into_iter().collect::<Vec<_>>();
+            targets.sort();
+            (symbol_id, targets)
+        })
+        .collect())
+}
+
+async fn load_symbol_dependency_targets(
+    relational: &RelationalStorage,
+    repo_id: &str,
+) -> Result<HashMap<String, Vec<String>>> {
+    let sql = format!(
+        "SELECT e.from_symbol_id, LOWER(e.edge_kind) AS edge_kind, \
+COALESCE(target.symbol_fqn, target.path, e.to_symbol_ref, e.to_symbol_id, '') AS target_ref \
+FROM artefact_edges_current e \
+LEFT JOIN artefacts_current target ON target.repo_id = e.repo_id AND target.artefact_id = e.to_artefact_id \
+WHERE e.repo_id = '{}' AND e.edge_kind <> '{}' AND e.edge_kind <> '{}'",
+        esc_pg(repo_id),
+        esc_pg(EDGE_KIND_CALLS),
+        esc_pg(EDGE_KIND_EXPORTS),
+    );
+    let rows = relational.query_rows(&sql).await?;
+    let mut out = HashMap::<String, HashSet<String>>::new();
+    for row in rows {
+        let Some(from_symbol_id) = row.get("from_symbol_id").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(edge_kind) = row.get("edge_kind").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(target_ref) = row.get("target_ref").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(signal) = semantic::build_dependency_context_signal(edge_kind, target_ref) else {
+            continue;
+        };
+        out.entry(from_symbol_id.to_string())
+            .or_default()
+            .insert(signal);
     }
 
     Ok(out

--- a/bitloops_cli/src/engine/devql/ingestion/semantic_features_persistence.rs
+++ b/bitloops_cli/src/engine/devql/ingestion/semantic_features_persistence.rs
@@ -188,6 +188,18 @@ async fn load_pre_stage_artefacts_for_blob(
     parse_semantic_artefact_rows(rows)
 }
 
+async fn load_pre_stage_dependencies_for_blob(
+    relational: &RelationalStorage,
+    repo_id: &str,
+    blob_sha: &str,
+    path: &str,
+) -> Result<Vec<semantic::PreStageDependencyRow>> {
+    let rows = relational
+        .query_rows(&build_semantic_get_dependencies_sql(repo_id, blob_sha, path))
+        .await?;
+    parse_semantic_dependency_rows(rows)
+}
+
 async fn upsert_semantic_feature_rows(
     relational: &RelationalStorage,
     inputs: &[semantic::SemanticFeatureInput],
@@ -252,6 +264,21 @@ ORDER BY coalesce(start_byte, 0), coalesce(start_line, 0), artefact_id",
     )
 }
 
+fn build_semantic_get_dependencies_sql(repo_id: &str, blob_sha: &str, path: &str) -> String {
+    format!(
+        "SELECT e.from_artefact_id, LOWER(e.edge_kind) AS edge_kind, \
+COALESCE(target.symbol_fqn, target.path, e.to_symbol_ref, e.to_artefact_id, '') AS target_ref \
+FROM artefact_edges e \
+JOIN artefacts source ON source.repo_id = e.repo_id AND source.artefact_id = e.from_artefact_id \
+LEFT JOIN artefacts target ON target.repo_id = e.repo_id AND target.artefact_id = e.to_artefact_id \
+WHERE e.repo_id = '{repo_id}' AND e.blob_sha = '{blob_sha}' AND source.path = '{path}' \
+ORDER BY e.from_artefact_id, e.edge_kind, target_ref",
+        repo_id = esc_pg(repo_id),
+        blob_sha = esc_pg(blob_sha),
+        path = esc_pg(path),
+    )
+}
+
 fn parse_semantic_artefact_rows(rows: Vec<Value>) -> Result<Vec<semantic::PreStageArtefactRow>> {
     let mut artefacts = Vec::with_capacity(rows.len());
     for row in rows {
@@ -269,6 +296,20 @@ fn parse_semantic_artefact_rows(rows: Vec<Value>) -> Result<Vec<semantic::PreSta
         artefacts.push(artefact);
     }
     Ok(artefacts)
+}
+
+fn parse_semantic_dependency_rows(
+    rows: Vec<Value>,
+) -> Result<Vec<semantic::PreStageDependencyRow>> {
+    let mut dependencies = Vec::with_capacity(rows.len());
+    for row in rows {
+        let dependency = serde_json::from_value::<semantic::PreStageDependencyRow>(row)?;
+        if dependency.target_ref.trim().is_empty() {
+            continue;
+        }
+        dependencies.push(dependency);
+    }
+    Ok(dependencies)
 }
 
 fn build_semantic_get_index_state_sql(artefact_id: &str) -> String {
@@ -409,6 +450,7 @@ mod semantic_feature_persistence_tests {
                 body: "return repo.findById(id);".to_string(),
                 docstring: Some("Fetches O'Brien by id.".to_string()),
                 parent_kind: Some("class".to_string()),
+                dependency_signals: vec!["calls:user_repo::find_by_id".to_string()],
                 content_hash: Some("hash-1".to_string()),
             },
             &semantic::NoopSemanticSummaryProvider,
@@ -439,6 +481,15 @@ mod semantic_feature_persistence_tests {
         assert!(sql.contains("blob_sha = 'blob''1'"));
         assert!(sql.contains("path = 'src/o''brien.ts'"));
         assert!(sql.contains("signature, modifiers, docstring, content_hash"));
+    }
+
+    #[test]
+    fn semantic_feature_persistence_builds_get_dependencies_sql_with_escaped_values() {
+        let sql = build_semantic_get_dependencies_sql("repo'1", "blob'1", "src/o'brien.ts");
+        assert!(sql.contains("repo_id = 'repo''1'"));
+        assert!(sql.contains("blob_sha = 'blob''1'"));
+        assert!(sql.contains("source.path = 'src/o''brien.ts'"));
+        assert!(sql.contains("FROM artefact_edges e"));
     }
 
     #[test]
@@ -502,5 +553,18 @@ mod semantic_feature_persistence_tests {
             parsed[0].modifiers,
             vec!["public".to_string(), "async".to_string()]
         );
+    }
+
+    #[test]
+    fn semantic_feature_persistence_parses_dependency_rows() {
+        let parsed = parse_semantic_dependency_rows(vec![json!({
+            "from_artefact_id": "artefact-1",
+            "edge_kind": "calls",
+            "target_ref": "src/services/user.ts::UserRepo::findById"
+        })])
+        .expect("dependency rows should parse");
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].edge_kind, "calls");
     }
 }

--- a/bitloops_cli/src/engine/devql/mod.rs
+++ b/bitloops_cli/src/engine/devql/mod.rs
@@ -488,10 +488,19 @@ pub async fn run_ingest(cfg: &DevqlConfig, init: bool, max_checkpoints: usize) -
                 &normalized_path,
             )
             .await?;
-            let semantic_feature_inputs = semantic::build_semantic_feature_inputs_from_artefacts(
-                &pre_stage_artefacts,
-                &content,
-            );
+            let pre_stage_dependencies = load_pre_stage_dependencies_for_blob(
+                &relational,
+                &cfg.repo.repo_id,
+                &blob_sha,
+                &normalized_path,
+            )
+            .await?;
+            let semantic_feature_inputs =
+                semantic::build_semantic_feature_inputs_from_artefacts_with_dependencies(
+                    &pre_stage_artefacts,
+                    &pre_stage_dependencies,
+                    &content,
+                );
             let semantic_feature_stats = upsert_semantic_feature_rows(
                 &relational,
                 &semantic_feature_inputs,

--- a/bitloops_cli/src/engine/devql/vocab.rs
+++ b/bitloops_cli/src/engine/devql/vocab.rs
@@ -1,3 +1,10 @@
+pub(crate) const EDGE_KIND_IMPORTS: &str = "imports";
+pub(crate) const EDGE_KIND_CALLS: &str = "calls";
+pub(crate) const EDGE_KIND_REFERENCES: &str = "references";
+pub(crate) const EDGE_KIND_EXTENDS: &str = "extends";
+pub(crate) const EDGE_KIND_IMPLEMENTS: &str = "implements";
+pub(crate) const EDGE_KIND_EXPORTS: &str = "exports";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum EdgeKind {
     Imports,
@@ -13,23 +20,23 @@ impl EdgeKind {
 
     fn as_str(self) -> &'static str {
         match self {
-            Self::Imports => "imports",
-            Self::Calls => "calls",
-            Self::References => "references",
-            Self::Extends => "extends",
-            Self::Implements => "implements",
-            Self::Exports => "exports",
+            Self::Imports => EDGE_KIND_IMPORTS,
+            Self::Calls => EDGE_KIND_CALLS,
+            Self::References => EDGE_KIND_REFERENCES,
+            Self::Extends => EDGE_KIND_EXTENDS,
+            Self::Implements => EDGE_KIND_IMPLEMENTS,
+            Self::Exports => EDGE_KIND_EXPORTS,
         }
     }
 
     fn from_str(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "imports" => Some(Self::Imports),
-            "calls" => Some(Self::Calls),
-            "references" => Some(Self::References),
-            "extends" | Self::LEGACY_INHERITS => Some(Self::Extends),
-            "implements" => Some(Self::Implements),
-            "exports" => Some(Self::Exports),
+            EDGE_KIND_IMPORTS => Some(Self::Imports),
+            EDGE_KIND_CALLS => Some(Self::Calls),
+            EDGE_KIND_REFERENCES => Some(Self::References),
+            EDGE_KIND_EXTENDS | Self::LEGACY_INHERITS => Some(Self::Extends),
+            EDGE_KIND_IMPLEMENTS => Some(Self::Implements),
+            EDGE_KIND_EXPORTS => Some(Self::Exports),
             _ => None,
         }
     }

--- a/bitloops_cli/src/engine/devql/watch/capture.rs
+++ b/bitloops_cli/src/engine/devql/watch/capture.rs
@@ -265,7 +265,10 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )
             .expect("fetch current revision row");
-        assert!(!revision_row.0.is_empty(), "watch capture should retain base commit sha");
+        assert!(
+            !revision_row.0.is_empty(),
+            "watch capture should retain base commit sha"
+        );
         assert_eq!(revision_row.1, "temporary");
         assert!(revision_row.2.starts_with("temp:"));
         assert!(revision_row.3.is_some());
@@ -321,7 +324,10 @@ mod tests {
                 row.get(0)
             })
             .expect("count temporary checkpoints");
-        assert_eq!(temp_rows, 0, "no-content-change capture should not persist temp rows");
+        assert_eq!(
+            temp_rows, 0,
+            "no-content-change capture should not persist temp rows"
+        );
     }
 
     #[test]

--- a/bitloops_cli/src/engine/semantic_clones/mod.rs
+++ b/bitloops_cli/src/engine/semantic_clones/mod.rs
@@ -3,13 +3,16 @@ use std::collections::{BTreeSet, HashSet};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-const SYMBOL_CLONE_FINGERPRINT_VERSION: &str = "symbol-clone-fingerprint-v1";
+const SYMBOL_CLONE_FINGERPRINT_VERSION: &str = "symbol-clone-fingerprint-v2";
 const MAX_CLONE_EDGES_PER_SOURCE: usize = 20;
 const MIN_SIMILAR_IMPLEMENTATION_SCORE: f32 = 0.55;
 const MIN_SEMANTIC_SCORE: f32 = 0.40;
 const EXACT_DUPLICATE_SCORE_FLOOR: f32 = 0.99;
+const CONTEXTUAL_NEIGHBOR_MIN_SCORE: f32 = 0.55;
+const CONTEXTUAL_NEIGHBOR_MIN_SEMANTIC_SCORE: f32 = 0.55;
 const PREFERRED_LOCAL_PATTERN_SCORE_THRESHOLD: f32 = 0.72;
 const PREFERRED_LOCAL_PATTERN_MAX_CHURN_COUNT: usize = 2;
+const PREFERRED_LOCAL_PATTERN_MIN_CLONE_CONFIDENCE: f32 = 0.45;
 const PREFERRED_LOCAL_PATTERN_SCORE_BOOST: f32 = 0.05;
 const PREFERRED_LOCAL_PATTERN_SCORE_CAP: f32 = 0.98;
 
@@ -23,17 +26,19 @@ const LEXICAL_WEIGHT_CONTEXT_OVERLAP: f32 = 0.20;
 const LEXICAL_WEIGHT_SIGNATURE_SIMILARITY: f32 = 0.15;
 const LEXICAL_WEIGHT_NAME_MATCH: f32 = 0.10;
 
-const STRUCTURAL_WEIGHT_SAME_KIND: f32 = 0.35;
-const STRUCTURAL_WEIGHT_SAME_PARENT_KIND: f32 = 0.20;
-const STRUCTURAL_WEIGHT_PATH: f32 = 0.25;
+const STRUCTURAL_WEIGHT_SAME_KIND: f32 = 0.30;
+const STRUCTURAL_WEIGHT_SAME_PARENT_KIND: f32 = 0.15;
+const STRUCTURAL_WEIGHT_PATH: f32 = 0.20;
 const STRUCTURAL_WEIGHT_CALL: f32 = 0.20;
+const STRUCTURAL_WEIGHT_DEPENDENCY: f32 = 0.15;
 const STRUCTURAL_SCORE_FLOOR_SAME_KIND_WEIGHT: f32 = 0.25;
 const STRUCTURAL_SCORE_FLOOR_NAME_MATCH_WEIGHT: f32 = 0.10;
 
 const DIVERGED_NAME_MATCH_THRESHOLD: f32 = 0.75;
-const DIVERGED_PATH_SCORE_THRESHOLD: f32 = 0.60;
+const DIVERGED_SUMMARY_SIMILARITY_THRESHOLD: f32 = 0.25;
 const DIVERGED_IDENTIFIER_OVERLAP_THRESHOLD: f32 = 0.30;
-const DIVERGED_MIN_SEMANTIC_SCORE: f32 = 0.35;
+const DIVERGED_MIN_SEMANTIC_SCORE: f32 = 0.55;
+const DIVERGED_MIN_BODY_OVERLAP: f32 = 0.08;
 const DIVERGED_MAX_CALL_OVERLAP: f32 = 0.25;
 const DIVERGED_MAX_BODY_OVERLAP: f32 = 0.45;
 
@@ -41,17 +46,47 @@ const SHARED_LOGIC_MIN_LEXICAL_SCORE: f32 = 0.68;
 const SHARED_LOGIC_MIN_BODY_OVERLAP: f32 = 0.50;
 const SHARED_LOGIC_MIN_STRUCTURAL_SCORE: f32 = 0.58;
 const SHARED_LOGIC_MIN_SEMANTIC_SCORE: f32 = 0.42;
+const SHARED_LOGIC_MIN_CLONE_CONFIDENCE: f32 = 0.55;
+
+const IMPLEMENTATION_WEIGHT_BODY_OVERLAP: f32 = 0.35;
+const IMPLEMENTATION_WEIGHT_CALL_OVERLAP: f32 = 0.20;
+const IMPLEMENTATION_WEIGHT_DEPENDENCY_OVERLAP: f32 = 0.10;
+const IMPLEMENTATION_WEIGHT_IDENTIFIER_OVERLAP: f32 = 0.15;
+const IMPLEMENTATION_WEIGHT_SIGNATURE_SIMILARITY: f32 = 0.10;
+const IMPLEMENTATION_WEIGHT_SEMANTIC: f32 = 0.10;
+
+const LOCALITY_WEIGHT_SAME_FILE: f32 = 0.30;
+const LOCALITY_WEIGHT_SAME_CONTAINER: f32 = 0.25;
+const LOCALITY_WEIGHT_PATH: f32 = 0.20;
+const LOCALITY_WEIGHT_CONTEXT: f32 = 0.15;
+const LOCALITY_WEIGHT_PARENT_KIND: f32 = 0.10;
+
+const LOCALITY_DOMINANCE_MIN_SCORE: f32 = 0.75;
+const LOCALITY_DOMINANCE_MAX_IMPLEMENTATION_SCORE: f32 = 0.40;
+const LOCALITY_DOMINANCE_MIN_GAP: f32 = 0.25;
+const LOCALITY_DOMINANCE_CLONE_CONFIDENCE_CAP: f32 = 0.34;
+const CLONE_CONFIDENCE_MEDIUM_THRESHOLD: f32 = 0.45;
+const CLONE_CONFIDENCE_STRONG_THRESHOLD: f32 = 0.70;
+const PENALIZED_CANDIDATE_SCORE_BASE_WEIGHT: f32 = 0.60;
+const PENALIZED_CANDIDATE_SCORE_CLONE_CONFIDENCE_WEIGHT: f32 = 0.40;
+const PENALIZED_CANDIDATE_SCORE_CAP: f32 = 0.74;
+
+const LIMITING_SIGNAL_LOW_BODY_OVERLAP_THRESHOLD: f32 = 0.25;
+const LIMITING_SIGNAL_LOW_CALL_OVERLAP_THRESHOLD: f32 = 0.15;
+const LIMITING_SIGNAL_LOW_NAME_MATCH_THRESHOLD: f32 = 0.50;
+const LIMITING_SIGNAL_SUMMARY_GAP_THRESHOLD: f32 = 0.20;
 
 const MISSING_PARENT_KIND_SCORE: f32 = 0.40;
 const MISSING_SIGNATURE_SCORE: f32 = 0.25;
 const PARTIAL_NAME_MATCH_SCORE: f32 = 0.75;
 const SINGLE_SHARED_NAME_PREFIX_SCORE: f32 = 0.50;
-const SHARED_SIGNAL_EXPLANATION_LIMIT: usize = 8;
+const SHARED_SIGNAL_EXPLANATION_LIMIT: usize = 6;
 
 pub const RELATION_KIND_EXACT_DUPLICATE: &str = "exact_duplicate";
 pub const RELATION_KIND_SIMILAR_IMPLEMENTATION: &str = "similar_implementation";
 pub const RELATION_KIND_SHARED_LOGIC_CANDIDATE: &str = "shared_logic_candidate";
 pub const RELATION_KIND_DIVERGED_IMPLEMENTATION: &str = "diverged_implementation";
+pub const RELATION_KIND_WEAK_CLONE_CANDIDATE: &str = "weak_clone_candidate";
 pub const LABEL_PREFERRED_LOCAL_PATTERN: &str = "preferred_local_pattern";
 
 #[derive(Debug, Clone, PartialEq)]
@@ -71,6 +106,7 @@ pub struct SymbolCloneCandidateInput {
     pub context_tokens: Vec<String>,
     pub embedding: Vec<f32>,
     pub call_targets: Vec<String>,
+    pub dependency_targets: Vec<String>,
     pub churn_count: usize,
 }
 
@@ -140,9 +176,11 @@ fn build_symbol_clone_edge(
     let semantic_score = semantic_similarity(source, target);
     let lexical = lexical_signals(source, target);
     let structural = structural_signals(source, target, lexical.name_match);
-    let mut score = (CLONE_SCORE_WEIGHT_SEMANTIC * semantic_score)
+    let base_score = (CLONE_SCORE_WEIGHT_SEMANTIC * semantic_score)
         + (CLONE_SCORE_WEIGHT_LEXICAL * lexical.score)
         + (CLONE_SCORE_WEIGHT_STRUCTURAL * structural.score);
+    let derived = derived_clone_signals(source, target, semantic_score, &lexical, &structural);
+    let mut score = penalized_candidate_score(base_score, &derived);
 
     let duplicate_body_hash_match = normalized_body_hash(source) == normalized_body_hash(target)
         && !source.normalized_body_tokens.is_empty();
@@ -155,11 +193,16 @@ fn build_symbol_clone_edge(
     {
         score = score.max(EXACT_DUPLICATE_SCORE_FLOOR);
         RELATION_KIND_EXACT_DUPLICATE.to_string()
-    } else if likely_diverged_implementation(semantic_score, &lexical, &structural) {
-        RELATION_KIND_DIVERGED_IMPLEMENTATION.to_string()
-    } else if likely_shared_logic_candidate(semantic_score, &lexical, &structural) {
+    } else if likely_shared_logic_candidate(semantic_score, &lexical, &structural, &derived) {
         RELATION_KIND_SHARED_LOGIC_CANDIDATE.to_string()
-    } else if score >= MIN_SIMILAR_IMPLEMENTATION_SCORE && semantic_score >= MIN_SEMANTIC_SCORE {
+    } else if likely_diverged_implementation(semantic_score, &lexical, &structural, &derived) {
+        RELATION_KIND_DIVERGED_IMPLEMENTATION.to_string()
+    } else if likely_contextual_neighbor(score, semantic_score, &derived) {
+        RELATION_KIND_WEAK_CLONE_CANDIDATE.to_string()
+    } else if score >= MIN_SIMILAR_IMPLEMENTATION_SCORE
+        && semantic_score >= MIN_SEMANTIC_SCORE
+        && derived.clone_confidence >= CLONE_CONFIDENCE_MEDIUM_THRESHOLD
+    {
         RELATION_KIND_SIMILAR_IMPLEMENTATION.to_string()
     } else {
         return None;
@@ -168,6 +211,8 @@ fn build_symbol_clone_edge(
     let mut labels = Vec::new();
     if relation_kind != RELATION_KIND_EXACT_DUPLICATE
         && score >= PREFERRED_LOCAL_PATTERN_SCORE_THRESHOLD
+        && derived.clone_confidence >= PREFERRED_LOCAL_PATTERN_MIN_CLONE_CONFIDENCE
+        && !derived.locality_dominates
         && target.churn_count <= PREFERRED_LOCAL_PATTERN_MAX_CHURN_COUNT
         && !is_experimental_path(&target.path)
     {
@@ -179,10 +224,11 @@ fn build_symbol_clone_edge(
     let explanation = build_explanation(&ExplanationContext {
         source,
         target,
-        relation_kind: &relation_kind,
+        candidate_score: score,
         semantic_score,
         lexical: &lexical,
         structural: &structural,
+        derived: &derived,
         duplicate_body_hash_match,
         signature_shape_hash_match,
         labels: &labels,
@@ -240,6 +286,7 @@ struct LexicalSignals {
     identifier_overlap: f32,
     body_overlap: f32,
     context_overlap: f32,
+    shared_body_tokens: Vec<String>,
     shared_identifier_tokens: Vec<String>,
     shared_context_tokens: Vec<String>,
 }
@@ -250,7 +297,7 @@ fn lexical_signals(
 ) -> LexicalSignals {
     let (identifier_overlap, shared_identifier_tokens) =
         jaccard_with_shared(&source.identifier_tokens, &target.identifier_tokens);
-    let (body_overlap, _) = jaccard_with_shared(
+    let (body_overlap, shared_body_tokens) = jaccard_with_shared(
         &source.normalized_body_tokens,
         &target.normalized_body_tokens,
     );
@@ -272,8 +319,9 @@ fn lexical_signals(
         identifier_overlap,
         body_overlap,
         context_overlap,
-        shared_identifier_tokens,
-        shared_context_tokens,
+        shared_body_tokens: filter_signal_tokens(shared_body_tokens),
+        shared_identifier_tokens: filter_signal_tokens(shared_identifier_tokens),
+        shared_context_tokens: filter_signal_tokens(shared_context_tokens),
     }
 }
 
@@ -284,16 +332,53 @@ struct StructuralSignals {
     same_parent_kind: f32,
     path_score: f32,
     call_score: f32,
+    dependency_score: f32,
     shared_call_targets: Vec<String>,
+    shared_dependency_targets: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct DerivedCloneSignals {
+    implementation_score: f32,
+    locality_score: f32,
+    clone_confidence: f32,
+    summary_similarity: f32,
+    same_file: bool,
+    same_container: bool,
+    shared_summary_tokens: Vec<String>,
+    locality_dominates: bool,
+    bias_warning: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LimitingSignal {
+    LowBodyOverlap,
+    NoSharedCalls,
+    LowCallOverlap,
+    DifferentName,
+    SummaryGap,
+}
+
+impl LimitingSignal {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::LowBodyOverlap => "low_body_overlap",
+            Self::NoSharedCalls => "no_shared_calls",
+            Self::LowCallOverlap => "low_call_overlap",
+            Self::DifferentName => "different_name",
+            Self::SummaryGap => "summary_gap",
+        }
+    }
 }
 
 struct ExplanationContext<'a> {
     source: &'a SymbolCloneCandidateInput,
     target: &'a SymbolCloneCandidateInput,
-    relation_kind: &'a str,
+    candidate_score: f32,
     semantic_score: f32,
     lexical: &'a LexicalSignals,
     structural: &'a StructuralSignals,
+    derived: &'a DerivedCloneSignals,
     duplicate_body_hash_match: bool,
     signature_shape_hash_match: bool,
     labels: &'a [String],
@@ -313,10 +398,13 @@ fn structural_signals(
     let path_score = path_similarity(&source.path, &target.path);
     let (call_score, shared_call_targets) =
         jaccard_with_shared(&source.call_targets, &target.call_targets);
+    let (dependency_score, shared_dependency_targets) =
+        jaccard_with_shared(&source.dependency_targets, &target.dependency_targets);
     let score = ((STRUCTURAL_WEIGHT_SAME_KIND * same_kind)
         + (STRUCTURAL_WEIGHT_SAME_PARENT_KIND * same_parent_kind)
         + (STRUCTURAL_WEIGHT_PATH * path_score)
-        + (STRUCTURAL_WEIGHT_CALL * call_score))
+        + (STRUCTURAL_WEIGHT_CALL * call_score)
+        + (STRUCTURAL_WEIGHT_DEPENDENCY * dependency_score))
         .clamp(0.0, 1.0)
         .max(
             (same_kind * STRUCTURAL_SCORE_FLOOR_SAME_KIND_WEIGHT)
@@ -329,7 +417,9 @@ fn structural_signals(
         same_parent_kind,
         path_score,
         call_score,
+        dependency_score,
         shared_call_targets,
+        shared_dependency_targets,
     }
 }
 
@@ -337,59 +427,82 @@ fn likely_diverged_implementation(
     semantic_score: f32,
     lexical: &LexicalSignals,
     structural: &StructuralSignals,
+    derived: &DerivedCloneSignals,
 ) -> bool {
     (lexical.name_match >= DIVERGED_NAME_MATCH_THRESHOLD
-        || structural.path_score >= DIVERGED_PATH_SCORE_THRESHOLD)
+        || derived.summary_similarity >= DIVERGED_SUMMARY_SIMILARITY_THRESHOLD
+        || !structural.shared_call_targets.is_empty()
+        || !structural.shared_dependency_targets.is_empty())
         && lexical.identifier_overlap >= DIVERGED_IDENTIFIER_OVERLAP_THRESHOLD
         && semantic_score >= DIVERGED_MIN_SEMANTIC_SCORE
+        && lexical.body_overlap >= DIVERGED_MIN_BODY_OVERLAP
         && structural.call_score <= DIVERGED_MAX_CALL_OVERLAP
         && lexical.body_overlap <= DIVERGED_MAX_BODY_OVERLAP
+        && derived.clone_confidence >= CLONE_CONFIDENCE_MEDIUM_THRESHOLD
 }
 
 fn likely_shared_logic_candidate(
     semantic_score: f32,
     lexical: &LexicalSignals,
     structural: &StructuralSignals,
+    derived: &DerivedCloneSignals,
 ) -> bool {
     lexical.score >= SHARED_LOGIC_MIN_LEXICAL_SCORE
         && lexical.body_overlap >= SHARED_LOGIC_MIN_BODY_OVERLAP
         && structural.score >= SHARED_LOGIC_MIN_STRUCTURAL_SCORE
         && semantic_score >= SHARED_LOGIC_MIN_SEMANTIC_SCORE
+        && derived.clone_confidence >= SHARED_LOGIC_MIN_CLONE_CONFIDENCE
 }
 
 fn build_explanation(ctx: &ExplanationContext<'_>) -> Value {
-    let explanation = match ctx.relation_kind {
-        RELATION_KIND_EXACT_DUPLICATE => {
-            "Same normalized body tokens and normalized signature; treat as an exact duplicate."
-                .to_string()
-        }
-        RELATION_KIND_DIVERGED_IMPLEMENTATION => {
-            "Name or path ancestry stays close, but the implementation has diverged in body tokens and call targets."
-                .to_string()
-        }
-        RELATION_KIND_SHARED_LOGIC_CANDIDATE => {
-            "High lexical and structural overlap suggests repeated local logic that could be extracted."
-                .to_string()
-        }
-        _ => "Strong semantic match with overlapping identifiers, context, and compatible structure."
-            .to_string(),
-    };
+    let limiting_signals = build_limiting_signals(ctx)
+        .into_iter()
+        .map(LimitingSignal::as_str)
+        .collect::<Vec<_>>();
 
     json!({
-        "explanation": explanation,
+        "limiting_signals": limiting_signals,
         "source_summary": ctx.source.summary,
         "target_summary": ctx.target.summary,
-        "shared_identifier_tokens": ctx.lexical.shared_identifier_tokens,
-        "shared_context_tokens": ctx.lexical.shared_context_tokens,
-        "shared_call_targets": ctx.structural.shared_call_targets,
+        "confidence": {
+            "candidate_score": ctx.candidate_score,
+            "clone_confidence": ctx.derived.clone_confidence,
+            "confidence_band": confidence_band(ctx.derived.clone_confidence),
+        },
+        "evidence": {
+            "implementation_score": ctx.derived.implementation_score,
+            "locality_score": ctx.derived.locality_score,
+            "summary_similarity": ctx.derived.summary_similarity,
+            "facts": {
+                "same_file": ctx.derived.same_file,
+                "same_container": ctx.derived.same_container,
+                "same_kind": ctx.structural.same_kind >= 1.0,
+                "same_parent_kind": ctx.structural.same_parent_kind >= 1.0,
+                "locality_dominates": ctx.derived.locality_dominates,
+            },
+            "bias_warning": ctx.derived.bias_warning,
+            "shared_signals": {
+                "body_tokens": ctx.lexical.shared_body_tokens,
+                "identifier_tokens": ctx.lexical.shared_identifier_tokens,
+                "context_tokens": ctx.lexical.shared_context_tokens,
+                "summary_tokens": ctx.derived.shared_summary_tokens,
+                "call_targets": ctx.structural.shared_call_targets,
+                "dependency_targets": ctx.structural.shared_dependency_targets,
+            },
+        },
         "duplicate_signals": {
             "body_hash_match": ctx.duplicate_body_hash_match,
             "signature_shape_match": ctx.signature_shape_hash_match,
         },
         "scores": {
+            "candidate": ctx.candidate_score,
+            "clone_confidence": ctx.derived.clone_confidence,
             "semantic": ctx.semantic_score,
             "lexical": ctx.lexical.score,
             "structural": ctx.structural.score,
+            "implementation": ctx.derived.implementation_score,
+            "locality": ctx.derived.locality_score,
+            "summary_similarity": ctx.derived.summary_similarity,
             "identifier_overlap": ctx.lexical.identifier_overlap,
             "body_overlap": ctx.lexical.body_overlap,
             "context_overlap": ctx.lexical.context_overlap,
@@ -398,9 +511,165 @@ fn build_explanation(ctx: &ExplanationContext<'_>) -> Value {
             "same_parent_kind": ctx.structural.same_parent_kind,
             "path_ancestry": ctx.structural.path_score,
             "call_overlap": ctx.structural.call_score,
+            "dependency_overlap": ctx.structural.dependency_score,
         },
         "labels": ctx.labels,
     })
+}
+
+fn likely_contextual_neighbor(
+    candidate_score: f32,
+    semantic_score: f32,
+    derived: &DerivedCloneSignals,
+) -> bool {
+    candidate_score >= CONTEXTUAL_NEIGHBOR_MIN_SCORE
+        && semantic_score >= CONTEXTUAL_NEIGHBOR_MIN_SEMANTIC_SCORE
+        && derived.locality_dominates
+}
+
+fn derived_clone_signals(
+    source: &SymbolCloneCandidateInput,
+    target: &SymbolCloneCandidateInput,
+    semantic_score: f32,
+    lexical: &LexicalSignals,
+    structural: &StructuralSignals,
+) -> DerivedCloneSignals {
+    let same_file = source.path == target.path;
+    let same_container = container_identity(&source.symbol_fqn)
+        .zip(container_identity(&target.symbol_fqn))
+        .map(|(left, right)| left == right)
+        .unwrap_or(false);
+    let (summary_similarity, shared_summary_tokens) = summary_similarity(source, target);
+    let implementation_score = ((IMPLEMENTATION_WEIGHT_BODY_OVERLAP * lexical.body_overlap)
+        + (IMPLEMENTATION_WEIGHT_CALL_OVERLAP * structural.call_score)
+        + (IMPLEMENTATION_WEIGHT_DEPENDENCY_OVERLAP * structural.dependency_score)
+        + (IMPLEMENTATION_WEIGHT_IDENTIFIER_OVERLAP * lexical.identifier_overlap)
+        + (IMPLEMENTATION_WEIGHT_SIGNATURE_SIMILARITY * lexical.signature_similarity)
+        + (IMPLEMENTATION_WEIGHT_SEMANTIC * semantic_score))
+        .clamp(0.0, 1.0);
+    let locality_score = ((LOCALITY_WEIGHT_SAME_FILE * bool_score(same_file))
+        + (LOCALITY_WEIGHT_SAME_CONTAINER * bool_score(same_container))
+        + (LOCALITY_WEIGHT_PATH * structural.path_score)
+        + (LOCALITY_WEIGHT_CONTEXT * lexical.context_overlap)
+        + (LOCALITY_WEIGHT_PARENT_KIND * structural.same_parent_kind.clamp(0.0, 1.0)))
+    .clamp(0.0, 1.0);
+    let locality_dominates = same_file
+        && locality_score >= LOCALITY_DOMINANCE_MIN_SCORE
+        && implementation_score <= LOCALITY_DOMINANCE_MAX_IMPLEMENTATION_SCORE
+        && (locality_score - implementation_score) >= LOCALITY_DOMINANCE_MIN_GAP;
+    let mut clone_confidence = implementation_score;
+    let mut bias_warning = None;
+    if locality_dominates {
+        clone_confidence = clone_confidence.min(LOCALITY_DOMINANCE_CLONE_CONFIDENCE_CAP);
+        bias_warning = Some("same_file_bias".to_string());
+    }
+
+    DerivedCloneSignals {
+        implementation_score,
+        locality_score,
+        clone_confidence,
+        summary_similarity,
+        same_file,
+        same_container,
+        shared_summary_tokens: filter_signal_tokens(shared_summary_tokens),
+        locality_dominates,
+        bias_warning,
+    }
+}
+
+fn penalized_candidate_score(base_score: f32, derived: &DerivedCloneSignals) -> f32 {
+    if !derived.locality_dominates {
+        return base_score;
+    }
+
+    ((base_score * PENALIZED_CANDIDATE_SCORE_BASE_WEIGHT)
+        + (derived.clone_confidence * PENALIZED_CANDIDATE_SCORE_CLONE_CONFIDENCE_WEIGHT))
+        .min(PENALIZED_CANDIDATE_SCORE_CAP)
+        .clamp(0.0, 1.0)
+}
+
+fn summary_similarity(
+    source: &SymbolCloneCandidateInput,
+    target: &SymbolCloneCandidateInput,
+) -> (f32, Vec<String>) {
+    let source_tokens = summary_tokens(&source.summary);
+    let target_tokens = summary_tokens(&target.summary);
+    jaccard_with_shared(&source_tokens, &target_tokens)
+}
+
+fn summary_tokens(summary: &str) -> Vec<String> {
+    summary
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter_map(|token| {
+            let token = token.trim().to_ascii_lowercase();
+            if is_informative_signal_token(&token) {
+                Some(token)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+fn filter_signal_tokens(tokens: Vec<String>) -> Vec<String> {
+    tokens
+        .into_iter()
+        .filter(|token| is_informative_signal_token(token))
+        .take(SHARED_SIGNAL_EXPLANATION_LIMIT)
+        .collect()
+}
+
+fn is_informative_signal_token(token: &str) -> bool {
+    token.len() >= 3 && token.chars().any(|ch| ch.is_ascii_alphabetic())
+}
+
+fn container_identity(symbol_fqn: &str) -> Option<String> {
+    let segments = symbol_fqn
+        .split("::")
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    if segments.len() < 2 {
+        return None;
+    }
+
+    Some(segments[..segments.len() - 1].join("::"))
+}
+
+fn bool_score(value: bool) -> f32 {
+    if value { 1.0 } else { 0.0 }
+}
+
+fn build_limiting_signals(ctx: &ExplanationContext<'_>) -> Vec<LimitingSignal> {
+    let mut out = Vec::new();
+    if ctx.lexical.body_overlap < LIMITING_SIGNAL_LOW_BODY_OVERLAP_THRESHOLD {
+        out.push(LimitingSignal::LowBodyOverlap);
+    }
+    if ctx.structural.call_score <= f32::EPSILON {
+        out.push(LimitingSignal::NoSharedCalls);
+    } else if ctx.structural.call_score < LIMITING_SIGNAL_LOW_CALL_OVERLAP_THRESHOLD {
+        out.push(LimitingSignal::LowCallOverlap);
+    }
+    if ctx.lexical.name_match < LIMITING_SIGNAL_LOW_NAME_MATCH_THRESHOLD {
+        out.push(LimitingSignal::DifferentName);
+    }
+    if ctx.derived.summary_similarity > f32::EPSILON
+        && ctx.derived.summary_similarity < LIMITING_SIGNAL_SUMMARY_GAP_THRESHOLD
+    {
+        out.push(LimitingSignal::SummaryGap);
+    }
+    out.truncate(4);
+    out
+}
+
+fn confidence_band(clone_confidence: f32) -> &'static str {
+    if clone_confidence >= CLONE_CONFIDENCE_STRONG_THRESHOLD {
+        "strong"
+    } else if clone_confidence >= CLONE_CONFIDENCE_MEDIUM_THRESHOLD {
+        "medium"
+    } else {
+        "weak"
+    }
 }
 
 fn build_clone_input_hash(
@@ -424,6 +693,8 @@ fn build_clone_input_hash(
             "target_body_tokens": &target.normalized_body_tokens,
             "source_calls": &source.call_targets,
             "target_calls": &target.call_targets,
+            "source_dependencies": &source.dependency_targets,
+            "target_dependencies": &target.dependency_targets,
             "source_churn": source.churn_count,
             "target_churn": target.churn_count,
         })
@@ -604,6 +875,7 @@ mod tests {
             context_tokens: vec!["services".to_string(), "orders".to_string()],
             embedding: vec![0.9, 0.1, 0.0],
             call_targets: vec!["db.fetchOrder".to_string()],
+            dependency_targets: vec!["references:order_repository::entity".to_string()],
             churn_count: 1,
         }
     }
@@ -698,5 +970,173 @@ mod tests {
             .get("labels")
             .and_then(Value::as_array);
         assert!(labels.is_some());
+    }
+
+    #[test]
+    fn build_symbol_clone_edges_marks_contextual_neighbors_when_locality_dominates() {
+        let mut source = sample_input("source", "execute");
+        source.canonical_kind = "method".to_string();
+        source.parent_kind = Some("class_declaration".to_string());
+        source.path = "src/handlers/change-path.ts".to_string();
+        source.symbol_fqn =
+            "src/handlers/change-path.ts::ChangePathOfCodeFileCommandHandler::execute".to_string();
+        source.summary = "Method execute. Applies the path change workflow.".to_string();
+        source.identifier_tokens = vec![
+            "change".to_string(),
+            "path".to_string(),
+            "code".to_string(),
+            "file".to_string(),
+        ];
+        source.normalized_body_tokens = vec![
+            "load".to_string(),
+            "validate".to_string(),
+            "rename".to_string(),
+        ];
+        source.call_targets = vec!["repo.loadFile".to_string(), "domain.renamePath".to_string()];
+
+        let mut target = sample_input("target", "command");
+        target.canonical_kind = "method".to_string();
+        target.parent_kind = Some("class_declaration".to_string());
+        target.path = source.path.clone();
+        target.symbol_fqn =
+            "src/handlers/change-path.ts::ChangePathOfCodeFileCommandHandler::command".to_string();
+        target.summary = "Method command. Returns the command payload.".to_string();
+        target.identifier_tokens = vec![
+            "change".to_string(),
+            "path".to_string(),
+            "command".to_string(),
+            "file".to_string(),
+        ];
+        target.normalized_body_tokens = vec![
+            "return".to_string(),
+            "command".to_string(),
+            "payload".to_string(),
+        ];
+        target.call_targets = vec!["factory.buildCommand".to_string()];
+
+        let result = build_symbol_clone_edges(&[source, target]);
+        let edge = result
+            .edges
+            .iter()
+            .find(|edge| edge.target_symbol_id == "target")
+            .expect("contextual neighbor edge");
+
+        assert_eq!(edge.relation_kind, RELATION_KIND_WEAK_CLONE_CANDIDATE);
+        assert!(edge.score < 0.75);
+        assert_eq!(
+            edge.explanation_json["confidence"]["confidence_band"],
+            Value::String("weak".to_string())
+        );
+        assert!(
+            edge.explanation_json["evidence"]["bias_warning"].as_str() == Some("same_file_bias")
+        );
+    }
+
+    #[test]
+    fn build_symbol_clone_edges_keeps_same_file_clone_confidence_when_impl_is_strong() {
+        let mut source = sample_input("source", "apply_path_change");
+        source.canonical_kind = "method".to_string();
+        source.parent_kind = Some("class_declaration".to_string());
+        source.path = "src/handlers/change-path.ts".to_string();
+        source.symbol_fqn =
+            "src/handlers/change-path.ts::ChangePathOfCodeFileCommandHandler::apply_path_change"
+                .to_string();
+        source.summary =
+            "Method apply path change. Applies the path change to the file.".to_string();
+        source.identifier_tokens = vec![
+            "apply".to_string(),
+            "path".to_string(),
+            "change".to_string(),
+            "file".to_string(),
+        ];
+        source.normalized_body_tokens = vec![
+            "load".to_string(),
+            "validate".to_string(),
+            "rename".to_string(),
+            "persist".to_string(),
+        ];
+        source.call_targets = vec![
+            "repo.loadFile".to_string(),
+            "domain.renamePath".to_string(),
+            "repo.persistFile".to_string(),
+        ];
+
+        let mut target = sample_input("target", "apply_path_change_for_move");
+        target.canonical_kind = "method".to_string();
+        target.parent_kind = Some("class_declaration".to_string());
+        target.path = source.path.clone();
+        target.symbol_fqn = "src/handlers/change-path.ts::ChangePathOfCodeFileCommandHandler::apply_path_change_for_move".to_string();
+        target.summary =
+            "Method apply path change for move. Applies the path change and persists it."
+                .to_string();
+        target.identifier_tokens = vec![
+            "apply".to_string(),
+            "path".to_string(),
+            "change".to_string(),
+            "move".to_string(),
+        ];
+        target.normalized_body_tokens = vec![
+            "load".to_string(),
+            "validate".to_string(),
+            "rename".to_string(),
+            "persist".to_string(),
+            "emit".to_string(),
+        ];
+        target.call_targets = vec![
+            "repo.loadFile".to_string(),
+            "domain.renamePath".to_string(),
+            "repo.persistFile".to_string(),
+        ];
+
+        let result = build_symbol_clone_edges(&[source, target]);
+        let edge = result
+            .edges
+            .iter()
+            .find(|edge| edge.target_symbol_id == "target")
+            .expect("same-file strong clone edge");
+
+        assert_ne!(edge.relation_kind, RELATION_KIND_WEAK_CLONE_CANDIDATE);
+        assert!(
+            edge.explanation_json["confidence"]["clone_confidence"]
+                .as_f64()
+                .expect("clone confidence")
+                >= CLONE_CONFIDENCE_MEDIUM_THRESHOLD as f64
+        );
+        assert!(edge.explanation_json["evidence"]["bias_warning"].is_null());
+    }
+
+    #[test]
+    fn build_symbol_clone_edges_exposes_dependency_overlap() {
+        let mut source = sample_input("source", "validate_path");
+        source.call_targets = vec!["repo.loadFile".to_string()];
+        source.dependency_targets = vec![
+            "references:path_service::path".to_string(),
+            "implements:path_validator".to_string(),
+        ];
+
+        let mut target = sample_input("target", "validate_moved_path");
+        target.call_targets = vec!["repo.loadMovedFile".to_string()];
+        target.dependency_targets = vec![
+            "references:path_service::path".to_string(),
+            "implements:path_validator".to_string(),
+        ];
+
+        let result = build_symbol_clone_edges(&[source, target]);
+        let edge = result
+            .edges
+            .iter()
+            .find(|edge| edge.target_symbol_id == "target")
+            .expect("dependency-aware clone edge");
+
+        assert!(
+            edge.explanation_json["scores"]["dependency_overlap"]
+                .as_f64()
+                .expect("dependency overlap")
+                > 0.0
+        );
+        assert_eq!(
+            edge.explanation_json["evidence"]["shared_signals"]["dependency_targets"][0],
+            Value::String("implements:path_validator".to_string())
+        );
     }
 }

--- a/bitloops_cli/src/engine/semantic_embeddings/mod.rs
+++ b/bitloops_cli/src/engine/semantic_embeddings/mod.rs
@@ -7,9 +7,9 @@ use crate::engine::providers::embeddings::{
     EmbeddingProvider, build_embedding_provider, default_embedding_model,
     default_embedding_provider, embedding_provider_requires_api_key,
 };
-use crate::engine::semantic_features::SemanticFeatureInput;
+use crate::engine::semantic_features::{SemanticFeatureInput, render_dependency_context};
 
-const EMBEDDING_FINGERPRINT_VERSION: &str = "symbol-embedding-fingerprint-v1";
+const EMBEDDING_FINGERPRINT_VERSION: &str = "symbol-embedding-fingerprint-v3";
 const MAX_EMBEDDING_BODY_CHARS: usize = 8_000;
 
 #[derive(Debug, Clone, Default)]
@@ -92,6 +92,7 @@ pub struct SymbolEmbeddingInput {
     pub signature: Option<String>,
     pub body: String,
     pub summary: String,
+    pub dependency_signals: Vec<String>,
     pub parent_kind: Option<String>,
     pub content_hash: Option<String>,
 }
@@ -148,6 +149,7 @@ pub fn build_symbol_embedding_inputs(
                 signature: input.signature.clone(),
                 body: input.body.clone(),
                 summary,
+                dependency_signals: input.dependency_signals.clone(),
                 parent_kind: input.parent_kind.clone(),
                 content_hash: input.content_hash.clone(),
             })
@@ -162,28 +164,25 @@ pub fn build_symbol_embedding_text(input: &SymbolEmbeddingInput) -> String {
         .as_deref()
         .map(normalize_whitespace)
         .unwrap_or_default();
-    let parent_kind = input.parent_kind.as_deref().unwrap_or_default();
+    let dependencies = render_dependency_context(&input.dependency_signals);
 
+    // Keep the clone semantic basis focused on symbol behavior rather than location.
     format!(
         "kind: {kind}\n\
 language: {language}\n\
 language_kind: {language_kind}\n\
-path: {path}\n\
-symbol_fqn: {symbol_fqn}\n\
 name: {name}\n\
 signature: {signature}\n\
-parent_kind: {parent_kind}\n\
 summary: {summary}\n\
+dependencies: {dependencies}\n\
 body:\n{body}",
         kind = input.canonical_kind,
         language = input.language,
         language_kind = input.language_kind,
-        path = input.path,
-        symbol_fqn = input.symbol_fqn,
         name = input.name,
         signature = signature,
-        parent_kind = parent_kind,
         summary = normalize_whitespace(&input.summary),
+        dependencies = dependencies,
         body = body,
     )
 }
@@ -199,16 +198,14 @@ pub fn build_symbol_embedding_input_hash(
             "artefact_id": &input.artefact_id,
             "repo_id": &input.repo_id,
             "blob_sha": &input.blob_sha,
-            "path": &input.path,
             "language": input.language.to_ascii_lowercase(),
             "canonical_kind": input.canonical_kind.to_ascii_lowercase(),
             "language_kind": input.language_kind.to_ascii_lowercase(),
-            "symbol_fqn": &input.symbol_fqn,
             "name": &input.name,
             "signature": input.signature.as_deref().map(normalize_whitespace),
             "summary": normalize_whitespace(&input.summary),
+            "dependency_signals": &input.dependency_signals,
             "body": truncate_chars(normalize_whitespace(&input.body), MAX_EMBEDDING_BODY_CHARS),
-            "parent_kind": input.parent_kind.as_deref().map(|value| value.to_ascii_lowercase()),
             "content_hash": &input.content_hash,
         })
         .to_string(),
@@ -312,6 +309,10 @@ mod tests {
             body: "return email.trim().toLowerCase();".to_string(),
             summary: "Function normalize email. Normalizes email addresses before storage."
                 .to_string(),
+            dependency_signals: vec![
+                "calls:user_repo::find_by_id".to_string(),
+                "references:user::email".to_string(),
+            ],
             parent_kind: Some("file".to_string()),
             content_hash: Some("hash-1".to_string()),
         }
@@ -336,6 +337,7 @@ mod tests {
                 body: "return email.trim().toLowerCase();".to_string(),
                 docstring: None,
                 parent_kind: Some("file".to_string()),
+                dependency_signals: vec!["calls:user_repo::find_by_id".to_string()],
                 content_hash: None,
             },
             SemanticFeatureInput {
@@ -354,6 +356,7 @@ mod tests {
                 body: "import x from 'y';".to_string(),
                 docstring: None,
                 parent_kind: Some("file".to_string()),
+                dependency_signals: vec!["imports:y".to_string()],
                 content_hash: None,
             },
         ];
@@ -389,6 +392,7 @@ mod tests {
                 body: "return email.trim().toLowerCase();".to_string(),
                 docstring: None,
                 parent_kind: Some("file".to_string()),
+                dependency_signals: vec!["calls:user_repo::find_by_id".to_string()],
                 content_hash: None,
             },
             SemanticFeatureInput {
@@ -407,6 +411,7 @@ mod tests {
                 body: "return name.trim().replace(/\\s+/g, ' ');".to_string(),
                 docstring: None,
                 parent_kind: Some("file".to_string()),
+                dependency_signals: vec!["references:user_profile::name".to_string()],
                 content_hash: None,
             },
         ];
@@ -451,8 +456,40 @@ mod tests {
     fn symbol_embedding_text_includes_summary_and_body() {
         let text = build_symbol_embedding_text(&sample_input());
         assert!(text.contains("summary: Function normalize email."));
+        assert!(text.contains("dependencies: calls:user repo::find by id"));
         assert!(text.contains("body:"));
         assert!(text.contains("return email.trim().toLowerCase();"));
+        assert!(!text.contains("path:"));
+        assert!(!text.contains("symbol_fqn:"));
+        assert!(!text.contains("parent_kind:"));
+    }
+
+    #[test]
+    fn symbol_embedding_hash_changes_when_dependencies_change() {
+        let provider = MockEmbeddingProvider;
+        let base = sample_input();
+        let mut changed = base.clone();
+        changed.dependency_signals = vec!["calls:user_repo::save".to_string()];
+
+        assert_ne!(
+            build_symbol_embedding_input_hash(&base, &provider),
+            build_symbol_embedding_input_hash(&changed, &provider)
+        );
+    }
+
+    #[test]
+    fn symbol_embedding_hash_ignores_path_and_symbol_location() {
+        let provider = MockEmbeddingProvider;
+        let base = sample_input();
+        let mut changed = base.clone();
+        changed.path = "src/renamed/user.ts".to_string();
+        changed.symbol_fqn = "src/renamed/user.ts::normalizeEmail".to_string();
+        changed.parent_kind = Some("module".to_string());
+
+        assert_eq!(
+            build_symbol_embedding_input_hash(&base, &provider),
+            build_symbol_embedding_input_hash(&changed, &provider)
+        );
     }
 
     #[test]

--- a/bitloops_cli/src/engine/semantic_features/common.rs
+++ b/bitloops_cli/src/engine/semantic_features/common.rs
@@ -3,7 +3,11 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
+use crate::engine::devql::EDGE_KIND_EXPORTS;
+
 use super::MAX_BODY_TOKENS;
+
+const MAX_COMPACT_DEPENDENCY_SEGMENT_TOKENS: usize = 4;
 
 pub(super) fn normalize_name(name: &str) -> String {
     let tokens = split_identifier_tokens(name);
@@ -58,6 +62,86 @@ pub(super) fn normalize_repo_path(path: &str) -> String {
     normalized.trim_start_matches('/').to_string()
 }
 
+pub(crate) fn build_dependency_context_signal(edge_kind: &str, target_ref: &str) -> Option<String> {
+    let edge_kind = edge_kind.trim().to_ascii_lowercase();
+    // Export edges describe module surface, not what the symbol itself depends on.
+    if edge_kind.is_empty() || edge_kind == EDGE_KIND_EXPORTS {
+        return None;
+    }
+
+    let target = compact_dependency_target(target_ref);
+    if target.is_empty() {
+        return None;
+    }
+
+    Some(format!("{edge_kind}:{target}"))
+}
+
+pub(crate) fn render_dependency_context(signals: &[String]) -> String {
+    signals
+        .iter()
+        .map(|signal| signal.replace('_', " "))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn compact_dependency_target(target_ref: &str) -> String {
+    let trimmed = target_ref.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let namespace_segments = trimmed
+        .split("::")
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    if namespace_segments.len() >= 2 {
+        let compact = namespace_segments[namespace_segments.len() - 2..]
+            .iter()
+            .map(|segment| {
+                compact_dependency_segment(segment, segment.contains('/') || segment.contains('\\'))
+            })
+            .filter(|segment| !segment.is_empty())
+            .collect::<Vec<_>>();
+        if !compact.is_empty() {
+            return compact.join("::");
+        }
+    }
+
+    compact_dependency_segment(trimmed, trimmed.contains('/') || trimmed.contains('\\'))
+}
+
+fn compact_dependency_segment(segment: &str, path_like: bool) -> String {
+    let segment = segment.rsplit(['/', '\\']).next().unwrap_or(segment).trim();
+    if segment.is_empty() {
+        return String::new();
+    }
+
+    let mut tokens = split_identifier_tokens(segment);
+    if path_like {
+        strip_trailing_path_suffix_token(&mut tokens);
+    }
+    if tokens.is_empty() {
+        return segment.to_ascii_lowercase();
+    }
+
+    let start = tokens
+        .len()
+        .saturating_sub(MAX_COMPACT_DEPENDENCY_SEGMENT_TOKENS);
+    tokens[start..].join("_")
+}
+
+fn strip_trailing_path_suffix_token(tokens: &mut Vec<String>) {
+    let should_strip = tokens.last().is_some_and(|token| {
+        let len = token.len();
+        (1..=4).contains(&len) && token.chars().all(|ch| ch.is_ascii_lowercase())
+    });
+    if should_strip {
+        tokens.pop();
+    }
+}
+
 fn semantic_identifier_regex() -> &'static Regex {
     static IDENTIFIER_REGEX: OnceLock<Regex> = OnceLock::new();
     IDENTIFIER_REGEX.get_or_init(|| Regex::new(r"[A-Za-z_][A-Za-z0-9_]*").unwrap())
@@ -95,4 +179,36 @@ fn split_camel_case_word(input: &str) -> Vec<String> {
     }
 
     pieces
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dependency_context_signal_compacts_path_like_targets() {
+        let signal = build_dependency_context_signal(
+            "calls",
+            "src/bounded-contexts/code.ts::ChangePathOfCodeFileCommandHandler::execute",
+        )
+        .expect("dependency signal");
+
+        assert_eq!(
+            signal,
+            "calls:change_path_of_code_file_command_handler::execute"
+        );
+    }
+
+    #[test]
+    fn dependency_context_signal_ignores_exports() {
+        assert!(build_dependency_context_signal(EDGE_KIND_EXPORTS, "src/app.ts::foo").is_none());
+    }
+
+    #[test]
+    fn dependency_context_signal_keeps_non_path_dotted_segments() {
+        let signal = build_dependency_context_signal("references", "Domain.Event::payload")
+            .expect("dependency signal");
+
+        assert_eq!(signal, "references:domain_event::payload");
+    }
 }

--- a/bitloops_cli/src/engine/semantic_features/common.rs
+++ b/bitloops_cli/src/engine/semantic_features/common.rs
@@ -7,8 +7,6 @@ use crate::engine::devql::EDGE_KIND_EXPORTS;
 
 use super::MAX_BODY_TOKENS;
 
-const MAX_COMPACT_DEPENDENCY_SEGMENT_TOKENS: usize = 4;
-
 pub(super) fn normalize_name(name: &str) -> String {
     let tokens = split_identifier_tokens(name);
     if tokens.is_empty() {
@@ -125,11 +123,7 @@ fn compact_dependency_segment(segment: &str, path_like: bool) -> String {
     if tokens.is_empty() {
         return segment.to_ascii_lowercase();
     }
-
-    let start = tokens
-        .len()
-        .saturating_sub(MAX_COMPACT_DEPENDENCY_SEGMENT_TOKENS);
-    tokens[start..].join("_")
+    tokens.join("_")
 }
 
 fn strip_trailing_path_suffix_token(tokens: &mut Vec<String>) {

--- a/bitloops_cli/src/engine/semantic_features/features.rs
+++ b/bitloops_cli/src/engine/semantic_features/features.rs
@@ -78,6 +78,9 @@ fn build_context_tokens(
     for modifier in modifiers {
         tokens.extend(split_identifier_tokens(modifier));
     }
+    for dependency_signal in &input.dependency_signals {
+        tokens.extend(split_identifier_tokens(dependency_signal));
+    }
     tokens.extend(identifier_tokens.iter().cloned());
     dedupe_tokens(tokens, MAX_CONTEXT_TOKENS)
 }
@@ -109,6 +112,7 @@ mod tests {
             body: "return db.users.findById(id);".to_string(),
             docstring: None,
             parent_kind: Some("class".to_string()),
+            dependency_signals: vec!["calls:user_repo::find_by_id".to_string()],
             content_hash: Some("hash-1".to_string()),
         }
     }
@@ -132,6 +136,7 @@ mod tests {
             row.context_tokens.contains(&"services".to_string())
                 && row.context_tokens.contains(&"class".to_string())
                 && row.context_tokens.contains(&"async".to_string())
+                && row.context_tokens.contains(&"calls".to_string())
         );
         assert_eq!(
             row.modifiers,

--- a/bitloops_cli/src/engine/semantic_features/mod.rs
+++ b/bitloops_cli/src/engine/semantic_features/mod.rs
@@ -2,10 +2,13 @@
 mod core;
 
 pub use core::{
-    NoopSemanticSummaryProvider, PreStageArtefactRow, SemanticFeatureIndexState,
-    SemanticFeatureIngestionStats, SemanticFeatureInput, SemanticFeatureRows,
-    SemanticSummaryCandidate, SemanticSummaryProvider, SemanticSummaryProviderConfig,
-    build_semantic_feature_input_hash, build_semantic_feature_inputs_from_artefacts,
-    build_semantic_feature_rows, build_semantic_summary_provider, is_semantic_enrichment_candidate,
+    NoopSemanticSummaryProvider, PreStageArtefactRow, PreStageDependencyRow,
+    SemanticFeatureIndexState, SemanticFeatureIngestionStats, SemanticFeatureInput,
+    SemanticFeatureRows, SemanticSummaryCandidate, SemanticSummaryProvider,
+    SemanticSummaryProviderConfig, build_semantic_feature_input_hash,
+    build_semantic_feature_inputs_from_artefacts,
+    build_semantic_feature_inputs_from_artefacts_with_dependencies, build_semantic_feature_rows,
+    build_semantic_summary_provider, is_semantic_enrichment_candidate,
     resolve_semantic_summary_endpoint, semantic_features_require_reindex,
 };
+pub(crate) use core::{build_dependency_context_signal, render_dependency_context};

--- a/bitloops_cli/src/engine/semantic_features/semantic.rs
+++ b/bitloops_cli/src/engine/semantic_features/semantic.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow};
 
 use crate::engine::providers::llm::{LlmProvider, build_llm_provider};
 
-use super::common::{normalize_repo_path, split_identifier_tokens};
+use super::common::{normalize_repo_path, render_dependency_context, split_identifier_tokens};
 use super::{MAX_SUMMARY_BODY_CHARS, SemanticFeatureInput};
 
 pub use crate::engine::providers::llm::resolve_semantic_summary_endpoint;
@@ -106,6 +106,8 @@ fn build_semantic_summary_prompt(input: &SemanticFeatureInput) -> String {
         body.to_string()
     };
 
+    let dependency_context = render_dependency_context(&input.dependency_signals);
+
     format!(
         "Summarize this code symbol and return only JSON.\n\n\
 JSON schema:\n\
@@ -126,6 +128,7 @@ signature: {signature}\n\
 modifiers: {modifiers}\n\
 docstring: {docstring}\n\
 parent_kind: {parent_kind}\n\
+dependencies: {dependencies}\n\
 body:\n{body}",
         language = input.language,
         kind = input.canonical_kind,
@@ -137,6 +140,7 @@ body:\n{body}",
         modifiers = input.modifiers.join(", "),
         docstring = input.docstring.as_deref().unwrap_or(""),
         parent_kind = input.parent_kind.as_deref().unwrap_or(""),
+        dependencies = dependency_context,
         body = body,
     )
 }
@@ -417,6 +421,7 @@ mod tests {
             body: "return value;".to_string(),
             docstring: None,
             parent_kind: Some("module".to_string()),
+            dependency_signals: vec!["calls:user_repo::load_by_id".to_string()],
             content_hash: Some("hash-1".to_string()),
         }
     }
@@ -451,6 +456,7 @@ mod tests {
         let prompt = build_semantic_summary_prompt(&input);
         assert!(prompt.contains("docstring: // Normalizes email."));
         assert!(prompt.contains("modifiers: export"));
+        assert!(prompt.contains("dependencies: calls:user repo::load by id"));
         let body_section = prompt
             .split("body:\n")
             .nth(1)

--- a/bitloops_cli/src/engine/semantic_features/semantic_features.rs
+++ b/bitloops_cli/src/engine/semantic_features/semantic_features.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 
 use serde_json::json;
@@ -12,6 +12,7 @@ mod features;
 mod semantic;
 
 use self::common::{build_body_tokens, normalize_name, normalize_repo_path};
+pub(crate) use self::common::{build_dependency_context_signal, render_dependency_context};
 use self::features::{SymbolFeaturesRow, build_features_row, normalize_signature};
 pub use self::semantic::{
     NoopSemanticSummaryProvider, SemanticSummaryCandidate, SemanticSummaryProvider,
@@ -20,11 +21,12 @@ pub use self::semantic::{
 };
 use self::semantic::{SymbolSemanticsRow, build_semantics_row, normalize_summary_text};
 
-const SEMANTIC_FEATURES_FINGERPRINT_VERSION: &str = "semantic-features-fingerprint-v2";
+const SEMANTIC_FEATURES_FINGERPRINT_VERSION: &str = "semantic-features-fingerprint-v3";
 const MAX_IDENTIFIER_TOKENS: usize = 64;
 const MAX_BODY_TOKENS: usize = 256;
 const MAX_CONTEXT_TOKENS: usize = 64;
 const MAX_SUMMARY_BODY_CHARS: usize = 2_000;
+const MAX_DEPENDENCY_SIGNALS: usize = 16;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PreStageArtefactRow {
@@ -58,6 +60,13 @@ pub struct PreStageArtefactRow {
     pub content_hash: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PreStageDependencyRow {
+    pub from_artefact_id: String,
+    pub edge_kind: String,
+    pub target_ref: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemanticFeatureInput {
     pub artefact_id: String,
@@ -75,6 +84,7 @@ pub struct SemanticFeatureInput {
     pub body: String,
     pub docstring: Option<String>,
     pub parent_kind: Option<String>,
+    pub dependency_signals: Vec<String>,
     pub content_hash: Option<String>,
 }
 
@@ -101,15 +111,32 @@ pub fn build_semantic_feature_inputs_from_artefacts(
     artefacts: &[PreStageArtefactRow],
     blob_content: &str,
 ) -> Vec<SemanticFeatureInput> {
+    build_semantic_feature_inputs_from_artefacts_with_dependencies(artefacts, &[], blob_content)
+}
+
+pub fn build_semantic_feature_inputs_from_artefacts_with_dependencies(
+    artefacts: &[PreStageArtefactRow],
+    dependencies: &[PreStageDependencyRow],
+    blob_content: &str,
+) -> Vec<SemanticFeatureInput> {
     let by_id = artefacts
         .iter()
         .map(|row| (row.artefact_id.clone(), row))
         .collect::<HashMap<_, _>>();
+    let dependency_signals_by_artefact_id = build_dependency_signals_by_artefact_id(dependencies);
 
     artefacts
         .iter()
         .filter_map(|row| {
-            let input = build_semantic_feature_input_from_artefact(row, blob_content, &by_id);
+            let input = build_semantic_feature_input_from_artefact(
+                row,
+                blob_content,
+                &by_id,
+                dependency_signals_by_artefact_id
+                    .get(&row.artefact_id)
+                    .cloned()
+                    .unwrap_or_default(),
+            );
             is_semantic_enrichment_candidate(&input).then_some(input)
         })
         .collect()
@@ -126,6 +153,7 @@ fn build_semantic_feature_input_from_artefact(
     row: &PreStageArtefactRow,
     blob_content: &str,
     by_id: &HashMap<String, &PreStageArtefactRow>,
+    dependency_signals: Vec<String>,
 ) -> SemanticFeatureInput {
     let parent = row
         .parent_artefact_id
@@ -151,8 +179,34 @@ fn build_semantic_feature_input_from_artefact(
         body,
         docstring: row.docstring.clone(),
         parent_kind: parent.map(|parent_row| parent_row.canonical_kind.clone()),
+        dependency_signals,
         content_hash: row.content_hash.clone(),
     }
+}
+
+fn build_dependency_signals_by_artefact_id(
+    dependencies: &[PreStageDependencyRow],
+) -> HashMap<String, Vec<String>> {
+    let mut out = HashMap::<String, BTreeSet<String>>::new();
+    for dependency in dependencies {
+        let Some(signal) =
+            build_dependency_context_signal(&dependency.edge_kind, &dependency.target_ref)
+        else {
+            continue;
+        };
+        out.entry(dependency.from_artefact_id.clone())
+            .or_default()
+            .insert(signal);
+    }
+
+    out.into_iter()
+        .map(|(artefact_id, signals)| {
+            (
+                artefact_id,
+                signals.into_iter().take(MAX_DEPENDENCY_SIGNALS).collect(),
+            )
+        })
+        .collect()
 }
 
 fn derive_symbol_name(row: &PreStageArtefactRow) -> String {
@@ -249,6 +303,7 @@ pub fn build_semantic_feature_input_hash(
                 .map(normalize_summary_text)
                 .filter(|value| !value.is_empty()),
             "parent_kind": input.parent_kind.as_deref().map(|value| value.to_ascii_lowercase()),
+            "dependency_signals": &input.dependency_signals,
             "content_hash": &input.content_hash,
         })
         .to_string(),
@@ -335,6 +390,7 @@ mod tests {
             body: "return email.trim().toLowerCase();".to_string(),
             docstring: Some("Normalize email addresses.".to_string()),
             parent_kind: Some("file".to_string()),
+            dependency_signals: vec!["calls:email::trim".to_string()],
             content_hash: Some("hash-1".to_string()),
         };
         let mut changed = base.clone();
@@ -364,6 +420,7 @@ mod tests {
             body: "return email.trim().toLowerCase();".to_string(),
             docstring: Some("Normalize email addresses.".to_string()),
             parent_kind: Some("file".to_string()),
+            dependency_signals: vec!["calls:email::trim".to_string()],
             content_hash: Some("hash-1".to_string()),
         };
         let mut changed = base.clone();
@@ -407,6 +464,7 @@ mod tests {
             body: "return email.trim().toLowerCase();".to_string(),
             docstring: Some("Normalize email addresses.".to_string()),
             parent_kind: Some("file".to_string()),
+            dependency_signals: vec!["calls:email::trim".to_string()],
             content_hash: Some("hash-1".to_string()),
         };
 
@@ -447,5 +505,57 @@ mod tests {
 
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].artefact_id, "artefact-1");
+    }
+
+    #[test]
+    fn semantic_features_input_hash_changes_when_dependencies_change() {
+        let base = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "src/services/user.ts".to_string(),
+            language: "typescript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function".to_string(),
+            symbol_fqn: "src/services/user.ts::normalizeEmail".to_string(),
+            name: "normalizeEmail".to_string(),
+            signature: Some("export function normalizeEmail(email: string): string {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return email.trim().toLowerCase();".to_string(),
+            docstring: Some("Normalize email addresses.".to_string()),
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec!["calls:email::trim".to_string()],
+            content_hash: Some("hash-1".to_string()),
+        };
+        let mut changed = base.clone();
+        changed.dependency_signals = vec!["calls:email::normalize".to_string()];
+
+        assert_ne!(
+            build_semantic_feature_input_hash(&base, &semantic::NoopSemanticSummaryProvider),
+            build_semantic_feature_input_hash(&changed, &semantic::NoopSemanticSummaryProvider)
+        );
+    }
+
+    #[test]
+    fn semantic_features_build_inputs_attach_dependency_signals() {
+        let artefacts = vec![sample_row()];
+        let dependencies = vec![PreStageDependencyRow {
+            from_artefact_id: "artefact-1".to_string(),
+            edge_kind: "calls".to_string(),
+            target_ref: "src/repos/user.repo.ts::UserRepo::findById".to_string(),
+        }];
+        let content = "export class UserService {\n  async getById(id: string) {\n    return db.users.findById(id);\n  }\n}\n";
+
+        let inputs = build_semantic_feature_inputs_from_artefacts_with_dependencies(
+            &artefacts,
+            &dependencies,
+            content,
+        );
+
+        assert_eq!(
+            inputs[0].dependency_signals,
+            vec!["calls:user_repo::find_by_id".to_string()]
+        );
     }
 }

--- a/bitloops_cli/src/store_config/mod.rs
+++ b/bitloops_cli/src/store_config/mod.rs
@@ -858,6 +858,7 @@ pub(crate) fn resolve_watch_runtime_config_for_tests(
     })
 }
 
+#[cfg(test)]
 pub(crate) fn resolve_store_embedding_config_for_tests(
     file_cfg: StoreFileConfig,
     env: &[(&str, &str)],

--- a/bitloops_cli/src/store_config/tests.rs
+++ b/bitloops_cli/src/store_config/tests.rs
@@ -459,201 +459,201 @@ fn watch_runtime_config_prefers_env_over_file() {
 
 #[test]
 fn dashboard_file_config_load_reads_repo_config_file() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        write_repo_config(
-            temp.path(),
-            serde_json::json!({
-                "dashboard": {
-                    "use_bitloops_local": true
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_repo_config(
+        temp.path(),
+        serde_json::json!({
+            "dashboard": {
+                "use_bitloops_local": true
+            }
+        }),
+    );
+
+    with_cwd(temp.path(), || {
+        let cfg = DashboardFileConfig::load();
+        assert_eq!(cfg.use_bitloops_local, Some(true));
+    });
+}
+
+#[test]
+fn dashboard_use_bitloops_local_reads_repo_config_file() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_repo_config(
+        temp.path(),
+        serde_json::json!({
+            "dashboard": {
+                "use_bitloops_local": true
+            }
+        }),
+    );
+
+    with_cwd(temp.path(), || {
+        assert!(dashboard_use_bitloops_local());
+    });
+}
+
+#[test]
+fn resolve_store_backend_config_reads_repo_config_from_current_dir() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_repo_config(
+        temp.path(),
+        serde_json::json!({
+            "stores": {
+                "relational": {
+                    "provider": "postgres",
+                    "postgres_dsn": "postgres://user:pass@localhost:5432/bitloops"
+                },
+                "events": {
+                    "provider": "clickhouse",
+                    "clickhouse_url": "http://localhost:8123",
+                    "clickhouse_database": "bitloops"
+                },
+                "blob": {
+                    "provider": "local",
+                    "local_path": "tmp/blobs"
                 }
-            }),
+            }
+        }),
+    );
+
+    with_cwd(temp.path(), || {
+        let cfg = resolve_store_backend_config().expect("store backend config");
+        assert_eq!(cfg.relational.provider, RelationalProvider::Postgres);
+        assert_eq!(
+            cfg.relational.postgres_dsn.as_deref(),
+            Some("postgres://user:pass@localhost:5432/bitloops")
         );
+        assert_eq!(cfg.events.provider, EventsProvider::ClickHouse);
+        assert_eq!(cfg.events.clickhouse_database.as_deref(), Some("bitloops"));
+        assert_eq!(cfg.blobs.provider, BlobStorageProvider::Local);
+        assert_eq!(cfg.blobs.local_path.as_deref(), Some("tmp/blobs"));
+    });
+}
 
-        with_cwd(temp.path(), || {
-            let cfg = DashboardFileConfig::load();
-            assert_eq!(cfg.use_bitloops_local, Some(true));
-        });
-    }
-
-    #[test]
-    fn dashboard_use_bitloops_local_reads_repo_config_file() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        write_repo_config(
-            temp.path(),
-            serde_json::json!({
-                "dashboard": {
-                    "use_bitloops_local": true
+#[test]
+fn resolve_store_backend_config_for_repo_uses_repo_root_parameter() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_repo_config(
+        temp.path(),
+        serde_json::json!({
+            "stores": {
+                "relational": {
+                    "provider": "sqlite",
+                    "sqlite_path": "data/devql.sqlite"
+                },
+                "event": {
+                    "provider": "duckdb",
+                    "duckdb_path": "data/events.duckdb"
                 }
-            }),
-        );
+            }
+        }),
+    );
 
-        with_cwd(temp.path(), || {
-            assert!(dashboard_use_bitloops_local());
-        });
-    }
+    let cfg = resolve_store_backend_config_for_repo(temp.path()).expect("store backend config");
+    assert_eq!(cfg.relational.provider, RelationalProvider::Sqlite);
+    assert_eq!(
+        cfg.relational.sqlite_path.as_deref(),
+        Some("data/devql.sqlite")
+    );
+    assert_eq!(cfg.events.provider, EventsProvider::DuckDb);
+    assert_eq!(
+        cfg.events.duckdb_path.as_deref(),
+        Some("data/events.duckdb")
+    );
+}
 
-    #[test]
-    fn resolve_store_backend_config_reads_repo_config_from_current_dir() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        write_repo_config(
-            temp.path(),
-            serde_json::json!({
-                "stores": {
-                    "relational": {
-                        "provider": "postgres",
-                        "postgres_dsn": "postgres://user:pass@localhost:5432/bitloops"
-                    },
-                    "events": {
-                        "provider": "clickhouse",
-                        "clickhouse_url": "http://localhost:8123",
-                        "clickhouse_database": "bitloops"
-                    },
-                    "blob": {
-                        "provider": "local",
-                        "local_path": "tmp/blobs"
-                    }
+#[test]
+fn store_file_config_load_reads_repo_config_file() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_repo_config(
+        temp.path(),
+        serde_json::json!({
+            "stores": {
+                "relational": {
+                    "provider": "postgres"
+                },
+                "events": {
+                    "provider": "clickhouse"
                 }
-            }),
-        );
+            }
+        }),
+    );
 
-        with_cwd(temp.path(), || {
-            let cfg = resolve_store_backend_config().expect("store backend config");
-            assert_eq!(cfg.relational.provider, RelationalProvider::Postgres);
+    with_cwd(temp.path(), || {
+        let cfg = StoreFileConfig::load();
+        assert_eq!(cfg.relational_provider.as_deref(), Some("postgres"));
+        assert_eq!(cfg.events_provider.as_deref(), Some("clickhouse"));
+    });
+}
+
+#[test]
+fn resolve_store_semantic_config_reads_file_and_env() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_repo_config(
+        temp.path(),
+        serde_json::json!({
+            "semantic": {
+                "provider": "openai",
+                "model": "gpt-4.1-mini",
+                "api_key": "file-key",
+                "base_url": "http://localhost:11434/v1/chat/completions"
+            }
+        }),
+    );
+
+    with_process_state(
+        Some(temp.path()),
+        &[
+            (ENV_SEMANTIC_PROVIDER, Some("openai_compatible")),
+            (ENV_SEMANTIC_MODEL, Some("qwen2.5-coder")),
+            (ENV_SEMANTIC_API_KEY, Some("env-key")),
+            (
+                ENV_SEMANTIC_BASE_URL,
+                Some("http://localhost:9999/v1/chat/completions"),
+            ),
+        ],
+        || {
+            let cfg = resolve_store_semantic_config();
+            assert_eq!(cfg.semantic_provider.as_deref(), Some("openai_compatible"));
+            assert_eq!(cfg.semantic_model.as_deref(), Some("qwen2.5-coder"));
+            assert_eq!(cfg.semantic_api_key.as_deref(), Some("env-key"));
             assert_eq!(
-                cfg.relational.postgres_dsn.as_deref(),
-                Some("postgres://user:pass@localhost:5432/bitloops")
+                cfg.semantic_base_url.as_deref(),
+                Some("http://localhost:9999/v1/chat/completions")
             );
-            assert_eq!(cfg.events.provider, EventsProvider::ClickHouse);
-            assert_eq!(cfg.events.clickhouse_database.as_deref(), Some("bitloops"));
-            assert_eq!(cfg.blobs.provider, BlobStorageProvider::Local);
-            assert_eq!(cfg.blobs.local_path.as_deref(), Some("tmp/blobs"));
-        });
-    }
+        },
+    );
+}
 
-    #[test]
-    fn resolve_store_backend_config_for_repo_uses_repo_root_parameter() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        write_repo_config(
-            temp.path(),
-            serde_json::json!({
-                "stores": {
-                    "relational": {
-                        "provider": "sqlite",
-                        "sqlite_path": "data/devql.sqlite"
-                    },
-                    "event": {
-                        "provider": "duckdb",
-                        "duckdb_path": "data/events.duckdb"
-                    }
-                }
-            }),
-        );
+#[test]
+fn resolve_store_embedding_config_reads_file_and_env() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_repo_config(
+        temp.path(),
+        serde_json::json!({
+            "stores": {
+                "embedding_provider": "voyage",
+                "embedding_model": "voyage-code-3",
+                "embedding_api_key": "file-key"
+            }
+        }),
+    );
 
-        let cfg = resolve_store_backend_config_for_repo(temp.path()).expect("store backend config");
-        assert_eq!(cfg.relational.provider, RelationalProvider::Sqlite);
-        assert_eq!(
-            cfg.relational.sqlite_path.as_deref(),
-            Some("data/devql.sqlite")
-        );
-        assert_eq!(cfg.events.provider, EventsProvider::DuckDb);
-        assert_eq!(
-            cfg.events.duckdb_path.as_deref(),
-            Some("data/events.duckdb")
-        );
-    }
-
-    #[test]
-    fn store_file_config_load_reads_repo_config_file() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        write_repo_config(
-            temp.path(),
-            serde_json::json!({
-                "stores": {
-                    "relational": {
-                        "provider": "postgres"
-                    },
-                    "events": {
-                        "provider": "clickhouse"
-                    }
-                }
-            }),
-        );
-
-        with_cwd(temp.path(), || {
-            let cfg = StoreFileConfig::load();
-            assert_eq!(cfg.relational_provider.as_deref(), Some("postgres"));
-            assert_eq!(cfg.events_provider.as_deref(), Some("clickhouse"));
-        });
-    }
-
-    #[test]
-    fn resolve_store_semantic_config_reads_file_and_env() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        write_repo_config(
-            temp.path(),
-            serde_json::json!({
-                "semantic": {
-                    "provider": "openai",
-                    "model": "gpt-4.1-mini",
-                    "api_key": "file-key",
-                    "base_url": "http://localhost:11434/v1/chat/completions"
-                }
-            }),
-        );
-
-        with_process_state(
-            Some(temp.path()),
-            &[
-                (ENV_SEMANTIC_PROVIDER, Some("openai_compatible")),
-                (ENV_SEMANTIC_MODEL, Some("qwen2.5-coder")),
-                (ENV_SEMANTIC_API_KEY, Some("env-key")),
-                (
-                    ENV_SEMANTIC_BASE_URL,
-                    Some("http://localhost:9999/v1/chat/completions"),
-                ),
-            ],
-            || {
-                let cfg = resolve_store_semantic_config();
-                assert_eq!(cfg.semantic_provider.as_deref(), Some("openai_compatible"));
-                assert_eq!(cfg.semantic_model.as_deref(), Some("qwen2.5-coder"));
-                assert_eq!(cfg.semantic_api_key.as_deref(), Some("env-key"));
-                assert_eq!(
-                    cfg.semantic_base_url.as_deref(),
-                    Some("http://localhost:9999/v1/chat/completions")
-                );
-            },
-        );
-    }
-
-    #[test]
-    fn resolve_store_embedding_config_reads_file_and_env() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        write_repo_config(
-            temp.path(),
-            serde_json::json!({
-                "stores": {
-                    "embedding_provider": "voyage",
-                    "embedding_model": "voyage-code-3",
-                    "embedding_api_key": "file-key"
-                }
-            }),
-        );
-
-        with_process_state(
-            Some(temp.path()),
-            &[
-                (ENV_EMBEDDING_PROVIDER, Some("openai")),
-                (ENV_EMBEDDING_MODEL, Some("text-embedding-3-large")),
-                (ENV_EMBEDDING_API_KEY, Some("env-key")),
-            ],
-            || {
-                let cfg = resolve_store_embedding_config();
-                assert_eq!(cfg.embedding_provider.as_deref(), Some("openai"));
-                assert_eq!(
-                    cfg.embedding_model.as_deref(),
-                    Some("text-embedding-3-large")
-                );
-                assert_eq!(cfg.embedding_api_key.as_deref(), Some("env-key"));
-            },
-        );
-    }
+    with_process_state(
+        Some(temp.path()),
+        &[
+            (ENV_EMBEDDING_PROVIDER, Some("openai")),
+            (ENV_EMBEDDING_MODEL, Some("text-embedding-3-large")),
+            (ENV_EMBEDDING_API_KEY, Some("env-key")),
+        ],
+        || {
+            let cfg = resolve_store_embedding_config();
+            assert_eq!(cfg.embedding_provider.as_deref(), Some("openai"));
+            assert_eq!(
+                cfg.embedding_model.as_deref(),
+                Some("text-embedding-3-large")
+            );
+            assert_eq!(cfg.embedding_api_key.as_deref(), Some("env-key"));
+        },
+    );
+}


### PR DESCRIPTION
## Summary

This PR makes semantic clone results more understandable and more useful by separating retrieval from confidence, simplifying the explanation payload, and incorporating dependency context across the semantic pipeline.

## What Changed

- Clone scoring now separates:
  - `score`: ranking / candidate score
  - `clone_confidence`: how likely the pair is a real clone

- Clone explanations are now structured and less noisy:
  - removed backend-written prose
  - removed redundant fields like `schema_version` and positive-signal duplication
  - kept `relation_kind`, `limiting_signals`, `confidence`, `evidence`, `scores`, and `labels`

- Added `weak_clone_candidate` as a safer bucket for nearby semantic matches with weak implementation evidence, instead of overstating them as stronger clone relations.

- Reduced locality bias in `semantic_score` by removing path/location fields from embedding input.

- Added dependency context to all semantic stages:
  - Stage 1: summary prompt, feature hashing, and context tokens
  - Stage 2: embedding text and embedding hash
  - Stage 3: clone comparison now considers shared non-call dependencies in addition to shared calls

- Clone explanations now expose dependency evidence:
  - `dependency_overlap`
  - shared dependency targets

- Dependency signals are compacted into short, stable forms to avoid noisy path-heavy explanations.

- Replaced raw edge-kind string literals with shared DevQL edge-kind constants for consistency.

## Why

The main goal was to make clone results easier to trust and easier to consume:

- same-file or same-container neighbors can still be surfaced
- but they no longer look like strong clones unless implementation evidence supports that
- explanations now tell you what limited the verdict without burying you in debug noise
- dependency information helps distinguish “same theme” from “same implementation behavior”

## Behavioral Impact

- Same-file semantic neighbors are less likely to be overstated.
- Cross-file or same-file pairs with genuinely similar implementation should still score well.
- Semantic similarity is now more behavior-oriented and less path-oriented.
- Dependency-aware matches can now surface even when call overlap alone is weak.
## Validation

- [x] I ran the relevant tests locally.
- [x] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

