### PR TITLE
Update vulnerability reporting guidelines in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,13 +6,12 @@ The Bitloops team takes security issues seriously. We appreciate responsible
 disclosure and will make every effort to acknowledge valid reports and handle
 them carefully.
 
-If you believe you found a vulnerability, please report it privately. Do not
+**If you believe you found a vulnerability, please report it privately. Do not
 open a public issue for anything that could expose users, repositories,
-credentials, prompts, local metadata, or private code.
+credentials, prompts, local metadata, or private code.**
 
 Preferred reporting channels:
 
-- GitHub Security Advisories for this repository, if private reporting is enabled
 - Email [opencode@bitloops.com](mailto:opencode@bitloops.com) with `SECURITY` in
   the subject line
 


### PR DESCRIPTION
Emphasize the importance of private vulnerability reporting and correct the reporting mechanism.

## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [x] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [x] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

