### PR TITLE
Cli 1474 bitloops init has an error open code

### DIFF
--- a/bitloops/src/adapters/agents/adapters/builtin.rs
+++ b/bitloops/src/adapters/agents/adapters/builtin.rs
@@ -270,14 +270,14 @@ pub(super) fn builtin_registrations() -> Vec<AgentAdapterRegistration> {
                 protocol_family: protocol_family_jsonl(),
                 target_profile: profile_for(
                     AGENT_NAME_OPEN_CODE,
-                    "opencode",
+                    "OpenCode",
                     PROTOCOL_FAMILY_JSONL_CLI,
                     &["open-code"],
                     BASE_CAPABILITIES,
                 ),
                 package: AgentAdapterPackageDescriptor::first_party_linked(
                     AGENT_NAME_OPEN_CODE,
-                    "opencode",
+                    "OpenCode",
                 ),
                 config_schema: AgentConfigSchema::empty("adapter.opencode"),
             },

--- a/bitloops/src/adapters/agents/adapters_test/builtin_tests.rs
+++ b/bitloops/src/adapters/agents/adapters_test/builtin_tests.rs
@@ -60,34 +60,3 @@ fn TestBuiltinAdapterRegistrySupportsCanonicalResolution() {
     assert!(profiles.iter().any(|profile| profile == "copilot"));
     assert!(profiles.iter().any(|profile| profile == "gemini"));
 }
-
-#[test]
-#[allow(non_snake_case)]
-fn TestBuiltinAdapterDisplayNameConsistency() {
-    let registry = AgentAdapterRegistry::builtin();
-
-    for agent_name in registry.available_agents() {
-        let registration = registry
-            .resolve(&agent_name)
-            .unwrap_or_else(|err| panic!("failed to resolve agent {agent_name}: {err}"));
-        let descriptor = registration.descriptor();
-
-        assert_eq!(
-            descriptor.display_name.trim(),
-            descriptor.package.display_name.trim(),
-            "adapter '{}': package display_name '{}' must match adapter display_name '{}'",
-            descriptor.id,
-            descriptor.package.display_name,
-            descriptor.display_name,
-        );
-
-        assert_eq!(
-            descriptor.display_name.trim(),
-            descriptor.target_profile.display_name.trim(),
-            "adapter '{}': target_profile display_name '{}' must match adapter display_name '{}'",
-            descriptor.id,
-            descriptor.target_profile.display_name,
-            descriptor.display_name,
-        );
-    }
-}

--- a/bitloops/src/adapters/agents/adapters_test/builtin_tests.rs
+++ b/bitloops/src/adapters/agents/adapters_test/builtin_tests.rs
@@ -60,3 +60,34 @@ fn TestBuiltinAdapterRegistrySupportsCanonicalResolution() {
     assert!(profiles.iter().any(|profile| profile == "copilot"));
     assert!(profiles.iter().any(|profile| profile == "gemini"));
 }
+
+#[test]
+#[allow(non_snake_case)]
+fn TestBuiltinAdapterDisplayNameConsistency() {
+    let registry = AgentAdapterRegistry::builtin();
+
+    for agent_name in registry.available_agents() {
+        let registration = registry
+            .resolve(&agent_name)
+            .unwrap_or_else(|err| panic!("failed to resolve agent {agent_name}: {err}"));
+        let descriptor = registration.descriptor();
+
+        assert_eq!(
+            descriptor.display_name.trim(),
+            descriptor.package.display_name.trim(),
+            "adapter '{}': package display_name '{}' must match adapter display_name '{}'",
+            descriptor.id,
+            descriptor.package.display_name,
+            descriptor.display_name,
+        );
+
+        assert_eq!(
+            descriptor.display_name.trim(),
+            descriptor.target_profile.display_name.trim(),
+            "adapter '{}': target_profile display_name '{}' must match adapter display_name '{}'",
+            descriptor.id,
+            descriptor.target_profile.display_name,
+            descriptor.display_name,
+        );
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                 

bitloops init panics at startup with:                                                                                                                                                                                                   
builtin adapter registrations must be valid: package opencode must share the adapter display name OpenCode                                                                                                                 
                                                                                                                                                                                                                                          
  Root cause: The OpenCode builtin adapter registration in builtin.rs used inconsistent casing for the display name — the adapter declared "OpenCode" (PascalCase) but the target profile and package both passed "opencode" (lowercase). 
  The registry constructor enforces that package.display_name == descriptor.display_name, so this mismatch causes a bail! that gets unwrapped into a panic.                                                                               
                                                                                                                                                                                                                                          
  Fix: Two string literal changes in src/adapters/agents/adapters/builtin.rs — changed "opencode" to "OpenCode" in both the profile_for() and first_party_linked() calls so all three display name sites match, consistent with how every 
  other agent (Claude Code, Copilot, Codex, Cursor, Gemini) is registered.                                                                                                                                                              
                                                                                                                                                                                                                                          
  Impact: This single root cause was responsible for 39 test failures across 4 test modules (adapter registry, CLI init, CLI enable, checkpoint lifecycle) — all now pass. Total suite: 1778 passed, 0 failed.    
<!-- Briefly describe what changed and why -->

## Validation

- [X] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [X] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

