### PR TITLE
Deduplicate edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Fixed DevQL interface to query from the correct table depending on the query.
 - Fixed workspace revisions being persisted twice for a single change.
 - DB schema definitions now include a content hash so the schema watcher detects changes automatically, removing the need for a manual restart.
+- Edges deduplication in case of references
 
 ## [0.0.10] - 2026-03-12
 

--- a/bitloops/src/host/devql/ingestion/edges_js_ts.rs
+++ b/bitloops/src/host/devql/ingestion/edges_js_ts.rs
@@ -93,8 +93,7 @@ pub(super) fn extract_js_ts_dependency_edges(
             }
             // Skip if the identifier is immediately preceded by '.' — it is a member access and
             // call_member_re will emit the correct member-form edge for it.
-            if name_m.start() > 0
-                && line.as_bytes().get(name_m.start() - 1).copied() == Some(b'.')
+            if name_m.start() > 0 && line.as_bytes().get(name_m.start() - 1).copied() == Some(b'.')
             {
                 continue;
             }

--- a/bitloops/src/host/devql/ingestion/edges_js_ts.rs
+++ b/bitloops/src/host/devql/ingestion/edges_js_ts.rs
@@ -91,6 +91,13 @@ pub(super) fn extract_js_ts_dependency_edges(
             if is_control_keyword(&name) {
                 continue;
             }
+            // Skip if the identifier is immediately preceded by '.' — it is a member access and
+            // call_member_re will emit the correct member-form edge for it.
+            if name_m.start() > 0
+                && line.as_bytes().get(name_m.start() - 1).copied() == Some(b'.')
+            {
+                continue;
+            }
 
             if let Some(target_fqn) = callable_name_to_fqn.get(&name) {
                 edges.push(JsTsDependencyEdge {

--- a/bitloops/src/host/devql/ingestion/edges_reference.rs
+++ b/bitloops/src/host/devql/ingestion/edges_reference.rs
@@ -11,7 +11,7 @@ pub(super) fn collect_js_ts_reference_edges_recursive(
     let line_no = node.start_position().row as i32 + 1;
     if let Some(owner) = smallest_enclosing_callable(line_no, ctx.callables) {
         match node.kind() {
-            "type_identifier" => {
+            "type_identifier" if !js_ts_node_is_in_extends_clause(node) => {
                 if let Ok(name) = node.utf8_text(content.as_bytes()) {
                     push_reference_edge(
                         col,
@@ -26,7 +26,10 @@ pub(super) fn collect_js_ts_reference_edges_recursive(
                     );
                 }
             }
-            "identifier" if js_ts_identifier_is_value_reference(node) => {
+            "identifier"
+                if js_ts_identifier_is_value_reference(node)
+                    && !js_ts_node_is_in_extends_clause(node) =>
+            {
                 if let Ok(name) = node.utf8_text(content.as_bytes()) {
                     push_reference_edge(
                         col,

--- a/bitloops/src/host/devql/ingestion/edges_shared.rs
+++ b/bitloops/src/host/devql/ingestion/edges_shared.rs
@@ -333,6 +333,28 @@ pub(super) fn symbol_lookup_name_from_text(text: &str) -> Option<String> {
     Some(candidate.to_string())
 }
 
+/// Returns true when `node` sits inside an `extends_clause` or `extends_type_clause` in the
+/// JS/TS AST. Used to suppress spurious `references` edges for types that are already captured
+/// by an `extends` edge.
+pub(super) fn js_ts_node_is_in_extends_clause(mut node: tree_sitter::Node) -> bool {
+    loop {
+        let Some(parent) = node.parent() else {
+            return false;
+        };
+        match parent.kind() {
+            "extends_clause" | "extends_type_clause" => return true,
+            // Stop at declaration boundaries — never cross into a different symbol's scope.
+            "class_declaration"
+            | "class_body"
+            | "interface_declaration"
+            | "function_declaration"
+            | "method_definition"
+            | "program" => return false,
+            _ => node = parent,
+        }
+    }
+}
+
 pub(super) fn js_ts_identifier_is_value_reference(node: tree_sitter::Node) -> bool {
     let Some(parent) = node.parent() else {
         return true;
@@ -373,6 +395,16 @@ pub(super) fn rust_identifier_is_value_reference(node: tree_sitter::Node) -> boo
         "call_expression" => !node_matches_parent_field(node, parent, "function"),
         "field_expression" => !node_matches_parent_field(node, parent, "field"),
         "macro_invocation" => !node_matches_parent_field(node, parent, "macro"),
+        // Suppress e.g. `AppServer` in `AppServer::new(...)`.  The identifier is the path
+        // qualifier of a scoped associated call; the `calls` edge already captures the
+        // dependency, so a redundant `references` edge is not needed.
+        "scoped_identifier" => {
+            let Some(grandparent) = parent.parent() else {
+                return true;
+            };
+            !(grandparent.kind() == "call_expression"
+                && node_matches_parent_field(parent, grandparent, "function"))
+        }
         _ => true,
     }
 }

--- a/bitloops/src/host/devql/tests/devql_tests/extraction_js_ts.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/extraction_js_ts.rs
@@ -522,3 +522,133 @@ export { remoteFoo as remoteAlias } from "./remote";
         Some("re_export")
     );
 }
+
+// Case 1: extends clause must NOT also produce a references edge
+// When a class or interface only mentions a type in its extends/implements clause, that type
+// relationship is fully captured by the extends edge. A duplicate references edge for the same
+// target is noise. Currently FAILS because the reference extractor also picks up the inherited
+// type name and emits a spurious references edge.
+#[test]
+fn extract_js_ts_dependency_edges_extends_clause_does_not_emit_redundant_references_edge() {
+    let content = r#"class Animal {}
+class Dog extends Animal {}
+
+interface Base {
+  id: string;
+}
+interface Serializable extends Base {}
+"#;
+    let artefacts = extract_js_ts_artefacts(content, "src/sample.ts").unwrap();
+    let edges = extract_js_ts_dependency_edges(content, "src/sample.ts", &artefacts).unwrap();
+
+    // extends edges must be present — baseline
+    assert!(
+        edges.iter().any(|e| {
+            e.edge_kind == "extends"
+                && e.from_symbol_fqn == "src/sample.ts::Dog"
+                && e.to_target_symbol_fqn.as_deref() == Some("src/sample.ts::Animal")
+        }),
+        "expected extends edge Dog → Animal"
+    );
+    assert!(
+        edges.iter().any(|e| {
+            e.edge_kind == "extends"
+                && e.from_symbol_fqn == "src/sample.ts::Serializable"
+                && e.to_target_symbol_fqn.as_deref() == Some("src/sample.ts::Base")
+        }),
+        "expected extends edge Serializable → Base"
+    );
+
+    // no spurious references edges for the same target — the extends edge is sufficient
+    assert!(
+        !edges.iter().any(|e| {
+            e.edge_kind == "references"
+                && e.from_symbol_fqn == "src/sample.ts::Dog"
+                && e.to_target_symbol_fqn.as_deref() == Some("src/sample.ts::Animal")
+        }),
+        "extends clause should not also emit a references edge for Animal (duplicate)"
+    );
+    assert!(
+        !edges.iter().any(|e| {
+            e.edge_kind == "references"
+                && e.from_symbol_fqn == "src/sample.ts::Serializable"
+                && e.to_target_symbol_fqn.as_deref() == Some("src/sample.ts::Base")
+        }),
+        "extends clause should not also emit a references edge for Base (duplicate)"
+    );
+}
+
+// Case 2: member call + identifier call duplication
+// obj.method() fires both regexes: call_ident_re matches `method(` and call_member_re matches
+// `.method(`, producing two edges for the same invocation. Only the member edge should be kept.
+#[test]
+fn extract_js_ts_dependency_edges_member_call_does_not_also_emit_identifier_call() {
+    let content = r#"function run() {
+  console.timeEnd("label");
+  obj.process();
+}
+"#;
+    let artefacts = extract_js_ts_artefacts(content, "src/sample.ts").unwrap();
+    let edges = extract_js_ts_dependency_edges(content, "src/sample.ts", &artefacts).unwrap();
+
+    let calls_from_run: Vec<_> = edges
+        .iter()
+        .filter(|e| e.edge_kind == "calls" && e.from_symbol_fqn == "src/sample.ts::run")
+        .collect();
+
+    // timeEnd: should produce exactly one edge (member form), not two (member + identifier)
+    let timeend_edges: Vec<_> = calls_from_run
+        .iter()
+        .filter(|e| {
+            e.to_symbol_ref
+                .as_deref()
+                .map(|r| r.contains("timeEnd"))
+                .unwrap_or(false)
+        })
+        .collect();
+    assert_eq!(
+        timeend_edges.len(),
+        1,
+        "timeEnd() call should produce exactly one edge (member), got {:?}",
+        timeend_edges
+            .iter()
+            .map(|e| (e.to_symbol_ref.as_deref(), e.metadata.get("call_form")))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        timeend_edges[0]
+            .metadata
+            .get("call_form")
+            .and_then(|v| v.as_str()),
+        Some("member"),
+        "the single timeEnd edge should use call_form=member"
+    );
+
+    // process: same assertion for a second member call on a different line
+    let process_edges: Vec<_> = calls_from_run
+        .iter()
+        .filter(|e| {
+            e.to_symbol_ref
+                .as_deref()
+                .map(|r| r.contains("process"))
+                .unwrap_or(false)
+        })
+        .collect();
+    assert_eq!(
+        process_edges.len(),
+        1,
+        "process() call should produce exactly one edge (member), got {:?}",
+        process_edges
+            .iter()
+            .map(|e| (e.to_symbol_ref.as_deref(), e.metadata.get("call_form")))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        process_edges[0]
+            .metadata
+            .get("call_form")
+            .and_then(|v| v.as_str()),
+        Some("member"),
+        "the single process edge should use call_form=member"
+    );
+}

--- a/bitloops/src/host/devql/tests/devql_tests/extraction_rust.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/extraction_rust.rs
@@ -543,3 +543,50 @@ fn factorial(n: u64) -> u64 {
         "unresolved rust call edges should be filtered out under the import+local policy"
     );
 }
+
+// Case 3: Rust associated call `Type::fn()` must NOT also emit a references edge for the type.
+// `AppServer::new(...)` produces a calls(associated) edge; `AppServer` as the scoped-identifier
+// path qualifier must not additionally produce a references edge.
+#[test]
+fn extract_rust_dependency_edges_associated_call_does_not_emit_redundant_references_edge() {
+    let content = r#"struct AppServer {
+    host: String,
+}
+
+impl AppServer {
+    fn new(host: &str, port: u16) -> Self {
+        AppServer { host: host.to_string() }
+    }
+}
+
+fn boot() {
+    let server = AppServer::new("127.0.0.1", 8080);
+}
+"#;
+    let artefacts = extract_rust_artefacts(content, "src/lib.rs").unwrap();
+    let edges = extract_rust_dependency_edges(content, "src/lib.rs", &artefacts).unwrap();
+
+    // calls edge must be present
+    assert!(
+        edges.iter().any(|e| {
+            e.edge_kind == "calls"
+                && e.from_symbol_fqn == "src/lib.rs::boot"
+                && e.to_target_symbol_fqn
+                    .as_deref()
+                    .is_some_and(|t| t.contains("new"))
+        }),
+        "expected a calls edge for AppServer::new from boot"
+    );
+
+    // no spurious references edge for AppServer from the call site
+    assert!(
+        !edges.iter().any(|e| {
+            e.edge_kind == "references"
+                && e.from_symbol_fqn == "src/lib.rs::boot"
+                && e.to_target_symbol_fqn
+                    .as_deref()
+                    .is_some_and(|t| t.contains("AppServer"))
+        }),
+        "AppServer::new() call should not also emit a references edge for AppServer (duplicate)"
+    );
+}


### PR DESCRIPTION
## Summary

Deduplicated edges
https://bitloops.atlassian.net/browse/CLI-1452

## Validation

- [x] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [x] Linked Jira issue(s) are updated with implementation notes and test results.
- [x] Final status transitions match the task definition of done.

