### PR TITLE
Remove obsolete methods from repo fakes

### DIFF
--- a/bitloops/src/capability_packs/test_harness/ingest/coverage.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/coverage.rs
@@ -347,9 +347,6 @@ mod tests {
     use anyhow::Result;
 
     use super::{execute, format_summary, parse_lcov_report};
-    use crate::capability_packs::knowledge::storage::{
-        KnowledgeItemRow, KnowledgeRelationAssertionRow, KnowledgeSourceRow,
-    };
     use crate::capability_packs::test_harness::storage::TestHarnessCoverageGateway;
     use crate::host::capability_host::gateways::RelationalGateway;
     use crate::models::{
@@ -398,52 +395,6 @@ mod tests {
     }
 
     impl RelationalGateway for FakeRelationalGateway {
-        fn initialise_schema(&self) -> Result<()> {
-            unreachable!("unused in coverage tests")
-        }
-
-        fn persist_ingestion(
-            &self,
-            _source: &KnowledgeSourceRow,
-            _item: &KnowledgeItemRow,
-        ) -> Result<()> {
-            unreachable!("unused in coverage tests")
-        }
-
-        fn insert_relation_assertion(
-            &self,
-            _relation: &KnowledgeRelationAssertionRow,
-        ) -> Result<()> {
-            unreachable!("unused in coverage tests")
-        }
-
-        fn find_item(&self, _repo_id: &str, _source_id: &str) -> Result<Option<KnowledgeItemRow>> {
-            unreachable!("unused in coverage tests")
-        }
-
-        fn find_item_by_id(
-            &self,
-            _repo_id: &str,
-            _knowledge_item_id: &str,
-        ) -> Result<Option<KnowledgeItemRow>> {
-            unreachable!("unused in coverage tests")
-        }
-
-        fn find_source_by_id(
-            &self,
-            _knowledge_source_id: &str,
-        ) -> Result<Option<KnowledgeSourceRow>> {
-            unreachable!("unused in coverage tests")
-        }
-
-        fn list_items_for_repo(
-            &self,
-            _repo_id: &str,
-            _limit: usize,
-        ) -> Result<Vec<KnowledgeItemRow>> {
-            unreachable!("unused in coverage tests")
-        }
-
         fn resolve_checkpoint_id(&self, _repo_id: &str, _checkpoint_ref: &str) -> Result<String> {
             unreachable!("unused in coverage tests")
         }

--- a/bitloops/src/capability_packs/test_harness/ingest/parse_llvm_json.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/parse_llvm_json.rs
@@ -152,9 +152,6 @@ mod tests {
     use anyhow::Result;
 
     use super::*;
-    use crate::capability_packs::knowledge::storage::{
-        KnowledgeItemRow, KnowledgeRelationAssertionRow, KnowledgeSourceRow,
-    };
     use crate::host::capability_host::gateways::RelationalGateway;
 
     #[derive(Default)]
@@ -163,52 +160,6 @@ mod tests {
     }
 
     impl RelationalGateway for FakeRelationalGateway {
-        fn initialise_schema(&self) -> Result<()> {
-            unreachable!("unused in llvm ingest tests")
-        }
-
-        fn persist_ingestion(
-            &self,
-            _source: &KnowledgeSourceRow,
-            _item: &KnowledgeItemRow,
-        ) -> Result<()> {
-            unreachable!("unused in llvm ingest tests")
-        }
-
-        fn insert_relation_assertion(
-            &self,
-            _relation: &KnowledgeRelationAssertionRow,
-        ) -> Result<()> {
-            unreachable!("unused in llvm ingest tests")
-        }
-
-        fn find_item(&self, _repo_id: &str, _source_id: &str) -> Result<Option<KnowledgeItemRow>> {
-            unreachable!("unused in llvm ingest tests")
-        }
-
-        fn find_item_by_id(
-            &self,
-            _repo_id: &str,
-            _knowledge_item_id: &str,
-        ) -> Result<Option<KnowledgeItemRow>> {
-            unreachable!("unused in llvm ingest tests")
-        }
-
-        fn find_source_by_id(
-            &self,
-            _knowledge_source_id: &str,
-        ) -> Result<Option<KnowledgeSourceRow>> {
-            unreachable!("unused in llvm ingest tests")
-        }
-
-        fn list_items_for_repo(
-            &self,
-            _repo_id: &str,
-            _limit: usize,
-        ) -> Result<Vec<KnowledgeItemRow>> {
-            unreachable!("unused in llvm ingest tests")
-        }
-
         fn resolve_checkpoint_id(&self, _repo_id: &str, _checkpoint_ref: &str) -> Result<String> {
             unreachable!("unused in llvm ingest tests")
         }

--- a/bitloops/src/capability_packs/test_harness/ingest/results.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/results.rs
@@ -152,9 +152,6 @@ mod tests {
     use anyhow::Result;
 
     use super::{execute, map_jest_status, normalize_test_path};
-    use crate::capability_packs::knowledge::storage::{
-        KnowledgeItemRow, KnowledgeRelationAssertionRow, KnowledgeSourceRow,
-    };
     use crate::capability_packs::test_harness::storage::TestHarnessRepository;
     use crate::host::capability_host::gateways::RelationalGateway;
     use crate::models::{
@@ -228,52 +225,6 @@ mod tests {
     }
 
     impl RelationalGateway for FakeRelationalGateway {
-        fn initialise_schema(&self) -> Result<()> {
-            unreachable!("unused in results tests")
-        }
-
-        fn persist_ingestion(
-            &self,
-            _source: &KnowledgeSourceRow,
-            _item: &KnowledgeItemRow,
-        ) -> Result<()> {
-            unreachable!("unused in results tests")
-        }
-
-        fn insert_relation_assertion(
-            &self,
-            _relation: &KnowledgeRelationAssertionRow,
-        ) -> Result<()> {
-            unreachable!("unused in results tests")
-        }
-
-        fn find_item(&self, _repo_id: &str, _source_id: &str) -> Result<Option<KnowledgeItemRow>> {
-            unreachable!("unused in results tests")
-        }
-
-        fn find_item_by_id(
-            &self,
-            _repo_id: &str,
-            _knowledge_item_id: &str,
-        ) -> Result<Option<KnowledgeItemRow>> {
-            unreachable!("unused in results tests")
-        }
-
-        fn find_source_by_id(
-            &self,
-            _knowledge_source_id: &str,
-        ) -> Result<Option<KnowledgeSourceRow>> {
-            unreachable!("unused in results tests")
-        }
-
-        fn list_items_for_repo(
-            &self,
-            _repo_id: &str,
-            _limit: usize,
-        ) -> Result<Vec<KnowledgeItemRow>> {
-            unreachable!("unused in results tests")
-        }
-
         fn resolve_checkpoint_id(&self, _repo_id: &str, _checkpoint_ref: &str) -> Result<String> {
             unreachable!("unused in results tests")
         }


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

