### PR TITLE
Update version to 0.0.11 and enhance changelog with new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.0.11] - 2026-03-25
+
+### Added
+
 - **Unified multi-scope configuration** (`CLI-1459`): One configuration domain replaces the legacy `settings.json` / `config.json` split. All settings (hooks, strategy, stores, knowledge, semantic, dashboard, watch) now live in a single `config.json` / `config.local.json` file pair using a versioned envelope format (`version` / `scope` / `settings`). Layer precedence: code defaults → global `~/.bitloops/config.json` → project shared → project local → environment variables. Deep-merge semantics for objects; arrays replace entirely; explicit `null` clears keys from lower layers.
 - **Monorepo project-root discovery** (`CLI-1463`): `bitloops_project_root()` walks upward from `cwd` to find the nearest `.bitloops/` directory marker. Falls back to git root when no marker exists. Git hooks still install at git root; config, stores, and agent directories resolve from the Bitloops project root.
 - **Provider-less store backend model** (`CLI-1481`–`CLI-1484`): Removed `provider` enum fields from `RelationalBackendConfig`, `EventsBackendConfig`, and `BlobStorageConfig`. Local backends (SQLite, DuckDB, local blob) are always present; remote backends (Postgres, ClickHouse, S3, GCS) activate when their connection string or bucket is configured. Consumer dispatch sites use capability checks (`has_postgres()`, `has_clickhouse()`, `s3_bucket.is_some()`) instead of `match provider`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,7 +131,7 @@ Edit `Cargo.toml`:
 
 ```toml
 [package]
-version = "0.1.0"   # ← change this
+version = "0.0.11"   # ← change this
 ```
 
 ### 2. Run the release script
@@ -146,7 +146,7 @@ This will:
 
 - Read the version from `Cargo.toml`
 - Commit the version bump
-- Create and push the git tag (`v0.1.0`)
+- Create and push the git tag (`v0.0.11`)
 - GitHub Actions picks up the tag and builds all platform binaries automatically
 
 Before release builds, generate the environment-specific dashboard config:
@@ -206,7 +206,7 @@ The `install.sh` script at the repo root detects the platform, downloads the mat
 class Bitloops < Formula
   desc "Bitloops CLI"
   homepage "https://github.com/bitloops/bitloops-cli"
-  version "0.1.0"
+  version "0.0.11"
   license "MIT"
 
   on_macos do

--- a/bitloops/Cargo.lock
+++ b/bitloops/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitloops"
-version = "0.1.0"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/bitloops/Cargo.toml
+++ b/bitloops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitloops"
-version = "0.1.0"
+version = "0.0.11"
 edition = "2024"
 
 [features]

--- a/bitloops/src/capability_packs/knowledge/descriptor.rs
+++ b/bitloops/src/capability_packs/knowledge/descriptor.rs
@@ -2,13 +2,13 @@ use crate::host::capability_host::{CapabilityDependency, CapabilityDescriptor};
 
 const KNOWLEDGE_DEPENDENCIES: &[CapabilityDependency] = &[CapabilityDependency {
     capability_id: "test_harness",
-    min_version: "0.1.0",
+    min_version: "0.0.11",
 }];
 
 pub static KNOWLEDGE_DESCRIPTOR: CapabilityDescriptor = CapabilityDescriptor {
     id: "knowledge",
     display_name: "Knowledge",
-    version: "0.1.0",
+    version: "0.0.11",
     api_version: 1,
     description: "Repository-scoped external knowledge ingestion, versioning, relations, and retrieval.",
     default_enabled: true,

--- a/bitloops/src/capability_packs/knowledge/migrations/initial.rs
+++ b/bitloops/src/capability_packs/knowledge/migrations/initial.rs
@@ -12,7 +12,7 @@ fn run_initial_knowledge_migration(ctx: &mut dyn KnowledgeMigrationContext) -> R
 
 pub static KNOWLEDGE_MIGRATIONS: &[CapabilityMigration] = &[CapabilityMigration {
     capability_id: "knowledge",
-    version: "0.1.0",
+    version: "0.0.11",
     description: "Initial knowledge schema",
     run: MigrationRunner::Knowledge(run_initial_knowledge_migration),
 }];

--- a/bitloops/src/capability_packs/semantic_clones/descriptor.rs
+++ b/bitloops/src/capability_packs/semantic_clones/descriptor.rs
@@ -3,7 +3,7 @@ use crate::host::capability_host::CapabilityDescriptor;
 pub static SEMANTIC_CLONES_DESCRIPTOR: CapabilityDescriptor = CapabilityDescriptor {
     id: super::types::SEMANTIC_CLONES_CAPABILITY_ID,
     display_name: "Semantic Clones",
-    version: "0.1.0",
+    version: "0.0.11",
     api_version: 1,
     description: "Semantic clone detection: embeddings-backed candidate scoring and symbol_clone_edges materialisation.",
     default_enabled: true,

--- a/bitloops/src/capability_packs/semantic_clones/migrations.rs
+++ b/bitloops/src/capability_packs/semantic_clones/migrations.rs
@@ -12,7 +12,7 @@ fn run_semantic_clones_initial_schema(ctx: &mut dyn CapabilityMigrationContext) 
 
 pub static SEMANTIC_CLONES_MIGRATIONS: &[CapabilityMigration] = &[CapabilityMigration {
     capability_id: super::types::SEMANTIC_CLONES_CAPABILITY_ID,
-    version: "0.1.0",
+    version: "0.0.11",
     description: "symbol_clone_edges on DevQL SQLite relational",
     run: MigrationRunner::Core(run_semantic_clones_initial_schema),
 }];

--- a/bitloops/src/capability_packs/test_harness/descriptor.rs
+++ b/bitloops/src/capability_packs/test_harness/descriptor.rs
@@ -3,7 +3,7 @@ use crate::host::capability_host::CapabilityDescriptor;
 pub static TEST_HARNESS_DESCRIPTOR: CapabilityDescriptor = CapabilityDescriptor {
     id: "test_harness",
     display_name: "Test Harness",
-    version: "0.1.0",
+    version: "0.0.11",
     api_version: 1,
     description: "Verification mapping across tests, coverage, classification, and artefact-level confidence/strength.",
     default_enabled: true,

--- a/bitloops/src/config/unified_config.rs
+++ b/bitloops/src/config/unified_config.rs
@@ -1,4 +1,4 @@
-//! Unified multi-scope configuration for Bitloops 0.1.0.
+//! Unified multi-scope configuration for Bitloops 0.0.11.
 //!
 //! One config schema, one merge pipeline: code defaults → global → project → project_local → env.
 

--- a/bitloops/tests/test_harness_support/mod.rs
+++ b/bitloops/tests/test_harness_support/mod.rs
@@ -463,7 +463,7 @@ pub fn write_rust_hybrid_fixture(workspace: &Workspace) {
         r#"
 [package]
 name = "rust_detection_fixture"
-version = "0.1.0"
+version = "0.0.11"
 edition = "2021"
 
 [dev-dependencies]

--- a/runbook.md
+++ b/runbook.md
@@ -35,7 +35,7 @@ mkdir -p src/models src/repositories src/services tests/e2e
 cat > Cargo.toml <<'EOF'
 [package]
 name = "test_harness_proof"
-version = "0.1.0"
+version = "0.0.11"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This commit updates the version number across multiple files to 0.0.11, reflecting the latest release. The CHANGELOG is also updated to include significant additions such as unified multi-scope configuration, monorepo project-root discovery, and a provider-less store backend model. These changes improve configuration management and enhance the overall functionality of the Bitloops CLI.