### PR TITLE
CLI-1180:Setup the webserver so that it uses mkcert to offer https access

### DIFF
--- a/bitloops/Cargo.lock
+++ b/bitloops/Cargo.lock
@@ -331,6 +331,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,12 +562,16 @@ dependencies = [
  "env_logger",
  "fastembed",
  "figlet-rs",
+ "hyper",
+ "hyper-util",
  "log",
  "notify",
  "object_store",
  "regex",
  "reqwest 0.13.2",
  "rusqlite",
+ "rustls",
+ "rustls-pemfile",
  "semver",
  "serde",
  "serde_json",
@@ -539,6 +582,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
+ "tokio-rustls",
  "tower",
  "tree-sitter",
  "tree-sitter-javascript",
@@ -547,6 +591,7 @@ dependencies = [
  "utoipa",
  "uuid",
  "walkdir",
+ "x509-parser",
  "zstd",
 ]
 
@@ -1100,6 +1145,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2320,6 +2385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,6 +2914,15 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3742,6 +3822,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,6 +3869,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5562,6 +5660,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
 ]
 
 [[package]]

--- a/bitloops/Cargo.toml
+++ b/bitloops/Cargo.toml
@@ -47,6 +47,12 @@ object_store = { version = "0.13.2", features = ["aws", "gcp"] }
 fastembed = { version = "5.12.1", default-features = false, features = ["hf-hub-rustls-tls", "image-models", "ort-load-dynamic"] }
 walkdir = "2.5"
 chrono = { version = "0.4", default-features = true, features = ["clock"] }
+rustls = "0.23"
+tokio-rustls = "0.26"
+rustls-pemfile = "2"
+x509-parser = "0.16"
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio", "server", "http1", "service"] }
 
 [dev-dependencies]
 cucumber = "0.22.1"

--- a/bitloops/src/api.rs
+++ b/bitloops/src/api.rs
@@ -3,7 +3,9 @@ mod bundle_types;
 mod db;
 mod dto;
 mod handlers;
+mod hosts;
 mod router;
+pub mod tls;
 
 use crate::config::dashboard_use_bitloops_local;
 use crate::host::checkpoints::strategy::manual_commit::{
@@ -15,10 +17,13 @@ use anyhow::{Context, Result, anyhow, bail};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
+use std::io::IsTerminal;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio_rustls::TlsAcceptor;
 
 pub const DEFAULT_DASHBOARD_PORT: u16 = 5667;
 
@@ -113,6 +118,12 @@ pub(super) enum ServeMode {
     Bundle(PathBuf),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DashboardTransport {
+    Http,
+    Https,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct DashboardState {
     pub(super) repo_root: PathBuf,
@@ -134,10 +145,26 @@ pub async fn run(config: DashboardServerConfig) -> Result<()> {
         );
     }
 
-    let selected_host = select_host_with_dashboard_preference(
-        config.host.as_deref(),
-        dashboard_use_bitloops_local(),
-    );
+    let mut startup_warnings: Vec<String> = Vec::new();
+
+    let selected_host = if let Some(explicit_host) = config.host.as_deref().and_then(normalized_host) {
+        explicit_host.to_string()
+    } else if dashboard_use_bitloops_local() {
+        match hosts::ensure_default_dashboard_host_mapping()? {
+            hosts::HostMappingOutcome::AlreadyCorrect | hosts::HostMappingOutcome::Updated => {
+                PREFERRED_LOCAL_HOST.to_string()
+            }
+            hosts::HostMappingOutcome::NeedsFallback { reason } => {
+                startup_warnings.push(format!(
+                    "Warning: could not map {PREFERRED_LOCAL_HOST} in the hosts file: {reason}\n\
+                     Falling back to localhost for this run."
+                ));
+                FALLBACK_LOCAL_HOST.to_string()
+            }
+        }
+    } else {
+        FALLBACK_LOCAL_HOST.to_string()
+    };
     let bind_addr = resolve_bind_addr(&selected_host, config.port)?;
 
     let listener = TcpListener::bind(bind_addr).await.with_context(|| {
@@ -149,6 +176,36 @@ pub async fn run(config: DashboardServerConfig) -> Result<()> {
     let local_addr = listener
         .local_addr()
         .context("Reading dashboard listener address")?;
+    let browser_host = browser_host_for_url(&selected_host, local_addr);
+    let (transport, tls_acceptor) = if !tls::mkcert_on_path() {
+        startup_warnings.push(format!(
+            "Warning: `mkcert` is not on PATH. Falling back to local HTTP.\n\
+             See https://bitloops.com/docs/guides/dashboard-local-https-setup for mkcert and /etc/hosts setup instructions."
+        ));
+        (DashboardTransport::Http, None)
+    } else {
+        match tls::ensure_dashboard_tls_material(&browser_host) {
+            Ok(tls_material) => {
+                log::debug!(
+                    "Dashboard TLS: cert={} key={}",
+                    tls_material.cert_path.display(),
+                    tls_material.key_path.display()
+                );
+                (
+                    DashboardTransport::Https,
+                    Some(TlsAcceptor::from(tls_material.server_config.clone())),
+                )
+            }
+            Err(err) => {
+                startup_warnings.push(format!(
+                    "Warning: Dashboard HTTPS setup failed ({err:#}).\n\
+                     Falling back to local HTTP.\n\
+                     See https://bitloops.com/docs/guides/dashboard-local-https-setup for mkcert and /etc/hosts setup instructions."
+                ));
+                (DashboardTransport::Http, None)
+            }
+        }
+    };
 
     let bundle_dir = resolve_bundle_dir(config.bundle_dir.as_deref());
     let serve_mode = if has_bundle_index(&bundle_dir) {
@@ -160,8 +217,7 @@ pub async fn run(config: DashboardServerConfig) -> Result<()> {
         .or_else(|_| env::current_dir().context("Getting current directory for dashboard state"))
         .unwrap_or_else(|_| PathBuf::from("."));
 
-    let browser_host = browser_host_for_url(&selected_host, local_addr);
-    let url = format_dashboard_url(&browser_host, local_addr.port());
+    let url = format_dashboard_url(transport, &browser_host, local_addr.port());
 
     println!();
     println!("{}", color_hex(&bitloops_wordmark(), BITLOOPS_PURPLE_HEX));
@@ -170,6 +226,12 @@ pub async fn run(config: DashboardServerConfig) -> Result<()> {
     print!("{}", color_hex("ready ", "#22c55e"));
     print!("at ");
     println!("{}", color_hex(&clickable_url(&url), BITLOOPS_PURPLE_HEX));
+    if !startup_warnings.is_empty() {
+        eprintln!();
+    }
+    for warning in &startup_warnings {
+        print_warning_message(warning);
+    }
     match &serve_mode {
         ServeMode::HelloWorld => {
             println!(
@@ -190,37 +252,157 @@ pub async fn run(config: DashboardServerConfig) -> Result<()> {
     if !config.no_open
         && let Err(err) = open_in_default_browser(&url)
     {
-        eprintln!("Warning: failed to open default browser: {err:#}");
+        print_warning_message(&format!("Warning: failed to open default browser: {err:#}"));
     }
 
-    serve_until_ctrl_c(
-        listener,
-        DashboardState {
-            repo_root,
-            mode: serve_mode,
-            db: db_init.pools,
-            bundle_dir,
-        },
-    )
+    let state = DashboardState {
+        repo_root,
+        mode: serve_mode,
+        db: db_init.pools,
+        bundle_dir,
+    };
+
+    match (transport, tls_acceptor) {
+        (DashboardTransport::Https, Some(acceptor)) => {
+            serve_until_ctrl_c_tls(listener, acceptor, state).await
+        }
+        (DashboardTransport::Http, _) => serve_until_ctrl_c_http(listener, state).await,
+        (DashboardTransport::Https, None) => {
+            Err(anyhow!("dashboard HTTPS selected without a TLS acceptor"))
+        }
+    }
+}
+
+async fn serve_until_ctrl_c_tls(
+    listener: TcpListener,
+    tls_acceptor: TlsAcceptor,
+    state: DashboardState,
+) -> Result<()> {
+    use hyper::server::conn::http1::Builder as Http1Builder;
+    use hyper_util::rt::TokioIo;
+    use hyper_util::service::TowerToHyperService;
+
+    let app = router::build_dashboard_router(state);
+    serve_until_ctrl_c_with_handler(listener, move |stream| {
+        let tls_acceptor = tls_acceptor.clone();
+        let app = app.clone();
+        async move {
+            let tls_stream = match tls_acceptor.accept(stream).await {
+                Ok(s) => s,
+                Err(e) => {
+                    let detail = e.to_string();
+                    if detail.contains("CertificateUnknown")
+                        || detail.contains("UnknownIssuer")
+                    {
+                        log::warn!(
+                            "TLS handshake failed: {e} \
+                             (the client rejected the certificate — run `mkcert -install` once, quit Chrome fully, retry)"
+                        );
+                    } else {
+                        log::warn!("TLS handshake failed: {e}");
+                    }
+                    return;
+                }
+            };
+            let io = TokioIo::new(tls_stream);
+            let service = TowerToHyperService::new(app);
+            if let Err(e) = Http1Builder::new().serve_connection(io, service).await {
+                log::warn!("HTTP connection error: {e}");
+            }
+        }
+    })
     .await
 }
 
-async fn serve_until_ctrl_c(listener: TcpListener, state: DashboardState) -> Result<()> {
+async fn serve_until_ctrl_c_http(listener: TcpListener, state: DashboardState) -> Result<()> {
+    use hyper::server::conn::http1::Builder as Http1Builder;
+    use hyper_util::rt::TokioIo;
+    use hyper_util::service::TowerToHyperService;
+
     let app = router::build_dashboard_router(state);
+    serve_until_ctrl_c_with_handler(listener, move |stream| {
+        let app = app.clone();
+        async move {
+            let io = TokioIo::new(stream);
+            let service = TowerToHyperService::new(app);
+            if let Err(e) = Http1Builder::new().serve_connection(io, service).await {
+                log::warn!("HTTP connection error: {e}");
+            }
+        }
+    })
+    .await
+}
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async {
-            let _ = tokio::signal::ctrl_c().await;
-        })
-        .await
-        .context("Serving dashboard requests")?;
+async fn serve_until_ctrl_c_with_handler<F, Fut>(listener: TcpListener, mut on_stream: F) -> Result<()>
+where
+    F: FnMut(tokio::net::TcpStream) -> Fut,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                break;
+            }
+            accept = listener.accept() => {
+                let (stream, _) = accept.context("accepting dashboard TCP connection")?;
+                tokio::spawn(on_stream(stream));
+            }
+        }
+    }
 
+    drop(listener);
+    tokio::time::sleep(Duration::from_secs(5)).await;
     println!("Dashboard server stopped.");
     Ok(())
 }
 
 fn clickable_url(url: &str) -> String {
     format!("\x1b]8;;{url}\x1b\\{url}\x1b]8;;\x1b\\")
+}
+
+fn terminal_supports_color() -> bool {
+    std::env::var_os("NO_COLOR").is_none() && std::io::stdout().is_terminal()
+}
+
+fn warning_block_lines(warning: &str, use_color: bool) -> Vec<String> {
+    let lines: Vec<&str> = warning.lines().collect();
+    if lines.is_empty() {
+        return Vec::new();
+    }
+
+    // Brown background close to terminal selection tone in user screenshot.
+    const WARN_STYLE: &str = "30;48;2;107;79;59";
+    let max_content_width = lines.iter().map(|line| line.len()).max().unwrap_or(0);
+    let total_width = max_content_width + 4; // two spaces left + two spaces right
+    let blank = " ".repeat(total_width);
+
+    if use_color {
+        let mut out = Vec::with_capacity(lines.len() + 3);
+        out.push(format!("\x1b[{WARN_STYLE}m{blank}\x1b[K\x1b[0m"));
+        let icon_line = format!("  \x1b[33m⚠\x1b[{WARN_STYLE}m  ");
+        out.push(format!("\x1b[{WARN_STYLE}m{icon_line}\x1b[K\x1b[0m"));
+        for line in &lines {
+            let content = format!("  {line:<width$}  ", width = max_content_width);
+            out.push(format!("\x1b[{WARN_STYLE}m{content}\x1b[K\x1b[0m"));
+        }
+        out.push(format!("\x1b[{WARN_STYLE}m{blank}\x1b[K\x1b[0m"));
+        return out;
+    }
+
+    let mut out = Vec::with_capacity(lines.len() + 3);
+    out.push(String::new());
+    out.push("  ⚠".to_string());
+    for line in &lines {
+        out.push(format!("  {line}"));
+    }
+    out.push(String::new());
+    out
+}
+
+fn print_warning_message(warning: &str) {
+    for line in warning_block_lines(warning, terminal_supports_color()) {
+        eprintln!("{line}");
+    }
 }
 
 fn canonical_user_key(name: &str, email: &str) -> String {
@@ -675,6 +857,7 @@ pub(super) fn expand_tilde_with_home(path: &Path, home: Option<&Path>) -> PathBu
     path.to_path_buf()
 }
 
+#[cfg(test)]
 pub(super) fn select_host_with_dashboard_preference(
     explicit_host: Option<&str>,
     use_bitloops_local: bool,
@@ -731,11 +914,19 @@ pub(super) fn browser_host_for_url(bind_host: &str, local_addr: SocketAddr) -> S
     }
 }
 
-pub(super) fn format_dashboard_url(host: &str, port: u16) -> String {
+fn dashboard_scheme(transport: DashboardTransport) -> &'static str {
+    match transport {
+        DashboardTransport::Http => "http",
+        DashboardTransport::Https => "https",
+    }
+}
+
+fn format_dashboard_url(transport: DashboardTransport, host: &str, port: u16) -> String {
+    let scheme = dashboard_scheme(transport);
     if host.contains(':') && !host.starts_with('[') {
-        format!("http://[{host}]:{port}")
+        format!("{scheme}://[{host}]:{port}")
     } else {
-        format!("http://{host}:{port}")
+        format!("{scheme}://{host}:{port}")
     }
 }
 

--- a/bitloops/src/api/hosts.rs
+++ b/bitloops/src/api/hosts.rs
@@ -1,0 +1,114 @@
+//! OS hosts file: ensure `bitloops.local` resolves to loopback for the default dashboard path.
+
+use anyhow::Result;
+use std::fs;
+use std::io;
+use std::net::ToSocketAddrs;
+use std::path::PathBuf;
+
+const BITLOOPS_HOST: &str = "bitloops.local";
+
+/// Result of attempting to make `bitloops.local` usable for the default dashboard bind.
+#[derive(Debug)]
+pub enum HostMappingOutcome {
+    /// Name already resolves to a loopback address.
+    AlreadyCorrect,
+    /// Hosts file was updated successfully.
+    Updated,
+    /// Cannot apply mapping; caller should fall back to `localhost`.
+    NeedsFallback { reason: String },
+}
+
+fn hosts_file_path() -> PathBuf {
+    #[cfg(windows)]
+    {
+        let windir = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
+        PathBuf::from(windir)
+            .join("System32")
+            .join("drivers")
+            .join("etc")
+            .join("hosts")
+    }
+    #[cfg(not(windows))]
+    PathBuf::from("/etc/hosts")
+}
+
+fn bitloops_resolves_to_loopback() -> bool {
+    let Ok(addrs) = format!("{BITLOOPS_HOST}:80").to_socket_addrs() else {
+        return false;
+    };
+    addrs.into_iter().any(|a| a.ip().is_loopback())
+}
+
+fn hosts_line_for_bitloops() -> String {
+    format!("127.0.0.1\t{BITLOOPS_HOST}\n")
+}
+
+/// Remove non-comment lines that mention `bitloops.local`, then append a managed mapping line.
+fn merge_hosts_content(existing: &str) -> String {
+    let mut out = String::new();
+    for line in existing.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+        if line.to_ascii_lowercase().contains(BITLOOPS_HOST) {
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    if !out.ends_with('\n') && !out.is_empty() {
+        out.push('\n');
+    }
+    out.push_str("# bitloops dashboard (managed)\n");
+    out.push_str(&hosts_line_for_bitloops());
+    out
+}
+
+/// Run **before** host probing for `bitloops.local` when using the default dashboard (no explicit `--host`).
+pub fn ensure_default_dashboard_host_mapping() -> Result<HostMappingOutcome> {
+    if bitloops_resolves_to_loopback() {
+        return Ok(HostMappingOutcome::AlreadyCorrect);
+    }
+
+    let path = hosts_file_path();
+    let existing = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            return Ok(HostMappingOutcome::NeedsFallback {
+                reason: format!("cannot read hosts file {}: {e}", path.display()),
+            });
+        }
+    };
+
+    let merged = merge_hosts_content(&existing);
+
+    match fs::write(&path, merged.as_bytes()) {
+        Ok(()) => {
+            if bitloops_resolves_to_loopback() {
+                Ok(HostMappingOutcome::Updated)
+            } else {
+                Ok(HostMappingOutcome::NeedsFallback {
+                    reason: format!(
+                        "updated {} but {BITLOOPS_HOST} still does not resolve to loopback",
+                        path.display()
+                    ),
+                })
+            }
+        }
+        Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+            Ok(HostMappingOutcome::NeedsFallback {
+                reason: format!(
+                    "permission denied writing hosts file {}: {e}",
+                    path.display()
+                ),
+            })
+        }
+        Err(e) => Ok(HostMappingOutcome::NeedsFallback {
+            reason: format!("cannot write hosts file {}: {e}", path.display()),
+        }),
+    }
+}

--- a/bitloops/src/api/tests.rs
+++ b/bitloops/src/api/tests.rs
@@ -2,11 +2,12 @@
 
 use super::router::build_dashboard_router;
 use super::{
-    ApiPage, DashboardState, GIT_FIELD_SEPARATOR, GIT_RECORD_SEPARATOR, ServeMode,
+    ApiPage, DashboardState, DashboardTransport, GIT_FIELD_SEPARATOR, GIT_RECORD_SEPARATOR,
+    ServeMode,
     branch_is_excluded, browser_host_for_url, build_branch_commit_log_args, canonical_agent_key,
     dashboard_user, default_bundle_dir_from_home, expand_tilde_with_home, format_dashboard_url,
     has_bundle_index, paginate, parse_branch_commit_log, parse_numstat_output, resolve_bundle_file,
-    select_host_with_dashboard_preference,
+    select_host_with_dashboard_preference, warning_block_lines,
 };
 use crate::test_support::git_fixtures::{git_ok, init_test_repo, repo_local_blob_root};
 use crate::test_support::process_state::{ProcessStateGuard, enter_env_vars};
@@ -878,7 +879,35 @@ fn browser_host_uses_localhost_for_unspecified_ipv6_bind() {
 
 #[test]
 fn format_dashboard_url_wraps_ipv6_hosts() {
-    assert_eq!(format_dashboard_url("::1", 5667), "http://[::1]:5667");
+    assert_eq!(
+        format_dashboard_url(DashboardTransport::Https, "::1", 5667),
+        "https://[::1]:5667"
+    );
+    assert_eq!(
+        format_dashboard_url(DashboardTransport::Http, "::1", 5667),
+        "http://[::1]:5667"
+    );
+}
+
+#[test]
+fn warning_block_lines_plain_keeps_multiline_text_and_icon() {
+    let rendered = warning_block_lines("Warning: first line\nsecond line", false);
+    assert_eq!(rendered.first(), Some(&String::new()));
+    assert_eq!(rendered.get(1).map(String::as_str), Some("  ⚠"));
+    assert_eq!(rendered.get(2).map(String::as_str), Some("  Warning: first line"));
+    assert_eq!(rendered.get(3).map(String::as_str), Some("  second line"));
+    assert_eq!(rendered.last(), Some(&String::new()));
+}
+
+#[test]
+fn warning_block_lines_colored_renders_padded_block_rows() {
+    let rendered = warning_block_lines("abc\nde", true);
+    assert_eq!(rendered.len(), 5, "top + icon + 2 text lines + bottom");
+    assert!(rendered[0].contains("\x1b[30;48;2;107;79;59m"));
+    assert!(rendered[1].contains("\x1b[33m⚠"));
+    assert!(rendered[2].contains("  abc  "));
+    assert!(rendered[3].contains("  de   "));
+    assert!(rendered.iter().all(|line| line.contains("\x1b[K")));
 }
 
 #[test]

--- a/bitloops/src/api/tls.rs
+++ b/bitloops/src/api/tls.rs
@@ -1,0 +1,478 @@
+//! Local HTTPS: mkcert leaf certs plus a shared `rustls::ServerConfig` for the dashboard.
+
+use anyhow::{Context, Result, anyhow, bail};
+use rustls::ServerConfig;
+use rustls::crypto::CryptoProvider;
+use rustls::pki_types::CertificateDer;
+use std::fs::{self, File};
+use std::io::BufReader;
+use std::net::{IpAddr, Ipv6Addr};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use x509_parser::extensions::GeneralName;
+use x509_parser::parse_x509_certificate;
+
+fn eprint_mkcert_not_found_on_path() {
+    eprintln!();
+    eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    eprintln!("  Dashboard HTTPS — mkcert not found");
+    eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    eprintln!();
+    eprintln!("  Step 1: install mkcert and put it on your PATH.");
+    eprintln!("  Step 2: run `mkcert -install`.");
+    eprintln!();
+    eprintln!("  macOS:  brew install mkcert nss");
+    eprintln!("  Then:   mkcert -install");
+    eprintln!();
+    eprintln!("  {}", mkcert_hint());
+    eprintln!();
+}
+
+fn mkcert_output_indicates_untrusted_ca(output: &str) -> bool {
+    output.contains(r#"Run "mkcert -install" for certificates to be trusted automatically"#)
+        || output.contains("not installed in the system trust store")
+}
+
+fn ensure_mkcert_trust_ready(mkcert: &Path) -> Result<()> {
+    let probe_root = std::env::temp_dir().join(format!(
+        "bitloops-mkcert-probe-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    fs::create_dir_all(&probe_root)
+        .with_context(|| format!("create {}", probe_root.display()))?;
+    let cert_path = probe_root.join("cert.pem");
+    let key_path = probe_root.join("key.pem");
+
+    let out = Command::new(mkcert)
+        .arg("-cert-file")
+        .arg(&cert_path)
+        .arg("-key-file")
+        .arg(&key_path)
+        .arg("localhost")
+        .arg("127.0.0.1")
+        .arg("::1")
+        .output()
+        .with_context(|| format!("running mkcert trust probe via {}", mkcert.display()))?;
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let combined = format!("{stderr}\n{stdout}");
+
+    let _ = fs::remove_file(&cert_path);
+    let _ = fs::remove_file(&key_path);
+    let _ = fs::remove_dir(&probe_root);
+
+    if out.status.success() && mkcert_output_indicates_untrusted_ca(&combined) {
+        bail!(
+            "mkcert local CA is not trusted by this machine/browser yet.\n\
+             Run `mkcert -install`, then retry dashboard."
+        );
+    }
+
+    if !out.status.success() {
+        bail!(
+            "mkcert trust probe failed (exit {}).\n\
+             stderr:\n{stderr}\n\
+             stdout:\n{stdout}\n\
+             {}",
+            out.status,
+            mkcert_hint()
+        );
+    }
+
+    Ok(())
+}
+
+/// Ensures `mkcert` is on `PATH` before any certificate work.
+pub fn require_mkcert_binary() -> Result<PathBuf> {
+    match which::which("mkcert") {
+        Ok(p) => Ok(p),
+        Err(_) => {
+            eprint_mkcert_not_found_on_path();
+            bail!("mkcert not found on PATH");
+        }
+    }
+}
+
+pub fn mkcert_on_path() -> bool {
+    which::which("mkcert").is_ok()
+}
+
+fn ensure_rustls_crypto_provider() -> Result<()> {
+    static INIT: OnceLock<std::result::Result<(), String>> = OnceLock::new();
+    let init = INIT.get_or_init(|| {
+        if CryptoProvider::get_default().is_none() {
+            return rustls::crypto::aws_lc_rs::default_provider()
+                .install_default()
+                .map_err(|e| format!("install rustls aws_lc_rs crypto provider: {e:?}"));
+        }
+        Ok(())
+    });
+    match init {
+        Ok(()) => Ok(()),
+        Err(msg) => Err(anyhow!("{msg}")),
+    }
+}
+
+fn cert_root_dir() -> PathBuf {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    home.unwrap_or_else(|| PathBuf::from("."))
+        .join(".bitloops")
+        .join("certs")
+}
+
+/// Deterministic directory name for a browser host (no collisions between IPv4/IPv6/DNS).
+pub fn host_id_for_path(browser_host: &str) -> String {
+    if let Ok(ip) = browser_host.parse::<IpAddr>() {
+        match ip {
+            IpAddr::V4(v4) => format!("ipv4-{}", v4).replace('.', "-"),
+            IpAddr::V6(v6) => {
+                if v6 == Ipv6Addr::LOCALHOST {
+                    "ipv6-localhost".to_string()
+                } else {
+                    format!("ipv6-{}", v6).replace(':', "-")
+                }
+            }
+        }
+    } else {
+        browser_host
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() {
+                    c.to_ascii_lowercase()
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>()
+    }
+}
+
+pub fn resolve_tls_paths_for_host(browser_host: &str) -> (PathBuf, PathBuf) {
+    let id = host_id_for_path(browser_host);
+    let dir = cert_root_dir().join(id);
+    (dir.join("cert.pem"), dir.join("key.pem"))
+}
+
+fn mkcert_hint() -> &'static str {
+    "More: https://github.com/FiloSottile/mkcert — macOS: brew install mkcert nss; Linux/Windows: see releases."
+}
+
+/// Build `mkcert` arguments after `-cert-file` / `-key-file` per plan.
+fn mkcert_identity_args(browser_host: &str) -> Vec<String> {
+    match browser_host {
+        "bitloops.local" => vec![
+            "bitloops.local".into(),
+            "localhost".into(),
+            "127.0.0.1".into(),
+            "::1".into(),
+        ],
+        "localhost" => vec!["localhost".into(), "127.0.0.1".into(), "::1".into()],
+        "127.0.0.1" => vec![
+            "127.0.0.1".into(),
+            "localhost".into(),
+            "::1".into(),
+        ],
+        "::1" => vec!["::1".into(), "localhost".into(), "127.0.0.1".into()],
+        other => {
+            vec![
+                other.to_string(),
+                "localhost".into(),
+                "127.0.0.1".into(),
+                "::1".into(),
+            ]
+        }
+    }
+}
+
+fn run_mkcert(cert_path: &Path, key_path: &Path, browser_host: &str) -> Result<()> {
+    let mkcert = require_mkcert_binary()?;
+    if let Some(parent) = cert_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+
+    let mut cmd = Command::new(&mkcert);
+    cmd.arg("-cert-file")
+        .arg(cert_path)
+        .arg("-key-file")
+        .arg(key_path);
+    for a in mkcert_identity_args(browser_host) {
+        cmd.arg(a);
+    }
+
+    let out = cmd.output().with_context(|| format!("running {:?}", cmd.get_program()))?;
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    if out.status.success() {
+        let combined = format!("{stderr}\n{stdout}");
+        if mkcert_output_indicates_untrusted_ca(&combined) {
+            bail!(
+                "mkcert generated certificate but local CA trust is not installed.\n\
+                 Run the instructions below, then retry launching the dashboard."
+            );
+        }
+        return Ok(());
+    }
+    bail!(
+        "mkcert failed (exit {}).\n\
+         stderr:\n{stderr}\n\
+         stdout:\n{stdout}\n\
+         {}",
+        out.status,
+        mkcert_hint()
+    )
+}
+
+fn load_server_config(cert_path: &Path, key_path: &Path) -> Result<Arc<ServerConfig>> {
+    let cert_file =
+        File::open(cert_path).with_context(|| format!("open cert {}", cert_path.display()))?;
+    let key_file = File::open(key_path).with_context(|| format!("open key {}", key_path.display()))?;
+
+    let mut cert_reader = BufReader::new(cert_file);
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut cert_reader)
+        .collect::<Result<Vec<_>, _>>()
+        .context("read certificate PEM chain")?;
+
+    let mut key_reader = BufReader::new(key_file);
+    let key = rustls_pemfile::private_key(&mut key_reader)
+        .context("read private key PEM")?
+        .ok_or_else(|| anyhow!("no private key found in {}", key_path.display()))?;
+
+    ensure_rustls_crypto_provider()?;
+
+    let config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .context("build rustls ServerConfig (check key matches certificate)")?;
+
+    Ok(Arc::new(config))
+}
+
+fn load_leaf_certificate(cert_path: &Path) -> Result<CertificateDer<'static>> {
+    let cert_file =
+        File::open(cert_path).with_context(|| format!("open cert {}", cert_path.display()))?;
+    let mut cert_reader = BufReader::new(cert_file);
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut cert_reader)
+        .collect::<Result<Vec<_>, _>>()
+        .context("read certificate PEM chain")?;
+    certs
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("no certificate found in {}", cert_path.display()))
+}
+
+fn browser_host_has_matching_san(
+    cert_path: &Path,
+    leaf_cert: &CertificateDer<'_>,
+    browser_host: &str,
+) -> Result<()> {
+    let (_, cert) = parse_x509_certificate(leaf_cert.as_ref())
+        .map_err(|e| anyhow!("parse X.509 certificate {}: {e}", cert_path.display()))?;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let nb = cert.validity().not_before.timestamp();
+    let na = cert.validity().not_after.timestamp();
+    if now < nb || now > na {
+        bail!(
+            "certificate at {} is outside its validity window (not_before={}, not_after={})",
+            cert_path.display(),
+            cert.validity().not_before,
+            cert.validity().not_after
+        );
+    }
+
+    let san = cert
+        .subject_alternative_name()
+        .map_err(|e| anyhow!("read SubjectAlternativeName from {}: {e}", cert_path.display()))?
+        .ok_or_else(|| anyhow!("certificate at {} has no SubjectAlternativeName extension", cert_path.display()))?;
+
+    if let Ok(ip) = browser_host.parse::<IpAddr>() {
+        let matches = san.value.general_names.iter().any(|name| match (ip, name) {
+            (IpAddr::V4(expected), GeneralName::IPAddress(raw)) => {
+                raw.len() == 4 && *raw == expected.octets().as_slice()
+            }
+            (IpAddr::V6(expected), GeneralName::IPAddress(raw)) => {
+                raw.len() == 16 && *raw == expected.octets().as_slice()
+            }
+            _ => false,
+        });
+        if matches {
+            return Ok(());
+        }
+        bail!(
+            "certificate at {} is missing IP SAN for {}",
+            cert_path.display(),
+            browser_host
+        );
+    }
+
+    let matches = san.value.general_names.iter().any(|name| match name {
+        GeneralName::DNSName(dns_name) => dns_name.eq_ignore_ascii_case(browser_host),
+        _ => false,
+    });
+    if matches {
+        return Ok(());
+    }
+
+    bail!(
+        "certificate at {} is missing DNS SAN for {}",
+        cert_path.display(),
+        browser_host
+    )
+}
+
+/// Validated TLS material for the dashboard (single shared server config).
+pub struct DashboardTlsMaterial {
+    pub server_config: Arc<ServerConfig>,
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+}
+
+/// Ensure PEMs exist and are valid for `browser_host`, then build [`ServerConfig`] once.
+pub fn ensure_dashboard_tls_material(browser_host: &str) -> Result<DashboardTlsMaterial> {
+    let mkcert = require_mkcert_binary()?;
+    ensure_mkcert_trust_ready(&mkcert)?;
+    let (cert_path, key_path) = resolve_tls_paths_for_host(browser_host);
+
+    if !cert_path.is_file() || !key_path.is_file() {
+        run_mkcert(&cert_path, &key_path, browser_host)?;
+    }
+
+    let server_config = match load_leaf_certificate(&cert_path)
+        .and_then(|leaf_cert| {
+            browser_host_has_matching_san(&cert_path, &leaf_cert, browser_host)?;
+            load_server_config(&cert_path, &key_path)
+        }) {
+        Ok(server_config) => server_config,
+        Err(validation_error) => {
+            log::warn!(
+                "dashboard TLS material invalid for host {browser_host}, regenerating: {validation_error:#}"
+            );
+            try_remove_pair(&cert_path, &key_path);
+            run_mkcert(&cert_path, &key_path, browser_host)?;
+            let leaf_cert = load_leaf_certificate(&cert_path)?;
+            browser_host_has_matching_san(&cert_path, &leaf_cert, browser_host)
+                .with_context(|| {
+                    format!(
+                        "regenerated certificate for {browser_host} is still invalid; \
+                         refusing to open the dashboard browser URL"
+                    )
+                })?;
+            load_server_config(&cert_path, &key_path).with_context(|| {
+                format!(
+                    "regenerated TLS material for {browser_host} is unusable; \
+                     refusing to open the dashboard browser URL"
+                )
+            })?
+        }
+    };
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(&key_path) {
+            let mut mode = meta.permissions();
+            mode.set_mode(0o600);
+            let _ = fs::set_permissions(&key_path, mode);
+        }
+    }
+
+    Ok(DashboardTlsMaterial {
+        server_config,
+        cert_path,
+        key_path,
+    })
+}
+
+fn try_remove_pair(cert_path: &Path, key_path: &Path) {
+    let _ = fs::remove_file(cert_path);
+    let _ = fs::remove_file(key_path);
+}
+
+// Inline implementation to avoid an extra dependency.
+mod which {
+    use std::path::PathBuf;
+
+    pub fn which(name: &str) -> std::result::Result<PathBuf, ()> {
+        let sep = std::env::var_os("PATH").unwrap_or_default();
+        for dir in std::env::split_paths(&sep) {
+            let p = dir.join(name);
+            if p.is_file() {
+                return Ok(p);
+            }
+            #[cfg(windows)]
+            {
+                let p_exe = dir.join(format!("{name}.exe"));
+                if p_exe.is_file() {
+                    return Ok(p_exe);
+                }
+            }
+        }
+        Err(())
+    }
+}
+
+#[cfg(test)]
+mod tls_tests {
+    use super::*;
+
+    #[test]
+    fn host_id_for_path_normalizes_hosts() {
+        assert_eq!(host_id_for_path("127.0.0.1"), "ipv4-127-0-0-1");
+        assert_eq!(host_id_for_path("::1"), "ipv6-localhost");
+        assert_eq!(host_id_for_path("bitloops.local"), "bitloops-local");
+    }
+
+    #[test]
+    fn mkcert_identity_args_include_loopback_identities() {
+        assert_eq!(
+            mkcert_identity_args("localhost"),
+            vec!["localhost", "127.0.0.1", "::1"]
+        );
+        assert_eq!(
+            mkcert_identity_args("bitloops.local"),
+            vec!["bitloops.local", "localhost", "127.0.0.1", "::1"]
+        );
+    }
+
+    #[test]
+    fn mkcert_identity_args_have_no_duplicate_sans() {
+        let ipv4 = mkcert_identity_args("127.0.0.1");
+        assert_eq!(ipv4, vec!["127.0.0.1", "localhost", "::1"]);
+
+        let ipv6 = mkcert_identity_args("::1");
+        assert_eq!(ipv6, vec!["::1", "localhost", "127.0.0.1"]);
+    }
+
+    #[test]
+    fn mkcert_identity_args_for_custom_host_include_loopback_fallbacks() {
+        assert_eq!(
+            mkcert_identity_args("dev.internal"),
+            vec!["dev.internal", "localhost", "127.0.0.1", "::1"]
+        );
+    }
+
+    #[test]
+    fn resolve_tls_paths_for_host_uses_host_specific_directory() {
+        let (cert, key) = resolve_tls_paths_for_host("bitloops.local");
+        assert!(cert.ends_with("bitloops-local/cert.pem"));
+        assert!(key.ends_with("bitloops-local/key.pem"));
+    }
+
+    #[test]
+    fn mkcert_output_untrusted_ca_detection() {
+        let text = r#"Note: the local CA is not installed in the system trust store.
+Run "mkcert -install" for certificates to be trusted automatically ⚠️"#;
+        assert!(mkcert_output_indicates_untrusted_ca(text));
+        assert!(!mkcert_output_indicates_untrusted_ca("Created a new certificate"));
+    }
+}

--- a/bitloops/src/config/resolve.rs
+++ b/bitloops/src/config/resolve.rs
@@ -32,7 +32,7 @@ pub fn dashboard_use_bitloops_local() -> bool {
     let settings = effective_settings_for_repo(&repo_root).unwrap_or_default();
     resolve_dashboard_from_unified(&settings)
         .use_bitloops_local
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 pub fn resolve_watch_runtime_config_for_repo(repo_root: &Path) -> WatchRuntimeConfig {

--- a/bitloops/src/config/store_config_tests/dashboard.rs
+++ b/bitloops/src/config/store_config_tests/dashboard.rs
@@ -23,7 +23,7 @@ fn dashboard_file_config_load_defaults_when_repo_config_missing() {
     let _guard = enter_process_state(Some(temp.path()), &[]);
 
     assert_eq!(DashboardFileConfig::load(), DashboardFileConfig::default());
-    assert!(!dashboard_use_bitloops_local());
+    assert!(dashboard_use_bitloops_local());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Setup the local dashboard server to use https using mkcert.

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

