### PR TITLE
Add repo awareness to checkpoint detail endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- **Dashboard checkpoint-detail REST endpoint now resolves repositories explicitly**: changed `GET /api/checkpoints/{checkpoint_id}` to `GET /api/checkpoints/{repo_id}/{checkpoint_id}` so the legacy dashboard API loads checkpoint details from the selected repository instead of implicitly reading from the default repo root. Updated the dashboard API regression tests and OpenAPI path coverage to match the repo-aware route.
+
 ### Fixed
 
 ## [0.0.12] - 2026-03-30

--- a/bitloops/src/api/handlers/checkpoint.rs
+++ b/bitloops/src/api/handlers/checkpoint.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use axum::{
     Json,
@@ -19,8 +19,9 @@ use crate::host::checkpoints::strategy::manual_commit::{CommittedInfo, read_sess
 
 #[utoipa::path(
     get,
-    path = "/api/checkpoints/{checkpoint_id}",
+    path = "/api/checkpoints/{repo_id}/{checkpoint_id}",
     params(
+        ("repo_id" = String, Path, description = "Repository id"),
         ("checkpoint_id" = String, Path, description = "Checkpoint id (12 hex characters)")
     ),
     responses(
@@ -32,11 +33,57 @@ use crate::host::checkpoints::strategy::manual_commit::{CommittedInfo, read_sess
 )]
 pub(crate) async fn handle_api_checkpoint(
     State(state): State<DashboardState>,
-    AxumPath(checkpoint_id): AxumPath<String>,
+    AxumPath((repo_id, checkpoint_id)): AxumPath<(String, String)>,
 ) -> std::result::Result<Json<ApiCheckpointDetailResponse>, ApiError> {
+    let repo_root = resolve_repo_root_from_repo_id(&state, &repo_id).await?;
+    Ok(Json(
+        load_checkpoint_detail(&repo_root, checkpoint_id).await?,
+    ))
+}
+
+fn api_token_usage_from_committed(info: &CommittedInfo) -> Option<ApiTokenUsageDto> {
+    info.token_usage.as_ref().map(|usage| ApiTokenUsageDto {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_tokens: usage.cache_creation_tokens,
+        cache_read_tokens: usage.cache_read_tokens,
+        api_call_count: usage.api_call_count,
+    })
+}
+
+async fn resolve_repo_root_from_repo_id(
+    state: &DashboardState,
+    repo_id: &str,
+) -> std::result::Result<PathBuf, ApiError> {
+    let repo_id = repo_id.trim();
+    if repo_id.is_empty() {
+        return Err(ApiError::bad_request("repo_id is required"));
+    }
+
+    let context = crate::graphql::DevqlGraphqlContext::for_global_request(
+        state.config_root.clone(),
+        state.repo_root.clone(),
+        state.repo_registry_path().map(std::path::Path::to_path_buf),
+        state.db.clone(),
+    );
+    let repository = context
+        .resolve_repository_selection(repo_id)
+        .await
+        .map_err(|_| ApiError::not_found(format!("repository not found: {repo_id}")))?;
+
+    repository
+        .repo_root()
+        .cloned()
+        .ok_or_else(|| ApiError::not_found(format!("repository checkout unknown for `{repo_id}`")))
+}
+
+async fn load_checkpoint_detail(
+    repo_root: &Path,
+    checkpoint_id: String,
+) -> std::result::Result<ApiCheckpointDetailResponse, ApiError> {
     let checkpoint_id = normalize_checkpoint_id(checkpoint_id)?;
     let Some(info) =
-        read_checkpoint_info_for_filtering(&state.repo_root, &checkpoint_id).map_err(|err| {
+        read_checkpoint_info_for_filtering(repo_root, &checkpoint_id).map_err(|err| {
             ApiError::internal(format!(
                 "failed to read checkpoint metadata for {checkpoint_id}: {err:#}"
             ))
@@ -49,7 +96,7 @@ pub(crate) async fn handle_api_checkpoint(
 
     let mut sessions = Vec::new();
     for session_index in 0..info.session_count {
-        let content = match read_session_content(&state.repo_root, &checkpoint_id, session_index) {
+        let content = match read_session_content(repo_root, &checkpoint_id, session_index) {
             Ok(content) => content,
             Err(err) => {
                 log::warn!(
@@ -98,13 +145,13 @@ pub(crate) async fn handle_api_checkpoint(
     }
 
     let files_touched = resolve_checkpoint_files_touched(
-        &state.repo_root,
+        repo_root,
         &info.branch,
         &info.checkpoint_id,
         &info.files_touched,
     );
     let token_usage = api_token_usage_from_committed(&info);
-    Ok(Json(ApiCheckpointDetailResponse {
+    Ok(ApiCheckpointDetailResponse {
         checkpoint_id: info.checkpoint_id,
         strategy: info.strategy,
         branch: info.branch,
@@ -113,16 +160,6 @@ pub(crate) async fn handle_api_checkpoint(
         session_count: info.session_count,
         token_usage,
         sessions,
-    }))
-}
-
-fn api_token_usage_from_committed(info: &CommittedInfo) -> Option<ApiTokenUsageDto> {
-    info.token_usage.as_ref().map(|usage| ApiTokenUsageDto {
-        input_tokens: usage.input_tokens,
-        output_tokens: usage.output_tokens,
-        cache_creation_tokens: usage.cache_creation_tokens,
-        cache_read_tokens: usage.cache_read_tokens,
-        api_call_count: usage.api_call_count,
     })
 }
 

--- a/bitloops/src/api/router.rs
+++ b/bitloops/src/api/router.rs
@@ -212,7 +212,10 @@ fn build_dashboard_api_router() -> Router<DashboardState> {
         .route("/users", get(handle_api_users))
         .route("/agents", get(handle_api_agents))
         .route("/db/health", get(handle_api_db_health))
-        .route("/checkpoints/{checkpoint_id}", get(handle_api_checkpoint))
+        .route(
+            "/checkpoints/{repo_id}/{checkpoint_id}",
+            get(handle_api_checkpoint),
+        )
         .route(
             "/check_bundle_version",
             get(handle_api_check_bundle_version),

--- a/bitloops/src/api/tests/dashboard_api_bundle.rs
+++ b/bitloops/src/api/tests/dashboard_api_bundle.rs
@@ -254,13 +254,15 @@ async fn api_repositories_lists_all_known_repositories() {
 #[tokio::test]
 async fn api_checkpoint_returns_detailed_session_payload() {
     let repo = seed_dashboard_repo();
+    let repo_id = crate::host::devql::resolve_repo_id(repo.path()).expect("resolve repo id");
     let app = build_dashboard_router(test_state(
         repo.path().to_path_buf(),
         ServeMode::HelloWorld,
         repo.path().to_path_buf(),
     ));
 
-    let (status, payload) = request_json(app, "/api/checkpoints/aabbccddeeff").await;
+    let checkpoint_path = format!("/api/checkpoints/{repo_id}/aabbccddeeff");
+    let (status, payload) = request_json(app, &checkpoint_path).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["checkpoint_id"], "aabbccddeeff");
     assert_eq!(payload["session_count"].as_u64(), Some(1));
@@ -333,13 +335,15 @@ async fn api_users_returns_name_and_email_from_graphql_wrapper() {
 #[tokio::test]
 async fn api_checkpoint_validates_checkpoint_id() {
     let repo = seed_dashboard_repo();
+    let repo_id = crate::host::devql::resolve_repo_id(repo.path()).expect("resolve repo id");
     let app = build_dashboard_router(test_state(
         repo.path().to_path_buf(),
         ServeMode::HelloWorld,
         repo.path().to_path_buf(),
     ));
 
-    let (status, payload) = request_json(app, "/api/checkpoints/not-an-id").await;
+    let checkpoint_path = format!("/api/checkpoints/{repo_id}/not-an-id");
+    let (status, payload) = request_json(app, &checkpoint_path).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(payload["error"]["code"], "bad_request");
     assert_eq!(
@@ -368,7 +372,7 @@ async fn api_openapi_json_lists_dashboard_paths() {
     assert!(payload["paths"].get("/api/db/health").is_some());
     assert!(
         payload["paths"]
-            .get("/api/checkpoints/{checkpoint_id}")
+            .get("/api/checkpoints/{repo_id}/{checkpoint_id}")
             .is_some()
     );
     assert!(payload["paths"].get("/api/check_bundle_version").is_some());

--- a/bitloops/src/config/store_config_tests/dashboard.rs
+++ b/bitloops/src/config/store_config_tests/dashboard.rs
@@ -25,7 +25,14 @@ fn resolve_dashboard_config_reads_repo_config_via_public_helper() {
 #[test]
 fn dashboard_file_config_load_defaults_when_repo_config_missing() {
     let temp = tempfile::tempdir().expect("temp dir");
-    let _guard = enter_process_state(Some(temp.path()), &[]);
+    let config_root = temp.path().to_string_lossy().to_string();
+    let _guard = enter_process_state(
+        Some(temp.path()),
+        &[(
+            "BITLOOPS_TEST_CONFIG_DIR_OVERRIDE",
+            Some(config_root.as_str()),
+        )],
+    );
 
     assert_eq!(DashboardFileConfig::load(), DashboardFileConfig::default());
     assert_eq!(resolve_dashboard_config(), DashboardFileConfig::default());


### PR DESCRIPTION
## Summary
Changed `GET /api/checkpoints/{checkpoint_id}` to `GET /api/checkpoints/{repo_id}/{checkpoint_id}` so the legacy dashboard API loads checkpoint details from the selected repository instead of implicitly reading from the default repo root. Updated the dashboard API regression tests and OpenAPI path coverage to match the repo-aware route.

## Validation

- [x] I ran the relevant tests locally.
- [x] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

