### PR TITLE
Fixed the CLI-1546 issue by using base64 encoding to handle special

### DIFF
--- a/bitloops/Cargo.lock
+++ b/bitloops/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-axum",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "clap_complete",

--- a/bitloops/Cargo.toml
+++ b/bitloops/Cargo.toml
@@ -28,6 +28,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"
 toml_edit = { version = "0.25", features = ["serde"] }
 regex = "1"
 tree-sitter = "0.26.7"

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -12,7 +12,7 @@ fn slim_scope_headers(repo_root: &Path) -> Vec<(String, String)> {
         ),
         (
             crate::devql_transport::HEADER_SCOPE_REPO_NAME.to_string(),
-            repo.name,
+            crate::devql_transport::encode_scope_header_value(&repo.name),
         ),
         (
             crate::devql_transport::HEADER_SCOPE_REPO_PROVIDER.to_string(),
@@ -20,23 +20,23 @@ fn slim_scope_headers(repo_root: &Path) -> Vec<(String, String)> {
         ),
         (
             crate::devql_transport::HEADER_SCOPE_REPO_ORGANISATION.to_string(),
-            repo.organization,
+            crate::devql_transport::encode_scope_header_value(&repo.organization),
         ),
         (
             crate::devql_transport::HEADER_SCOPE_REPO_IDENTITY.to_string(),
-            repo.identity,
+            crate::devql_transport::encode_scope_header_value(&repo.identity),
         ),
         (
             crate::devql_transport::HEADER_SCOPE_REPO_ROOT.to_string(),
-            repo_root.to_string_lossy().to_string(),
+            crate::devql_transport::encode_scope_header_value(&repo_root.to_string_lossy()),
         ),
         (
             crate::devql_transport::HEADER_SCOPE_BRANCH.to_string(),
-            "main".to_string(),
+            crate::devql_transport::encode_scope_header_value("main"),
         ),
         (
             crate::devql_transport::HEADER_SCOPE_GIT_DIR_RELATIVE_PATH.to_string(),
-            ".git".to_string(),
+            crate::devql_transport::encode_scope_header_value(".git"),
         ),
         (
             crate::devql_transport::HEADER_SCOPE_CONFIG_FINGERPRINT.to_string(),

--- a/bitloops/src/devql_transport.rs
+++ b/bitloops/src/devql_transport.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, anyhow, bail};
 use axum::http::HeaderMap;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use reqwest::RequestBuilder;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -82,29 +83,41 @@ pub(crate) fn attach_slim_cli_scope_headers(
 ) -> RequestBuilder {
     let request = request
         .header(HEADER_SCOPE_REPO_ID, scope.repo.repo_id.as_str())
-        .header(HEADER_SCOPE_REPO_NAME, scope.repo.name.as_str())
+        .header(
+            HEADER_SCOPE_REPO_NAME,
+            encode_scope_header_value(scope.repo.name.as_str()),
+        )
         .header(HEADER_SCOPE_REPO_PROVIDER, scope.repo.provider.as_str())
         .header(
             HEADER_SCOPE_REPO_ORGANISATION,
-            scope.repo.organization.as_str(),
+            encode_scope_header_value(scope.repo.organization.as_str()),
         )
-        .header(HEADER_SCOPE_REPO_IDENTITY, scope.repo.identity.as_str())
+        .header(
+            HEADER_SCOPE_REPO_IDENTITY,
+            encode_scope_header_value(scope.repo.identity.as_str()),
+        )
         .header(
             HEADER_SCOPE_REPO_ROOT,
-            scope.repo_root.to_string_lossy().to_string(),
+            encode_scope_header_value(&scope.repo_root.to_string_lossy()),
         )
-        .header(HEADER_SCOPE_BRANCH, scope.branch_name.as_str())
+        .header(
+            HEADER_SCOPE_BRANCH,
+            encode_scope_header_value(scope.branch_name.as_str()),
+        )
         .header(
             HEADER_SCOPE_CONFIG_FINGERPRINT,
             scope.config_fingerprint.as_str(),
         )
         .header(
             HEADER_SCOPE_GIT_DIR_RELATIVE_PATH,
-            scope.git_dir_relative_path.as_str(),
+            encode_scope_header_value(scope.git_dir_relative_path.as_str()),
         );
 
     match scope.project_path.as_deref() {
-        Some(project_path) => request.header(HEADER_SCOPE_PROJECT_PATH, project_path),
+        Some(project_path) => request.header(
+            HEADER_SCOPE_PROJECT_PATH,
+            encode_scope_header_value(project_path),
+        ),
         None => request,
     }
 }
@@ -112,26 +125,33 @@ pub(crate) fn attach_slim_cli_scope_headers(
 pub(crate) fn parse_slim_cli_scope_headers(
     headers: &HeaderMap,
 ) -> Result<Option<SlimCliRepoScope>> {
-    let Some(repo_root) = header_value(headers, HEADER_SCOPE_REPO_ROOT)? else {
+    let Some(repo_root) = decode_scope_header_value(headers, HEADER_SCOPE_REPO_ROOT)? else {
         return Ok(None);
     };
     let repo_root = PathBuf::from(repo_root);
     let repo = RepoIdentity {
         repo_id: required_header_value(headers, HEADER_SCOPE_REPO_ID)?,
-        name: required_header_value(headers, HEADER_SCOPE_REPO_NAME)?,
+        name: required_decoded_scope_header_value(headers, HEADER_SCOPE_REPO_NAME)?,
         provider: required_header_value(headers, HEADER_SCOPE_REPO_PROVIDER)?,
-        organization: required_header_value(headers, HEADER_SCOPE_REPO_ORGANISATION)?,
-        identity: required_header_value(headers, HEADER_SCOPE_REPO_IDENTITY)?,
+        organization: required_decoded_scope_header_value(headers, HEADER_SCOPE_REPO_ORGANISATION)?,
+        identity: required_decoded_scope_header_value(headers, HEADER_SCOPE_REPO_IDENTITY)?,
     };
 
     Ok(Some(SlimCliRepoScope {
         repo,
         repo_root,
-        branch_name: required_header_value(headers, HEADER_SCOPE_BRANCH)?,
-        project_path: header_value(headers, HEADER_SCOPE_PROJECT_PATH)?,
-        git_dir_relative_path: required_header_value(headers, HEADER_SCOPE_GIT_DIR_RELATIVE_PATH)?,
+        branch_name: required_decoded_scope_header_value(headers, HEADER_SCOPE_BRANCH)?,
+        project_path: decode_scope_header_value(headers, HEADER_SCOPE_PROJECT_PATH)?,
+        git_dir_relative_path: required_decoded_scope_header_value(
+            headers,
+            HEADER_SCOPE_GIT_DIR_RELATIVE_PATH,
+        )?,
         config_fingerprint: required_header_value(headers, HEADER_SCOPE_CONFIG_FINGERPRINT)?,
     }))
+}
+
+pub(crate) fn encode_scope_header_value(input: &str) -> String {
+    URL_SAFE_NO_PAD.encode(input.as_bytes())
 }
 
 pub(crate) fn load_repo_path_registry(path: &Path) -> Result<RepoPathRegistry> {
@@ -273,8 +293,28 @@ fn header_value(headers: &HeaderMap, name: &str) -> Result<Option<String>> {
     Ok(Some(value))
 }
 
+fn decode_scope_header_value(headers: &HeaderMap, name: &str) -> Result<Option<String>> {
+    let Some(value) = header_value(headers, name)? else {
+        return Ok(None);
+    };
+    let bytes = URL_SAFE_NO_PAD
+        .decode(value.as_bytes())
+        .with_context(|| format!("decoding Bitloops DevQL scope header `{name}` from base64url"))?;
+    let decoded = String::from_utf8(bytes)
+        .with_context(|| format!("decoding Bitloops DevQL scope header `{name}` as UTF-8"))?;
+    if decoded.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(decoded))
+}
+
 fn required_header_value(headers: &HeaderMap, name: &str) -> Result<String> {
     header_value(headers, name)?
+        .ok_or_else(|| anyhow!("missing Bitloops DevQL scope header `{name}`"))
+}
+
+fn required_decoded_scope_header_value(headers: &HeaderMap, name: &str) -> Result<String> {
+    decode_scope_header_value(headers, name)?
         .ok_or_else(|| anyhow!("missing Bitloops DevQL scope header `{name}`"))
 }
 
@@ -324,6 +364,8 @@ fn unix_timestamp_now() -> u64 {
 mod tests {
     use super::*;
     use crate::test_support::git_fixtures::{git_ok, init_test_repo};
+    use axum::http::HeaderValue;
+    use reqwest::Client;
     use tempfile::TempDir;
 
     fn canonical_path(path: &Path) -> PathBuf {
@@ -459,6 +501,62 @@ mod tests {
         assert_eq!(
             registry.entries[0].git_dir_relative_path.as_deref(),
             Some(".git")
+        );
+    }
+
+    #[test]
+    fn slim_cli_scope_headers_round_trip_unicode_scope_values() {
+        let scope = SlimCliRepoScope {
+            repo: RepoIdentity {
+                repo_id: "repo-id".to_string(),
+                name: "cafe-dashboard".to_string(),
+                provider: "local".to_string(),
+                organization: "local".to_string(),
+                identity: "local://local/cafe-dashboard".to_string(),
+            },
+            repo_root: PathBuf::from("/tmp/Jack’s MacBook Pro – 2/local-dashboard"),
+            branch_name: "main".to_string(),
+            project_path: Some("packages/café".to_string()),
+            git_dir_relative_path: ".git".to_string(),
+            config_fingerprint: "fingerprint-a".to_string(),
+        };
+
+        let request =
+            attach_slim_cli_scope_headers(Client::new().post("http://127.0.0.1/devql"), &scope)
+                .build()
+                .expect("build request with slim headers");
+
+        let parsed = parse_slim_cli_scope_headers(request.headers())
+            .expect("unicode scope headers should round-trip successfully")
+            .expect("scope headers should be present");
+
+        assert_eq!(parsed.repo_root, scope.repo_root);
+        assert_eq!(parsed.project_path, scope.project_path);
+        assert_eq!(parsed.branch_name, scope.branch_name);
+        assert_eq!(parsed.git_dir_relative_path, scope.git_dir_relative_path);
+        assert_eq!(parsed.config_fingerprint, scope.config_fingerprint);
+        assert_eq!(parsed.repo.repo_id, scope.repo.repo_id);
+        assert_eq!(parsed.repo.name, scope.repo.name);
+        assert_eq!(parsed.repo.provider, scope.repo.provider);
+        assert_eq!(parsed.repo.organization, scope.repo.organization);
+        assert_eq!(parsed.repo.identity, scope.repo.identity);
+    }
+
+    #[test]
+    fn parsing_scope_headers_rejects_invalid_base64url_payload() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HEADER_SCOPE_REPO_ROOT,
+            HeaderValue::from_static("not-base64!"),
+        );
+
+        let err = parse_slim_cli_scope_headers(&headers).expect_err("invalid base64url payload");
+
+        assert!(
+            format!("{err:#}").contains(
+                "decoding Bitloops DevQL scope header `x-bitloops-cli-repo-root` from base64url"
+            ),
+            "unexpected error: {err:#}"
         );
     }
 }


### PR DESCRIPTION
Implemented a strict-cutover fix for `CLI-1546`.

This change makes the slim DevQL transport encode all user-controlled scope header values as `UTF-8 + base64url` on the client and decode them on the server. That keeps the wire format ASCII-safe while preserving Unicode filesystem and repo metadata correctly.

## Encoded headers

- `x-bitloops-cli-repo-name`
- `x-bitloops-cli-repo-organisation`
- `x-bitloops-cli-repo-identity`
- `x-bitloops-cli-repo-root`
- `x-bitloops-cli-branch`
- `x-bitloops-cli-project-path`
- `x-bitloops-cli-git-dir-relative-path`

## Unchanged headers

- `x-bitloops-cli-repo-id`
- `x-bitloops-cli-repo-provider`
- `x-bitloops-cli-config-fingerprint`

## Why this fix

The root cause was that raw filesystem and repo metadata were being transported in HTTP headers. The client could send non-ASCII bytes, but the server decoded headers with `HeaderValue::to_str()`, which only accepts visible ASCII. That caused failures for paths containing characters like `’`, `–`, and `é`.

## Tests

- Added a Unicode scope header round-trip regression test
- Added an invalid base64url payload rejection test
- Updated slim route test helpers to use the new encoded header format

## Validation

- Targeted transport regression tests pass
- Slim GraphQL route test passes with the new encoded header format
