### PR TITLE
Move DevQL schema init to start and remove ingest init flag

### DIFF
--- a/bitloops/src/cli/daemon.rs
+++ b/bitloops/src/cli/daemon.rs
@@ -1,6 +1,6 @@
 use std::io::{self, BufRead, Write};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
 
 use crate::api::DashboardServerConfig;
@@ -137,6 +137,7 @@ async fn run_start_with_io(
     }
     let daemon_config = daemon::resolve_daemon_config(args.config.as_deref())?;
     let config = build_server_config(&args);
+    maybe_initialise_devql_schema_for_start().await?;
 
     if args.until_stopped {
         let state =
@@ -174,6 +175,67 @@ async fn run_start_with_io(
         preflight.startup_telemetry,
     )
     .await
+}
+
+async fn maybe_initialise_devql_schema_for_start() -> Result<()> {
+    let Ok(repo_root) = crate::utils::paths::repo_root() else {
+        return Ok(());
+    };
+
+    #[cfg(test)]
+    if let Some(result) = maybe_execute_start_schema_init_hook(repo_root.as_path()) {
+        return result;
+    }
+
+    let repo = crate::host::devql::resolve_repo_identity(&repo_root)
+        .context("resolving repository identity for `bitloops start`")?;
+    let cfg = crate::host::devql::DevqlConfig::from_env(repo_root.clone(), repo)
+        .context("resolving DevQL config for `bitloops start`")?;
+    crate::host::devql::execute_init_schema(&cfg, "bitloops start")
+        .await
+        .context("initialising DevQL schema during `bitloops start`")?;
+    Ok(())
+}
+
+#[cfg(test)]
+thread_local! {
+    static START_SCHEMA_INIT_HOOK: std::cell::RefCell<Option<std::rc::Rc<StartSchemaInitHook>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+type StartSchemaInitHook = dyn Fn(&std::path::Path) -> Result<()> + 'static;
+
+#[cfg(test)]
+fn with_start_schema_init_hook<T>(
+    hook: impl Fn(&std::path::Path) -> Result<()> + 'static,
+    f: impl FnOnce() -> T,
+) -> T {
+    START_SCHEMA_INIT_HOOK.with(
+        |cell: &std::cell::RefCell<Option<std::rc::Rc<StartSchemaInitHook>>>| {
+            assert!(
+                cell.borrow().is_none(),
+                "start schema init hook already installed"
+            );
+            *cell.borrow_mut() = Some(std::rc::Rc::new(hook));
+        },
+    );
+    let result = f();
+    START_SCHEMA_INIT_HOOK.with(
+        |cell: &std::cell::RefCell<Option<std::rc::Rc<StartSchemaInitHook>>>| {
+            *cell.borrow_mut() = None;
+        },
+    );
+    result
+}
+
+#[cfg(test)]
+fn maybe_execute_start_schema_init_hook(repo_root: &std::path::Path) -> Option<Result<()>> {
+    START_SCHEMA_INIT_HOOK.with(
+        |hook: &std::cell::RefCell<Option<std::rc::Rc<StartSchemaInitHook>>>| {
+            hook.borrow().as_ref().map(|hook| hook(repo_root))
+        },
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -505,10 +567,36 @@ mod tests {
     use super::*;
     use crate::cli::{Cli, Commands};
     use crate::daemon::{DaemonServiceMetadata, DaemonStatusReport, ServiceManagerKind};
+    use crate::test_support::git_fixtures::{git_ok, init_test_repo};
     use crate::test_support::process_state::enter_process_state;
     use clap::Parser;
+    use std::cell::RefCell;
+    use std::fs;
     use std::io::Cursor;
+    use std::path::PathBuf;
+    use std::rc::Rc;
     use tempfile::TempDir;
+
+    fn test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime")
+    }
+
+    fn seed_git_repo() -> TempDir {
+        let dir = TempDir::new().expect("temp dir");
+        let repo_root = dir.path();
+        init_test_repo(repo_root, "main", "Alice", "alice@example.com");
+        fs::write(
+            repo_root.join("src.rs"),
+            "pub fn ready() -> bool { true }\n",
+        )
+        .expect("write seed file");
+        git_ok(repo_root, &["add", "."]);
+        git_ok(repo_root, &["commit", "-m", "seed repo"]);
+        dir
+    }
 
     #[test]
     fn daemon_start_cli_parses_lifecycle_and_server_flags() {
@@ -832,6 +920,65 @@ mod tests {
         assert_eq!(decision.startup_telemetry, Some(false));
         assert!(!rendered.contains("Help us improve Bitloops"));
         assert!(!rendered.contains("Enable anonymous telemetry? [Y/n]"));
+    }
+
+    #[test]
+    fn start_schema_init_is_skipped_outside_repo_context() {
+        let workspace = TempDir::new().expect("temp workspace");
+        let _guard = enter_process_state(Some(workspace.path()), &[]);
+        let hook_called = Rc::new(RefCell::new(false));
+
+        with_start_schema_init_hook(
+            {
+                let hook_called = Rc::clone(&hook_called);
+                move |_repo_root| {
+                    *hook_called.borrow_mut() = true;
+                    Ok(())
+                }
+            },
+            || {
+                test_runtime()
+                    .block_on(maybe_initialise_devql_schema_for_start())
+                    .expect("schema init should be skipped outside a git repo");
+            },
+        );
+
+        assert!(
+            !*hook_called.borrow(),
+            "schema init hook should not run without a detected repository"
+        );
+    }
+
+    #[test]
+    fn start_schema_init_runs_for_detected_repo() {
+        let repo = seed_git_repo();
+        let _guard = enter_process_state(Some(repo.path()), &[]);
+        let captured = Rc::new(RefCell::new(None::<PathBuf>));
+
+        with_start_schema_init_hook(
+            {
+                let captured = Rc::clone(&captured);
+                move |repo_root| {
+                    *captured.borrow_mut() = Some(repo_root.to_path_buf());
+                    Ok(())
+                }
+            },
+            || {
+                test_runtime()
+                    .block_on(maybe_initialise_devql_schema_for_start())
+                    .expect("schema init should run when repo context is available");
+            },
+        );
+
+        let expected_repo_root = repo
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|_| repo.path().to_path_buf());
+        assert_eq!(
+            captured.borrow().as_deref(),
+            Some(expected_repo_root.as_path()),
+            "schema init should target the active repository root"
+        );
     }
 
     #[test]

--- a/bitloops/src/cli/devql.rs
+++ b/bitloops/src/cli/devql.rs
@@ -26,7 +26,7 @@ pub use args::{
     DevqlProjectionArgs, DevqlProjectionCommand, DevqlQueryArgs, DevqlSyncArgs,
 };
 
-pub(crate) const MISSING_SUBCOMMAND_MESSAGE: &str = "missing subcommand. Use one of: `bitloops devql init`, `bitloops devql ingest`, `bitloops devql sync`, `bitloops devql projection checkpoint-file-snapshots`, `bitloops devql query`, `bitloops devql connection-status`, `bitloops devql packs`, `bitloops devql knowledge add`, `bitloops devql knowledge associate`, `bitloops devql knowledge refresh`, `bitloops devql knowledge versions`";
+pub(crate) const MISSING_SUBCOMMAND_MESSAGE: &str = "missing subcommand. Use one of: `bitloops devql ingest`, `bitloops devql sync`, `bitloops devql projection checkpoint-file-snapshots`, `bitloops devql query`, `bitloops devql connection-status`, `bitloops devql packs`, `bitloops devql knowledge add`, `bitloops devql knowledge associate`, `bitloops devql knowledge refresh`, `bitloops devql knowledge versions`";
 
 pub async fn run(args: DevqlArgs) -> Result<()> {
     let Some(command) = args.command else {
@@ -69,7 +69,7 @@ pub async fn run(args: DevqlArgs) -> Result<()> {
     match command {
         DevqlCommand::Init(_) => graphql::run_init_via_graphql(&scope).await,
         DevqlCommand::Ingest(args) => {
-            graphql::run_ingest_via_graphql(&scope, args.init, args.max_checkpoints).await
+            graphql::run_ingest_via_graphql(&scope, args.max_checkpoints).await
         }
         DevqlCommand::Sync(args) => {
             let mode = if args.repair {

--- a/bitloops/src/cli/devql/args.rs
+++ b/bitloops/src/cli/devql/args.rs
@@ -8,7 +8,8 @@ pub struct DevqlArgs {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum DevqlCommand {
-    /// Create schema for configured relational/events backends.
+    /// Internal: create schema for configured relational/events backends.
+    #[command(hide = true)]
     Init(DevqlInitArgs),
     /// Ingest checkpoint/events and relational artefacts for configured backends.
     Ingest(DevqlIngestArgs),
@@ -31,10 +32,6 @@ pub struct DevqlInitArgs {}
 
 #[derive(Args, Debug, Clone)]
 pub struct DevqlIngestArgs {
-    /// Bootstrap tables before ingestion.
-    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
-    pub init: bool,
-
     /// Limit checkpoints processed (newest-first).
     #[arg(long, default_value_t = 500)]
     pub max_checkpoints: usize,

--- a/bitloops/src/cli/devql/graphql.rs
+++ b/bitloops/src/cli/devql/graphql.rs
@@ -87,7 +87,6 @@ pub(super) async fn run_init_via_graphql(scope: &SlimCliRepoScope) -> Result<()>
 
 pub(super) async fn run_ingest_via_graphql(
     scope: &SlimCliRepoScope,
-    init: bool,
     max_checkpoints: usize,
 ) -> Result<()> {
     let response: IngestMutationData = execute_devql_graphql(
@@ -95,7 +94,7 @@ pub(super) async fn run_ingest_via_graphql(
         INGEST_MUTATION,
         json!({
             "input": {
-                "init": init,
+                "init": false,
                 "maxCheckpoints": max_checkpoints,
             }
         }),

--- a/bitloops/src/cli/devql/tests.rs
+++ b/bitloops/src/cli/devql/tests.rs
@@ -121,8 +121,16 @@ fn devql_cli_parses_ingest_defaults() {
         panic!("expected devql ingest command");
     };
 
-    assert!(ingest.init);
     assert_eq!(ingest.max_checkpoints, 500);
+}
+
+#[test]
+fn devql_cli_rejects_removed_ingest_init_flag() {
+    let err = match Cli::try_parse_from(["bitloops", "devql", "ingest", "--init=false"]) {
+        Ok(_) => panic!("ingest --init flag should be rejected"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("--init"));
 }
 
 #[test]
@@ -178,9 +186,23 @@ fn devql_cli_parses_sync_modes() {
 #[test]
 fn devql_cli_rejects_conflicting_sync_modes() {
     let cases = vec![
-        vec!["bitloops", "devql", "sync", "--full", "--paths", "src/lib.rs"],
+        vec![
+            "bitloops",
+            "devql",
+            "sync",
+            "--full",
+            "--paths",
+            "src/lib.rs",
+        ],
         vec!["bitloops", "devql", "sync", "--full", "--repair"],
-        vec!["bitloops", "devql", "sync", "--paths", "src/lib.rs", "--repair"],
+        vec![
+            "bitloops",
+            "devql",
+            "sync",
+            "--paths",
+            "src/lib.rs",
+            "--repair",
+        ],
         vec![
             "bitloops",
             "devql",
@@ -521,7 +543,6 @@ fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
             test_runtime()
                 .block_on(run(DevqlArgs {
                     command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                        init: false,
                         max_checkpoints: 42,
                     })),
                 }))
@@ -552,7 +573,6 @@ fn devql_run_ingest_requires_running_daemon() {
         let err = test_runtime()
             .block_on(run(DevqlArgs {
                 command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                    init: true,
                     max_checkpoints: 500,
                 })),
             }))

--- a/bitloops/src/host/devql/tests/devql_tests.rs
+++ b/bitloops/src/host/devql/tests/devql_tests.rs
@@ -455,7 +455,6 @@ fn devql_cli_parses_ingest_defaults() {
         panic!("expected devql ingest command");
     };
 
-    assert!(ingest.init);
     assert_eq!(ingest.max_checkpoints, 500);
 }
 

--- a/bitloops/src/host/devql/tests/devql_tests/identity_and_schema.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/identity_and_schema.rs
@@ -262,18 +262,13 @@ fn incoming_revision_is_newer_rejects_older_commits_and_uses_commit_sha_as_tiebr
 }
 
 #[test]
-fn devql_ingest_accepts_explicit_false_for_init() {
-    let parsed = crate::cli::Cli::try_parse_from(["bitloops", "devql", "ingest", "--init=false"])
-        .expect("devql ingest should parse with explicit boolean value");
-
-    let Some(crate::cli::Commands::Devql(args)) = parsed.command else {
-        panic!("expected devql command");
+fn devql_ingest_rejects_removed_init_flag() {
+    let err = match crate::cli::Cli::try_parse_from(["bitloops", "devql", "ingest", "--init=false"])
+    {
+        Ok(_) => panic!("devql ingest --init flag should be rejected"),
+        Err(err) => err,
     };
-    let Some(DevqlCommand::Ingest(ingest)) = args.command else {
-        panic!("expected devql ingest command");
-    };
-
-    assert!(!ingest.init);
+    assert!(err.to_string().contains("--init"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

