### PR TITLE
Move DevQL schema migration process to daemon bootstrap

### DIFF
--- a/bitloops/schema.graphql
+++ b/bitloops/schema.graphql
@@ -294,13 +294,11 @@ type HealthStatus {
 }
 
 input IngestInput {
-	init: Boolean! = true
 	maxCheckpoints: Int! = 500
 }
 
 type IngestResult {
 	success: Boolean!
-	initRequested: Boolean!
 	checkpointsProcessed: Int!
 	eventsInserted: Int!
 	artefactsUpserted: Int!

--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -294,13 +294,11 @@ type HealthStatus {
 }
 
 input IngestInput {
-	init: Boolean! = true
 	maxCheckpoints: Int! = 500
 }
 
 type IngestResult {
 	success: Boolean!
-	initRequested: Boolean!
 	checkpointsProcessed: Int!
 	eventsInserted: Int!
 	artefactsUpserted: Int!

--- a/bitloops/src/api/dashboard_runtime.rs
+++ b/bitloops/src/api/dashboard_runtime.rs
@@ -140,17 +140,16 @@ pub(super) async fn run(
     let repo_root = config_root.clone();
 
     // Bootstrap DevQL schema on daemon start (idempotent).
-    if let Ok(repo_identity) = crate::host::devql::resolve_repo_identity(&repo_root) {
-        if let Err(err) = crate::host::devql::ensure_relational_and_events_schema(
+    if let Ok(repo_identity) = crate::host::devql::resolve_repo_identity(&repo_root)
+        && let Err(err) = crate::host::devql::ensure_relational_and_events_schema(
             &config_root,
             &repo_root,
             repo_identity,
         )
         .await
-        {
-            log::warn!("DevQL schema bootstrap on daemon start failed: {err:#}");
-            startup_warnings.push(format!("Warning: DevQL schema bootstrap failed: {err:#}"));
-        }
+    {
+        log::warn!("DevQL schema bootstrap on daemon start failed: {err:#}");
+        startup_warnings.push(format!("Warning: DevQL schema bootstrap failed: {err:#}"));
     }
 
     if matches!(startup_mode, DashboardStartupMode::SlowProbe)

--- a/bitloops/src/api/dashboard_runtime.rs
+++ b/bitloops/src/api/dashboard_runtime.rs
@@ -139,6 +139,20 @@ pub(super) async fn run(
     };
     let repo_root = config_root.clone();
 
+    // Bootstrap DevQL schema on daemon start (idempotent).
+    if let Ok(repo_identity) = crate::host::devql::resolve_repo_identity(&repo_root) {
+        if let Err(err) = crate::host::devql::ensure_relational_and_events_schema(
+            &config_root,
+            &repo_root,
+            repo_identity,
+        )
+        .await
+        {
+            log::warn!("DevQL schema bootstrap on daemon start failed: {err:#}");
+            startup_warnings.push(format!("Warning: DevQL schema bootstrap failed: {err:#}"));
+        }
+    }
+
     if matches!(startup_mode, DashboardStartupMode::SlowProbe)
         && discovery.tls
         && let Err(err) = persist_local_dashboard_discovery(&repo_root, discovery)

--- a/bitloops/src/api/tests/devql_mutations_and_health.rs
+++ b/bitloops/src/api/tests/devql_mutations_and_health.rs
@@ -197,9 +197,8 @@ async fn devql_mutations_initialise_schema_and_ingest_with_typed_results() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest(input: { init: true, maxCheckpoints: 500 }) {
+              ingest(input: { maxCheckpoints: 500 }) {
                 success
-                initRequested
                 checkpointsProcessed
                 eventsInserted
                 artefactsUpserted
@@ -227,7 +226,6 @@ async fn devql_mutations_initialise_schema_and_ingest_with_typed_results() {
         .into_json()
         .expect("graphql data to json");
     assert_eq!(ingest_json["ingest"]["success"], true);
-    assert_eq!(ingest_json["ingest"]["initRequested"], true);
     assert_eq!(ingest_json["ingest"]["checkpointsProcessed"], 0);
     assert_eq!(ingest_json["ingest"]["eventsInserted"], 0);
     assert_eq!(ingest_json["ingest"]["artefactsUpserted"], 0);
@@ -247,6 +245,75 @@ async fn devql_mutations_initialise_schema_and_ingest_with_typed_results() {
 }
 
 #[tokio::test]
+async fn daemon_bootstrap_creates_devql_schema_tables() {
+    let repo = seed_graphql_mutation_repo();
+    let _guard = enter_process_state(Some(repo.path()), &[]);
+    let sqlite_path = checkpoint_sqlite_path(repo.path());
+    seed_repository_catalog_row(repo.path(), SEEDED_REPO_NAME, "main");
+    seed_duckdb_events(repo.path(), &[]);
+
+    let daemon = tokio::spawn(crate::api::run_with_options(
+        crate::api::DashboardServerConfig {
+            host: Some("127.0.0.1".to_string()),
+            port: 0,
+            no_open: true,
+            force_http: true,
+            recheck_local_dashboard_net: false,
+            bundle_dir: None,
+        },
+        crate::api::DashboardRuntimeOptions {
+            ready_subject: "Test daemon".to_string(),
+            print_ready_banner: false,
+            open_browser: false,
+            shutdown_message: None,
+            on_ready: None,
+            on_shutdown: None,
+            config_root: Some(repo.path().to_path_buf()),
+            repo_registry_path: None,
+        },
+    ));
+
+    let wait = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if sqlite_path.exists() {
+                let conn = rusqlite::Connection::open(&sqlite_path).expect("open sqlite");
+                let required_tables = [
+                    "repo_sync_state",
+                    "current_file_state",
+                    "artefacts_current",
+                    "content_cache",
+                ];
+                let all_exist = required_tables.iter().all(|table| {
+                    conn.query_row(
+                        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                        [*table],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map(|count| count == 1)
+                    .unwrap_or(false)
+                });
+                if all_exist {
+                    break;
+                }
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    if wait.is_err() && daemon.is_finished() {
+        let result = daemon.await.expect("daemon join");
+        panic!("daemon exited early: {result:#?}");
+    }
+
+    daemon.abort();
+    let _ = daemon.await;
+
+    assert!(wait.is_ok(), "schema tables were not bootstrapped in time");
+}
+
+#[tokio::test]
 async fn devql_mutations_report_validation_and_backend_errors() {
     let repo = seed_graphql_mutation_repo();
     let _guard = enter_process_state(Some(repo.path()), &[]);
@@ -256,7 +323,7 @@ async fn devql_mutations_report_validation_and_backend_errors() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest(input: { init: true, maxCheckpoints: -1 }) {
+              ingest(input: { maxCheckpoints: -1 }) {
                 success
               }
             }
@@ -285,7 +352,7 @@ async fn devql_mutations_report_validation_and_backend_errors() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest(input: { init: false, maxCheckpoints: 1 }) {
+              ingest(input: { maxCheckpoints: 1 }) {
                 success
               }
             }
@@ -654,7 +721,7 @@ async fn devql_global_repo_mutations_require_slim_cli_scope() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest(input: { init: true, maxCheckpoints: 1 }) {
+              ingest(input: { maxCheckpoints: 1 }) {
                 success
               }
             }

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -1086,11 +1086,28 @@ async fn devql_ingest_mutation_publishes_progress_and_checkpoint_events_to_subsc
     let mut checkpoint_rx = context.subscriptions().subscribe_checkpoints();
     let schema = crate::graphql::build_slim_schema(context);
 
+    let init_response = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            mutation {
+              initSchema {
+                success
+              }
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        init_response.errors.is_empty(),
+        "graphql errors: {:?}",
+        init_response.errors
+    );
+
     let response = schema
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest(input: { init: true, maxCheckpoints: 1 }) {
+              ingest(input: { maxCheckpoints: 1 }) {
                 success
                 checkpointsProcessed
                 temporaryRowsPromoted

--- a/bitloops/src/cli/devql.rs
+++ b/bitloops/src/cli/devql.rs
@@ -3,9 +3,6 @@ use serde_json::{Value, json};
 use std::time::Instant;
 
 use crate::capability_packs::knowledge::run_knowledge_versions_via_host;
-use crate::config::{
-    SemanticCloneEmbeddingMode, SemanticSummaryMode, resolve_embedding_capability_config_for_repo,
-};
 use crate::devql_transport::{SlimCliRepoScope, discover_slim_cli_repo_scope};
 use crate::host::devql::{
     CheckpointFileSnapshotBackfillOptions, DevqlConfig, GraphqlCompileMode, ParsedDevqlQuery,
@@ -68,24 +65,10 @@ pub async fn run(args: DevqlArgs) -> Result<()> {
     }
 
     let cfg = DevqlConfig::from_env(repo_root, repo)?;
-    let enrichment_capability = resolve_embedding_capability_config_for_repo(&cfg.repo_root);
-    let enrichment_enabled = enrichment_capability.semantic_clones.summary_mode
-        != SemanticSummaryMode::Off
-        || (enrichment_capability.semantic_clones.embedding_mode
-            != SemanticCloneEmbeddingMode::Off
-            && enrichment_capability
-                .semantic_clones
-                .embedding_profile
-                .is_some());
-
     match command {
         DevqlCommand::Init(_) => graphql::run_init_via_graphql(&scope).await,
         DevqlCommand::Ingest(args) => {
-            if enrichment_enabled {
-                graphql::run_ingest_via_graphql(&scope, args.init, args.max_checkpoints).await
-            } else {
-                crate::host::devql::run_ingest(&cfg, args.init, args.max_checkpoints).await
-            }
+            graphql::run_ingest_via_graphql(&scope, args.max_checkpoints).await
         }
         DevqlCommand::Sync(args) => {
             let mode = if args.validate {

--- a/bitloops/src/cli/devql/args.rs
+++ b/bitloops/src/cli/devql/args.rs
@@ -31,10 +31,6 @@ pub struct DevqlInitArgs {}
 
 #[derive(Args, Debug, Clone)]
 pub struct DevqlIngestArgs {
-    /// Bootstrap tables before ingestion.
-    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
-    pub init: bool,
-
     /// Limit checkpoints processed (newest-first).
     #[arg(long, default_value_t = 500)]
     pub max_checkpoints: usize,

--- a/bitloops/src/cli/devql/graphql.rs
+++ b/bitloops/src/cli/devql/graphql.rs
@@ -38,7 +38,6 @@ const INGEST_MUTATION: &str = r#"
     mutation Ingest($input: IngestInput!) {
       ingest(input: $input) {
         success
-        initRequested
         checkpointsProcessed
         eventsInserted
         artefactsUpserted
@@ -100,7 +99,6 @@ pub(super) async fn run_init_via_graphql(scope: &SlimCliRepoScope) -> Result<()>
 
 pub(super) async fn run_ingest_via_graphql(
     scope: &SlimCliRepoScope,
-    init: bool,
     max_checkpoints: usize,
 ) -> Result<()> {
     ensure_daemon_available_for_ingest(scope.repo_root.as_path()).await?;
@@ -109,7 +107,6 @@ pub(super) async fn run_ingest_via_graphql(
         INGEST_MUTATION,
         json!({
             "input": {
-                "init": init,
                 "maxCheckpoints": max_checkpoints,
             }
         }),

--- a/bitloops/src/cli/devql/tests.rs
+++ b/bitloops/src/cli/devql/tests.rs
@@ -115,7 +115,6 @@ fn devql_cli_parses_ingest_defaults() {
         panic!("expected devql ingest command");
     };
 
-    assert!(ingest.init);
     assert_eq!(ingest.max_checkpoints, 500);
 }
 
@@ -614,7 +613,6 @@ fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
                         Ok(json!({
                             "ingest": {
                                 "success": true,
-                                "initRequested": false,
                                 "checkpointsProcessed": 2,
                                 "eventsInserted": 3,
                                 "artefactsUpserted": 5,
@@ -634,7 +632,6 @@ fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
                     test_runtime()
                         .block_on(run(DevqlArgs {
                             command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                                init: false,
                                 max_checkpoints: 42,
                             })),
                         }))
@@ -653,7 +650,6 @@ fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
         variables,
         json!({
             "input": {
-                "init": false,
                 "maxCheckpoints": 42
             }
         })
@@ -689,7 +685,6 @@ fn devql_run_ingest_bootstraps_daemon_when_needed() {
                         Ok(json!({
                             "ingest": {
                                 "success": true,
-                                "initRequested": true,
                                 "checkpointsProcessed": 0,
                                 "eventsInserted": 0,
                                 "artefactsUpserted": 0,
@@ -709,7 +704,6 @@ fn devql_run_ingest_bootstraps_daemon_when_needed() {
                     test_runtime()
                         .block_on(run(DevqlArgs {
                             command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                                init: true,
                                 max_checkpoints: 500,
                             })),
                         }))
@@ -730,7 +724,6 @@ fn devql_run_ingest_bootstraps_daemon_when_needed() {
         variables,
         json!({
             "input": {
-                "init": true,
                 "maxCheckpoints": 500
             }
         })
@@ -738,7 +731,7 @@ fn devql_run_ingest_bootstraps_daemon_when_needed() {
 }
 
 #[test]
-fn devql_run_ingest_stays_local_when_enrichment_is_disabled() {
+fn devql_run_ingest_uses_graphql_when_enrichment_is_disabled() {
     let repo = seed_devql_cli_repo();
     fs::write(
         repo.path()
@@ -759,46 +752,59 @@ embedding_mode = "off"
 "#,
     )
     .expect("write deterministic-only config");
+    let _guard = enter_process_state(Some(repo.path()), &[]);
     let graphql_calls = Rc::new(RefCell::new(0usize));
-    {
-        let _guard = enter_process_state(Some(repo.path()), &[]);
+    let bootstrap_calls = Rc::new(RefCell::new(0usize));
 
-        with_graphql_executor_hook(
-            {
-                let graphql_calls = Rc::clone(&graphql_calls);
-                move |_repo_root: &std::path::Path, _query: &str, _variables: &serde_json::Value| {
-                    *graphql_calls.borrow_mut() += 1;
-                    panic!("graphql should not be used when enrichment is disabled");
-                }
-            },
-            || {
-                test_runtime()
-                    .block_on(run(DevqlArgs {
-                        command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                            init: true,
-                            max_checkpoints: 25,
-                        })),
-                    }))
-                    .expect("local deterministic ingest should succeed");
-            },
-        );
-    }
-
-    assert_eq!(*graphql_calls.borrow(), 0);
-    assert!(
-        sqlite_path_for_repo(repo.path()).exists(),
-        "local ingest should initialize the relational database",
+    super::graphql::with_ingest_daemon_bootstrap_hook(
+        {
+            let bootstrap_calls = Rc::clone(&bootstrap_calls);
+            move |_repo_root: &std::path::Path| {
+                *bootstrap_calls.borrow_mut() += 1;
+                Ok(())
+            }
+        },
+        || {
+            with_graphql_executor_hook(
+                {
+                    let graphql_calls = Rc::clone(&graphql_calls);
+                    move |_repo_root: &std::path::Path,
+                          _query: &str,
+                          _variables: &serde_json::Value| {
+                        *graphql_calls.borrow_mut() += 1;
+                        Ok(json!({
+                            "ingest": {
+                                "success": true,
+                                "checkpointsProcessed": 0,
+                                "eventsInserted": 0,
+                                "artefactsUpserted": 0,
+                                "checkpointsWithoutCommit": 0,
+                                "temporaryRowsPromoted": 0,
+                                "semanticFeatureRowsUpserted": 0,
+                                "semanticFeatureRowsSkipped": 0,
+                                "symbolEmbeddingRowsUpserted": 0,
+                                "symbolEmbeddingRowsSkipped": 0,
+                                "symbolCloneEdgesUpserted": 0,
+                                "symbolCloneSourcesScored": 0
+                            }
+                        }))
+                    }
+                },
+                || {
+                    test_runtime()
+                        .block_on(run(DevqlArgs {
+                            command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
+                                max_checkpoints: 25,
+                            })),
+                        }))
+                        .expect("deterministic-only ingest should execute via GraphQL");
+                },
+            );
+        },
     );
-    with_isolated_daemon_state(repo.path(), || {
-        test_runtime()
-            .block_on(run(DevqlArgs {
-                command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                    init: true,
-                    max_checkpoints: 500,
-                })),
-            }))
-            .expect("deterministic-only ingest should stay local without a daemon");
-    });
+
+    assert_eq!(*bootstrap_calls.borrow(), 1);
+    assert_eq!(*graphql_calls.borrow(), 1);
 }
 
 #[test]

--- a/bitloops/src/graphql/mutation_root.rs
+++ b/bitloops/src/graphql/mutation_root.rs
@@ -13,8 +13,6 @@ pub struct MutationRoot;
 
 #[derive(Debug, Clone, InputObject)]
 pub struct IngestInput {
-    #[graphql(default = true)]
-    pub init: bool,
     #[graphql(default = 500)]
     pub max_checkpoints: i32,
 }
@@ -66,7 +64,6 @@ impl From<crate::host::devql::InitSchemaSummary> for InitSchemaResult {
 #[derive(Debug, Clone, PartialEq, Eq, SimpleObject)]
 pub struct IngestResult {
     pub success: bool,
-    pub init_requested: bool,
     pub checkpoints_processed: i32,
     pub events_inserted: i32,
     pub artefacts_upserted: i32,
@@ -84,7 +81,6 @@ impl From<crate::host::devql::IngestionCounters> for IngestResult {
     fn from(value: crate::host::devql::IngestionCounters) -> Self {
         Self {
             success: value.success,
-            init_requested: value.init_requested,
             checkpoints_processed: to_graphql_count(value.checkpoints_processed),
             events_inserted: to_graphql_count(value.events_inserted),
             artefacts_upserted: to_graphql_count(value.artefacts_upserted),
@@ -253,7 +249,6 @@ impl MutationRoot {
         let observer = GraphqlIngestionObserver::new(context);
         let summary = crate::host::devql::execute_ingest_with_observer(
             &cfg,
-            input.init,
             input.max_checkpoints as usize,
             Some(&observer),
             Some(crate::daemon::shared_enrichment_coordinator()),

--- a/bitloops/src/host/devql.rs
+++ b/bitloops/src/host/devql.rs
@@ -572,6 +572,28 @@ async fn initialise_devql_schema_for_command(
     ))
 }
 
+/// Ensures all DevQL relational and events schemas are up to date.
+/// Idempotent and safe to call on every daemon start.
+pub async fn ensure_relational_and_events_schema(
+    config_root: &Path,
+    repo_root: &Path,
+    repo: RepoIdentity,
+) -> Result<()> {
+    let backends = resolve_store_backend_config_for_repo(config_root)
+        .context("resolving DevQL backend config for schema bootstrap")?;
+    let cfg = DevqlConfig::from_roots(config_root.to_path_buf(), repo_root.to_path_buf(), repo)?;
+    let relational =
+        RelationalStorage::connect(&cfg, &backends.relational, "daemon schema bootstrap").await?;
+
+    if backends.events.has_clickhouse() {
+        init_clickhouse_schema(&cfg).await?;
+    } else {
+        init_duckdb_schema(repo_root, &backends.events).await?;
+    }
+    init_relational_schema(&cfg, &relational).await?;
+    Ok(())
+}
+
 pub(crate) async fn execute_init_schema(
     cfg: &DevqlConfig,
     command: &str,

--- a/bitloops/src/host/devql/commands_ingest.rs
+++ b/bitloops/src/host/devql/commands_ingest.rs
@@ -1,31 +1,26 @@
 use super::*;
 use crate::config::{SemanticCloneEmbeddingMode, SemanticSummaryMode};
 
-pub async fn run_ingest(cfg: &DevqlConfig, init: bool, max_checkpoints: usize) -> Result<()> {
-    let summary = execute_ingest(cfg, init, max_checkpoints).await?;
+pub async fn run_ingest(cfg: &DevqlConfig, max_checkpoints: usize) -> Result<()> {
+    let summary = execute_ingest(cfg, max_checkpoints).await?;
     println!("{}", format_ingestion_summary(&summary));
     Ok(())
 }
 
 pub(crate) async fn execute_ingest(
     cfg: &DevqlConfig,
-    init: bool,
     max_checkpoints: usize,
 ) -> Result<IngestionCounters> {
-    execute_ingest_with_observer(cfg, init, max_checkpoints, None, None).await
+    execute_ingest_with_observer(cfg, max_checkpoints, None, None).await
 }
 
 pub(crate) async fn execute_ingest_with_observer(
     cfg: &DevqlConfig,
-    init: bool,
     max_checkpoints: usize,
     observer: Option<&dyn IngestionObserver>,
     enrichment: Option<Arc<crate::daemon::EnrichmentCoordinator>>,
 ) -> Result<IngestionCounters> {
-    let mut counters = IngestionCounters {
-        init_requested: init,
-        ..IngestionCounters::default()
-    };
+    let mut counters = IngestionCounters::default();
     let mut checkpoints_total = 0usize;
     let mut checkpoints_processed = 0usize;
     emit_progress(
@@ -85,15 +80,6 @@ pub(crate) async fn execute_ingest_with_observer(
     } else {
         None
     };
-    if init {
-        if backends.events.has_clickhouse() {
-            init_clickhouse_schema(cfg).await?;
-        } else {
-            init_duckdb_schema(&cfg.repo_root, &backends.events).await?;
-        }
-        init_relational_schema(cfg, &relational).await?;
-    }
-
     ensure_repository_row(cfg, &relational).await?;
 
     let mut checkpoints = list_committed(&cfg.repo_root)?;

--- a/bitloops/src/host/devql/commands_sync.rs
+++ b/bitloops/src/host/devql/commands_sync.rs
@@ -727,6 +727,8 @@ fn determine_retention_class(desired: &sync::types::DesiredFileState) -> &'stati
 }
 
 fn is_missing_sync_schema_error(err: &anyhow::Error) -> bool {
+    // Temporary safeguard while daemon-start schema bootstrap rolls out across workflows.
+    // Keep this fallback so sync can still emit a direct remediation hint on legacy setups.
     let message = format!("{err:#}").to_ascii_lowercase();
     let missing_table_error = message.contains("no such table")
         || (message.contains("relation") && message.contains("does not exist"))

--- a/bitloops/src/host/devql/ingestion/types.rs
+++ b/bitloops/src/host/devql/ingestion/types.rs
@@ -6,7 +6,6 @@ use crate::host::checkpoints::strategy::manual_commit::CommittedInfo;
 #[serde(rename_all = "camelCase")]
 pub(crate) struct IngestionCounters {
     pub(crate) success: bool,
-    pub(crate) init_requested: bool,
     pub(crate) checkpoints_processed: usize,
     pub(crate) events_inserted: usize,
     pub(crate) artefacts_upserted: usize,

--- a/bitloops/src/host/devql/tests/devql_tests.rs
+++ b/bitloops/src/host/devql/tests/devql_tests.rs
@@ -463,7 +463,6 @@ fn devql_cli_parses_ingest_defaults() {
         panic!("expected devql ingest command");
     };
 
-    assert!(ingest.init);
     assert_eq!(ingest.max_checkpoints, 500);
 }
 

--- a/bitloops/src/host/devql/tests/devql_tests/identity_and_schema.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/identity_and_schema.rs
@@ -261,18 +261,17 @@ fn incoming_revision_is_newer_rejects_older_commits_and_uses_commit_sha_as_tiebr
 }
 
 #[test]
-fn devql_ingest_accepts_explicit_false_for_init() {
-    let parsed = crate::cli::Cli::try_parse_from(["bitloops", "devql", "ingest", "--init=false"])
-        .expect("devql ingest should parse with explicit boolean value");
-
-    let Some(crate::cli::Commands::Devql(args)) = parsed.command else {
-        panic!("expected devql command");
-    };
-    let Some(DevqlCommand::Ingest(ingest)) = args.command else {
-        panic!("expected devql ingest command");
+fn devql_ingest_rejects_removed_init_flag() {
+    let err = match crate::cli::Cli::try_parse_from(["bitloops", "devql", "ingest", "--init=false"])
+    {
+        Ok(_) => panic!("devql ingest should reject removed --init flag"),
+        Err(err) => err,
     };
 
-    assert!(!ingest.init);
+    assert!(
+        err.to_string().contains("--init"),
+        "expected clap error to mention --init, got: {err}"
+    );
 }
 
 #[test]

--- a/documentation/docs/getting-started/quickstart.md
+++ b/documentation/docs/getting-started/quickstart.md
@@ -85,7 +85,7 @@ bitloops start --until-stopped
 
 ## 6. Query And Ingest
 
-Initial project bootstrap already initialises the schema. You can then ingest and query:
+The daemon automatically initialises the DevQL schema on startup. You can ingest and query immediately:
 
 ```bash
 bitloops devql ingest
@@ -93,8 +93,6 @@ bitloops devql query "files changed last 7 days"
 ```
 
 ## 7. Sync Current State
-
-`bitloops devql init` must have run at least once for schema bootstrap; this bootstrap step will be automated for all DevQL commands soon.
 
 When you want to reconcile `artefacts_current`/`artefact_edges_current` with the current workspace:
 


### PR DESCRIPTION
## Summary

The changes refactor the DevQL ingestion process by removing the unnecessary `init` flag from the ingestion input and ensuring that the schema is automatically bootstrapped when the daemon starts. This simplifies the ingestion command and enhances the overall workflow.

## Validation

- [x] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

