### PR TITLE
Move sync to daemon execution context

### DIFF
--- a/bitloops/schema.graphql
+++ b/bitloops/schema.graphql
@@ -462,6 +462,7 @@ type MutationRoot {
 	updateCliTelemetryConsent(cliVersion: String!, telemetry: Boolean): UpdateCliTelemetryConsentResult!
 	initSchema: InitSchemaResult!
 	ingest(input: IngestInput!): IngestResult!
+	sync(input: SyncInput!): SyncResult!
 	bootstrapProject(skipBaseline: Boolean! = false): InitSchemaResult!
 	addKnowledge(input: AddKnowledgeInput!): AddKnowledgeResult!
 	associateKnowledge(input: AssociateKnowledgeInput!): AssociateKnowledgeResult!
@@ -536,6 +537,68 @@ enum SaveSelector {
 type SubscriptionRoot {
 	checkpointIngested(repoName: String!): Checkpoint!
 	ingestionProgress(repoName: String!): IngestionProgressEvent!
+}
+
+input SyncInput {
+	"""
+	Run a full workspace reconciliation.
+	"""
+	full: Boolean! = false
+	"""
+	Reconcile only the specified workspace paths (comma-delimited values accepted).
+	"""
+	paths: [String!] = null
+	"""
+	Rebuild sync state from the current workspace, ignoring stored manifest trust.
+	"""
+	repair: Boolean! = false
+	"""
+	Validate current-state tables against a full read-only workspace reconciliation.
+	"""
+	validate: Boolean! = false
+}
+
+type SyncResult {
+	success: Boolean!
+	mode: String!
+	parserVersion: String!
+	extractorVersion: String!
+	activeBranch: String
+	headCommitSha: String
+	headTreeSha: String
+	pathsUnchanged: Int!
+	pathsAdded: Int!
+	pathsChanged: Int!
+	pathsRemoved: Int!
+	cacheHits: Int!
+	cacheMisses: Int!
+	parseErrors: Int!
+	validation: SyncValidationResult
+}
+
+type SyncValidationFileDriftResult {
+	path: String!
+	missingArtefacts: Int!
+	staleArtefacts: Int!
+	mismatchedArtefacts: Int!
+	missingEdges: Int!
+	staleEdges: Int!
+	mismatchedEdges: Int!
+}
+
+type SyncValidationResult {
+	valid: Boolean!
+	expectedArtefacts: Int!
+	actualArtefacts: Int!
+	expectedEdges: Int!
+	actualEdges: Int!
+	missingArtefacts: Int!
+	staleArtefacts: Int!
+	mismatchedArtefacts: Int!
+	missingEdges: Int!
+	staleEdges: Int!
+	mismatchedEdges: Int!
+	filesWithDrift: [SyncValidationFileDriftResult!]!
 }
 
 type TelemetryEvent {

--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -462,6 +462,7 @@ type MutationRoot {
 	updateCliTelemetryConsent(cliVersion: String!, telemetry: Boolean): UpdateCliTelemetryConsentResult!
 	initSchema: InitSchemaResult!
 	ingest(input: IngestInput!): IngestResult!
+	sync(input: SyncInput!): SyncResult!
 	bootstrapProject(skipBaseline: Boolean! = false): InitSchemaResult!
 	addKnowledge(input: AddKnowledgeInput!): AddKnowledgeResult!
 	associateKnowledge(input: AssociateKnowledgeInput!): AssociateKnowledgeResult!
@@ -531,6 +532,68 @@ type SlimQueryRoot {
 type SlimSubscriptionRoot {
 	checkpointIngested: Checkpoint!
 	ingestionProgress: IngestionProgressEvent!
+}
+
+input SyncInput {
+	"""
+	Run a full workspace reconciliation.
+	"""
+	full: Boolean! = false
+	"""
+	Reconcile only the specified workspace paths (comma-delimited values accepted).
+	"""
+	paths: [String!] = null
+	"""
+	Rebuild sync state from the current workspace, ignoring stored manifest trust.
+	"""
+	repair: Boolean! = false
+	"""
+	Validate current-state tables against a full read-only workspace reconciliation.
+	"""
+	validate: Boolean! = false
+}
+
+type SyncResult {
+	success: Boolean!
+	mode: String!
+	parserVersion: String!
+	extractorVersion: String!
+	activeBranch: String
+	headCommitSha: String
+	headTreeSha: String
+	pathsUnchanged: Int!
+	pathsAdded: Int!
+	pathsChanged: Int!
+	pathsRemoved: Int!
+	cacheHits: Int!
+	cacheMisses: Int!
+	parseErrors: Int!
+	validation: SyncValidationResult
+}
+
+type SyncValidationFileDriftResult {
+	path: String!
+	missingArtefacts: Int!
+	staleArtefacts: Int!
+	mismatchedArtefacts: Int!
+	missingEdges: Int!
+	staleEdges: Int!
+	mismatchedEdges: Int!
+}
+
+type SyncValidationResult {
+	valid: Boolean!
+	expectedArtefacts: Int!
+	actualArtefacts: Int!
+	expectedEdges: Int!
+	actualEdges: Int!
+	missingArtefacts: Int!
+	staleArtefacts: Int!
+	mismatchedArtefacts: Int!
+	missingEdges: Int!
+	staleEdges: Int!
+	mismatchedEdges: Int!
+	filesWithDrift: [SyncValidationFileDriftResult!]!
 }
 
 type TelemetryEvent {

--- a/bitloops/src/cli/devql.rs
+++ b/bitloops/src/cli/devql.rs
@@ -6,9 +6,9 @@ use crate::capability_packs::knowledge::run_knowledge_versions_via_host;
 use crate::devql_transport::{SlimCliRepoScope, discover_slim_cli_repo_scope};
 use crate::host::devql::{
     CheckpointFileSnapshotBackfillOptions, DevqlConfig, GraphqlCompileMode, ParsedDevqlQuery,
-    SyncMode, SyncSummary, compile_devql_to_graphql_with_mode, compile_query_document,
-    format_query_output, parse_devql_query, run_capability_packs_report,
-    run_checkpoint_file_snapshot_backfill, run_sync_with_summary, use_raw_graphql_mode,
+    SyncSummary, compile_devql_to_graphql_with_mode, compile_query_document, format_query_output,
+    parse_devql_query, run_capability_packs_report, run_checkpoint_file_snapshot_backfill,
+    use_raw_graphql_mode,
 };
 
 mod args;
@@ -71,18 +71,14 @@ pub async fn run(args: DevqlArgs) -> Result<()> {
             graphql::run_ingest_via_graphql(&scope, args.max_checkpoints).await
         }
         DevqlCommand::Sync(args) => {
-            let mode = if args.validate {
-                SyncMode::Validate
-            } else if args.repair {
-                SyncMode::Repair
-            } else if let Some(paths) = args.paths {
-                SyncMode::Paths(paths)
-            } else if args.full {
-                SyncMode::Full
-            } else {
-                SyncMode::Auto
-            };
-            let summary = run_sync_with_summary(&cfg, mode).await?;
+            let summary = graphql::run_sync_via_graphql(
+                &scope,
+                args.full,
+                args.paths,
+                args.repair,
+                args.validate,
+            )
+            .await?;
             println!("{}", format_sync_completion_summary(&summary));
             Ok(())
         }

--- a/bitloops/src/cli/devql/graphql.rs
+++ b/bitloops/src/cli/devql/graphql.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 
 use crate::devql_transport::SlimCliRepoScope;
 use crate::host::devql::{
-    IngestionCounters, InitSchemaSummary, format_ingestion_summary, format_init_schema_summary,
+    IngestionCounters, InitSchemaSummary, SyncSummary, SyncValidationFileDrift,
+    SyncValidationSummary, format_ingestion_summary, format_init_schema_summary,
 };
 use crate::{api::DashboardServerConfig, daemon};
 
@@ -53,6 +54,49 @@ const INGEST_MUTATION: &str = r#"
     }
 "#;
 
+const SYNC_MUTATION: &str = r#"
+    mutation Sync($input: SyncInput!) {
+      sync(input: $input) {
+        success
+        mode
+        parserVersion
+        extractorVersion
+        activeBranch
+        headCommitSha
+        headTreeSha
+        pathsUnchanged
+        pathsAdded
+        pathsChanged
+        pathsRemoved
+        cacheHits
+        cacheMisses
+        parseErrors
+        validation {
+          valid
+          expectedArtefacts
+          actualArtefacts
+          expectedEdges
+          actualEdges
+          missingArtefacts
+          staleArtefacts
+          mismatchedArtefacts
+          missingEdges
+          staleEdges
+          mismatchedEdges
+          filesWithDrift {
+            path
+            missingArtefacts
+            staleArtefacts
+            mismatchedArtefacts
+            missingEdges
+            staleEdges
+            mismatchedEdges
+          }
+        }
+      }
+    }
+"#;
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InitSchemaMutationData {
@@ -63,6 +107,108 @@ struct InitSchemaMutationData {
 #[serde(rename_all = "camelCase")]
 struct IngestMutationData {
     ingest: IngestionCounters,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncMutationData {
+    sync: SyncMutationResult,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncMutationResult {
+    success: bool,
+    mode: String,
+    parser_version: String,
+    extractor_version: String,
+    active_branch: Option<String>,
+    head_commit_sha: Option<String>,
+    head_tree_sha: Option<String>,
+    paths_unchanged: usize,
+    paths_added: usize,
+    paths_changed: usize,
+    paths_removed: usize,
+    cache_hits: usize,
+    cache_misses: usize,
+    parse_errors: usize,
+    validation: Option<SyncValidationMutationResult>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncValidationMutationResult {
+    valid: bool,
+    expected_artefacts: usize,
+    actual_artefacts: usize,
+    expected_edges: usize,
+    actual_edges: usize,
+    missing_artefacts: usize,
+    stale_artefacts: usize,
+    mismatched_artefacts: usize,
+    missing_edges: usize,
+    stale_edges: usize,
+    mismatched_edges: usize,
+    files_with_drift: Vec<SyncValidationFileDriftMutationResult>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SyncValidationFileDriftMutationResult {
+    path: String,
+    missing_artefacts: usize,
+    stale_artefacts: usize,
+    mismatched_artefacts: usize,
+    missing_edges: usize,
+    stale_edges: usize,
+    mismatched_edges: usize,
+}
+
+impl From<SyncMutationResult> for SyncSummary {
+    fn from(value: SyncMutationResult) -> Self {
+        Self {
+            success: value.success,
+            mode: value.mode,
+            parser_version: value.parser_version,
+            extractor_version: value.extractor_version,
+            active_branch: value.active_branch,
+            head_commit_sha: value.head_commit_sha,
+            head_tree_sha: value.head_tree_sha,
+            paths_unchanged: value.paths_unchanged,
+            paths_added: value.paths_added,
+            paths_changed: value.paths_changed,
+            paths_removed: value.paths_removed,
+            cache_hits: value.cache_hits,
+            cache_misses: value.cache_misses,
+            parse_errors: value.parse_errors,
+            validation: value.validation.map(|validation| SyncValidationSummary {
+                valid: validation.valid,
+                expected_artefacts: validation.expected_artefacts,
+                actual_artefacts: validation.actual_artefacts,
+                expected_edges: validation.expected_edges,
+                actual_edges: validation.actual_edges,
+                missing_artefacts: validation.missing_artefacts,
+                stale_artefacts: validation.stale_artefacts,
+                mismatched_artefacts: validation.mismatched_artefacts,
+                missing_edges: validation.missing_edges,
+                stale_edges: validation.stale_edges,
+                mismatched_edges: validation.mismatched_edges,
+                files_with_drift: validation
+                    .files_with_drift
+                    .into_iter()
+                    .map(|file| SyncValidationFileDrift {
+                        path: file.path,
+                        missing_artefacts: file.missing_artefacts,
+                        stale_artefacts: file.stale_artefacts,
+                        mismatched_artefacts: file.mismatched_artefacts,
+                        missing_edges: file.missing_edges,
+                        stale_edges: file.stale_edges,
+                        mismatched_edges: file.mismatched_edges,
+                    })
+                    .collect(),
+            }),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -114,6 +260,30 @@ pub(super) async fn run_ingest_via_graphql(
     .await?;
     println!("{}", format_ingestion_summary(&response.ingest));
     Ok(())
+}
+
+pub(super) async fn run_sync_via_graphql(
+    scope: &SlimCliRepoScope,
+    full: bool,
+    paths: Option<Vec<String>>,
+    repair: bool,
+    validate: bool,
+) -> Result<SyncSummary> {
+    ensure_daemon_available_for_ingest(scope.repo_root.as_path()).await?;
+    let response: SyncMutationData = execute_devql_graphql(
+        scope,
+        SYNC_MUTATION,
+        json!({
+            "input": {
+                "full": full,
+                "paths": paths,
+                "repair": repair,
+                "validate": validate,
+            }
+        }),
+    )
+    .await?;
+    Ok(response.sync.into())
 }
 
 async fn ensure_daemon_available_for_ingest(_repo_root: &Path) -> Result<()> {

--- a/bitloops/src/cli/devql/tests.rs
+++ b/bitloops/src/cli/devql/tests.rs
@@ -808,6 +808,193 @@ embedding_mode = "off"
 }
 
 #[test]
+fn devql_run_sync_executes_graphql_mutation() {
+    let repo = seed_devql_cli_repo();
+    let _guard = enter_process_state(Some(repo.path()), &[]);
+    let captured = Rc::new(RefCell::new(None::<(String, serde_json::Value)>));
+
+    super::graphql::with_ingest_daemon_bootstrap_hook(
+        |_repo_root: &std::path::Path| Ok(()),
+        || {
+            with_graphql_executor_hook(
+                {
+                    let captured = Rc::clone(&captured);
+                    move |_repo_root: &std::path::Path,
+                          query: &str,
+                          variables: &serde_json::Value| {
+                        *captured.borrow_mut() = Some((query.to_string(), variables.clone()));
+                        Ok(json!({
+                            "sync": {
+                                "success": true,
+                                "mode": "full",
+                                "parserVersion": "parser@1",
+                                "extractorVersion": "extractor@1",
+                                "activeBranch": "main",
+                                "headCommitSha": "abc123",
+                                "headTreeSha": "def456",
+                                "pathsUnchanged": 4,
+                                "pathsAdded": 1,
+                                "pathsChanged": 2,
+                                "pathsRemoved": 0,
+                                "cacheHits": 3,
+                                "cacheMisses": 1,
+                                "parseErrors": 0,
+                                "validation": null
+                            }
+                        }))
+                    }
+                },
+                || {
+                    test_runtime()
+                        .block_on(run(DevqlArgs {
+                            command: Some(DevqlCommand::Sync(DevqlSyncArgs {
+                                full: true,
+                                paths: None,
+                                repair: false,
+                                validate: false,
+                            })),
+                        }))
+                        .expect("devql sync should succeed");
+                },
+            );
+        },
+    );
+
+    let (query, variables) = captured
+        .borrow_mut()
+        .take()
+        .expect("graphql mutation should be captured");
+    assert!(query.contains("sync"), "expected sync mutation in query");
+    assert_eq!(variables["input"]["full"], json!(true));
+}
+
+#[test]
+fn devql_run_sync_passes_paths_to_graphql_mutation() {
+    let repo = seed_devql_cli_repo();
+    let _guard = enter_process_state(Some(repo.path()), &[]);
+    let captured = Rc::new(RefCell::new(None::<(String, serde_json::Value)>));
+
+    super::graphql::with_ingest_daemon_bootstrap_hook(
+        |_repo_root: &std::path::Path| Ok(()),
+        || {
+            with_graphql_executor_hook(
+                {
+                    let captured = Rc::clone(&captured);
+                    move |_repo_root: &std::path::Path,
+                          query: &str,
+                          variables: &serde_json::Value| {
+                        *captured.borrow_mut() = Some((query.to_string(), variables.clone()));
+                        Ok(json!({
+                            "sync": {
+                                "success": true,
+                                "mode": "paths",
+                                "parserVersion": "parser@1",
+                                "extractorVersion": "extractor@1",
+                                "activeBranch": "main",
+                                "headCommitSha": "abc123",
+                                "headTreeSha": "def456",
+                                "pathsUnchanged": 0,
+                                "pathsAdded": 0,
+                                "pathsChanged": 1,
+                                "pathsRemoved": 0,
+                                "cacheHits": 0,
+                                "cacheMisses": 1,
+                                "parseErrors": 0,
+                                "validation": null
+                            }
+                        }))
+                    }
+                },
+                || {
+                    test_runtime()
+                        .block_on(run(DevqlArgs {
+                            command: Some(DevqlCommand::Sync(DevqlSyncArgs {
+                                full: false,
+                                paths: Some(vec![
+                                    "src/lib.rs".to_string(),
+                                    "src/main.rs".to_string(),
+                                ]),
+                                repair: false,
+                                validate: false,
+                            })),
+                        }))
+                        .expect("devql sync with paths should succeed");
+                },
+            );
+        },
+    );
+
+    let (_query, variables) = captured
+        .borrow_mut()
+        .take()
+        .expect("graphql mutation should be captured");
+    assert_eq!(
+        variables["input"]["paths"],
+        json!(["src/lib.rs", "src/main.rs"])
+    );
+}
+
+#[test]
+fn devql_run_sync_ensures_daemon_available() {
+    let repo = seed_devql_cli_repo();
+    let _guard = enter_process_state(Some(repo.path()), &[]);
+    let bootstrap_count = Rc::new(RefCell::new(0usize));
+
+    super::graphql::with_ingest_daemon_bootstrap_hook(
+        {
+            let bootstrap_count = Rc::clone(&bootstrap_count);
+            move |_repo_root: &std::path::Path| {
+                *bootstrap_count.borrow_mut() += 1;
+                Ok(())
+            }
+        },
+        || {
+            with_graphql_executor_hook(
+                |_repo_root: &std::path::Path, _query: &str, _variables: &serde_json::Value| {
+                    Ok(json!({
+                        "sync": {
+                            "success": true,
+                            "mode": "full",
+                            "parserVersion": "p@1",
+                            "extractorVersion": "e@1",
+                            "activeBranch": null,
+                            "headCommitSha": null,
+                            "headTreeSha": null,
+                            "pathsUnchanged": 0,
+                            "pathsAdded": 0,
+                            "pathsChanged": 0,
+                            "pathsRemoved": 0,
+                            "cacheHits": 0,
+                            "cacheMisses": 0,
+                            "parseErrors": 0,
+                            "validation": null
+                        }
+                    }))
+                },
+                || {
+                    test_runtime()
+                        .block_on(run(DevqlArgs {
+                            command: Some(DevqlCommand::Sync(DevqlSyncArgs {
+                                full: false,
+                                paths: None,
+                                repair: false,
+                                validate: false,
+                            })),
+                        }))
+                        .expect("devql sync should succeed");
+                },
+            );
+        },
+    );
+
+    assert_eq!(
+        *bootstrap_count.borrow(),
+        1,
+        "daemon bootstrap should be called once"
+    );
+}
+
+#[test]
 fn devql_run_projection_checkpoint_file_snapshots_succeeds_for_empty_repo() {
     let repo = seed_devql_cli_repo();
     let _guard = enter_process_state(Some(repo.path()), &[]);

--- a/bitloops/src/graphql/mutation_root.rs
+++ b/bitloops/src/graphql/mutation_root.rs
@@ -34,6 +34,22 @@ pub struct RefreshKnowledgeInput {
     pub knowledge_ref: String,
 }
 
+#[derive(Debug, Clone, InputObject)]
+pub struct SyncInput {
+    /// Run a full workspace reconciliation.
+    #[graphql(default = false)]
+    pub full: bool,
+    /// Reconcile only the specified workspace paths (comma-delimited values accepted).
+    #[graphql(default)]
+    pub paths: Option<Vec<String>>,
+    /// Rebuild sync state from the current workspace, ignoring stored manifest trust.
+    #[graphql(default = false)]
+    pub repair: bool,
+    /// Validate current-state tables against a full read-only workspace reconciliation.
+    #[graphql(default = false)]
+    pub validate: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, SimpleObject)]
 pub struct InitSchemaResult {
     pub success: bool,
@@ -92,6 +108,99 @@ impl From<crate::host::devql::IngestionCounters> for IngestResult {
             symbol_embedding_rows_skipped: to_graphql_count(value.symbol_embedding_rows_skipped),
             symbol_clone_edges_upserted: to_graphql_count(value.symbol_clone_edges_upserted),
             symbol_clone_sources_scored: to_graphql_count(value.symbol_clone_sources_scored),
+        }
+    }
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct SyncResult {
+    pub success: bool,
+    pub mode: String,
+    pub parser_version: String,
+    pub extractor_version: String,
+    pub active_branch: Option<String>,
+    pub head_commit_sha: Option<String>,
+    pub head_tree_sha: Option<String>,
+    pub paths_unchanged: i32,
+    pub paths_added: i32,
+    pub paths_changed: i32,
+    pub paths_removed: i32,
+    pub cache_hits: i32,
+    pub cache_misses: i32,
+    pub parse_errors: i32,
+    pub validation: Option<SyncValidationResult>,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct SyncValidationResult {
+    pub valid: bool,
+    pub expected_artefacts: i32,
+    pub actual_artefacts: i32,
+    pub expected_edges: i32,
+    pub actual_edges: i32,
+    pub missing_artefacts: i32,
+    pub stale_artefacts: i32,
+    pub mismatched_artefacts: i32,
+    pub missing_edges: i32,
+    pub stale_edges: i32,
+    pub mismatched_edges: i32,
+    pub files_with_drift: Vec<SyncValidationFileDriftResult>,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub struct SyncValidationFileDriftResult {
+    pub path: String,
+    pub missing_artefacts: i32,
+    pub stale_artefacts: i32,
+    pub mismatched_artefacts: i32,
+    pub missing_edges: i32,
+    pub stale_edges: i32,
+    pub mismatched_edges: i32,
+}
+
+impl From<crate::host::devql::SyncSummary> for SyncResult {
+    fn from(value: crate::host::devql::SyncSummary) -> Self {
+        Self {
+            success: value.success,
+            mode: value.mode,
+            parser_version: value.parser_version,
+            extractor_version: value.extractor_version,
+            active_branch: value.active_branch,
+            head_commit_sha: value.head_commit_sha,
+            head_tree_sha: value.head_tree_sha,
+            paths_unchanged: to_graphql_count(value.paths_unchanged),
+            paths_added: to_graphql_count(value.paths_added),
+            paths_changed: to_graphql_count(value.paths_changed),
+            paths_removed: to_graphql_count(value.paths_removed),
+            cache_hits: to_graphql_count(value.cache_hits),
+            cache_misses: to_graphql_count(value.cache_misses),
+            parse_errors: to_graphql_count(value.parse_errors),
+            validation: value.validation.map(|validation| SyncValidationResult {
+                valid: validation.valid,
+                expected_artefacts: to_graphql_count(validation.expected_artefacts),
+                actual_artefacts: to_graphql_count(validation.actual_artefacts),
+                expected_edges: to_graphql_count(validation.expected_edges),
+                actual_edges: to_graphql_count(validation.actual_edges),
+                missing_artefacts: to_graphql_count(validation.missing_artefacts),
+                stale_artefacts: to_graphql_count(validation.stale_artefacts),
+                mismatched_artefacts: to_graphql_count(validation.mismatched_artefacts),
+                missing_edges: to_graphql_count(validation.missing_edges),
+                stale_edges: to_graphql_count(validation.stale_edges),
+                mismatched_edges: to_graphql_count(validation.mismatched_edges),
+                files_with_drift: validation
+                    .files_with_drift
+                    .into_iter()
+                    .map(|file| SyncValidationFileDriftResult {
+                        path: file.path,
+                        missing_artefacts: to_graphql_count(file.missing_artefacts),
+                        stale_artefacts: to_graphql_count(file.stale_artefacts),
+                        mismatched_artefacts: to_graphql_count(file.mismatched_artefacts),
+                        missing_edges: to_graphql_count(file.missing_edges),
+                        stale_edges: to_graphql_count(file.stale_edges),
+                        mismatched_edges: to_graphql_count(file.mismatched_edges),
+                    })
+                    .collect(),
+            }),
         }
     }
 }
@@ -255,6 +364,33 @@ impl MutationRoot {
         )
         .await
         .map_err(|err| operation_error("BACKEND_ERROR", "ingestion", "ingest", err))?;
+        Ok(summary.into())
+    }
+
+    async fn sync(&self, ctx: &Context<'_>, input: SyncInput) -> Result<SyncResult> {
+        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
+        context
+            .require_repo_write_scope()
+            .map_err(|err| operation_error("BAD_USER_INPUT", "validation", "sync", err))?;
+        let cfg = context
+            .devql_config()
+            .map_err(|err| operation_error("BACKEND_ERROR", "configuration", "sync", err))?;
+
+        let mode = if input.validate {
+            crate::host::devql::SyncMode::Validate
+        } else if input.repair {
+            crate::host::devql::SyncMode::Repair
+        } else if let Some(paths) = input.paths {
+            crate::host::devql::SyncMode::Paths(paths)
+        } else if input.full {
+            crate::host::devql::SyncMode::Full
+        } else {
+            crate::host::devql::SyncMode::Auto
+        };
+
+        let summary = crate::host::devql::run_sync_with_summary(&cfg, mode)
+            .await
+            .map_err(|err| operation_error("BACKEND_ERROR", "sync", "sync", err))?;
         Ok(summary.into())
     }
 


### PR DESCRIPTION


Move synchronization logic to the daemon execution context


## Validation



- [x] I ran the relevant tests locally.

- [ ] I included the executed commands and outcomes in the PR description.



## TDD RED Evidence Gate (when applicable)



Reference policy: `docs/tdd-red-evidence.md`



- [ ] This PR does **not** require RED evidence (explain why), or

- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.

- [ ] RED evidence comments include command, failing result, and meaningful failure message.

- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.



## Jira



- [ ] Linked Jira issue(s) are updated with implementation notes and test results.

- [ ] Final status transitions match the task definition of done.

