### PR TITLE
Enhance sync cache error handling and update parse status constants to improve clarity

### DIFF
--- a/bitloops/src/host/devql/commands_sync.rs
+++ b/bitloops/src/host/devql/commands_sync.rs
@@ -217,6 +217,9 @@ async fn execute_sync_inner(
         {
             Some(cached) => {
                 counters.cache_hits += 1;
+                if cached.parse_status == sync::extraction::PARSE_STATUS_PARSE_ERROR {
+                    counters.parse_errors += 1;
+                }
                 if determine_retention_class(&desired) == "git_backed" {
                     sync::content_cache::promote_to_git_backed(
                         relational,
@@ -239,19 +242,23 @@ async fn execute_sync_inner(
                 counters.cache_misses += 1;
                 let content = read_effective_content(cfg, &desired)
                     .with_context(|| format!("reading effective content for `{}`", desired.path))?;
-                let Some(extraction) = sync::extraction::extract_to_cache_format(
-                    cfg,
-                    &desired.path,
-                    &desired.effective_content_id,
+                let extraction = extraction_or_parse_error(
+                    sync::extraction::extract_to_cache_format(
+                        cfg,
+                        &desired.path,
+                        &desired.effective_content_id,
+                        parser_version,
+                        extractor_version,
+                        &content,
+                    )
+                    .with_context(|| {
+                        format!("extracting `{}` into sync cache format", desired.path)
+                    })?,
+                    &mut counters,
+                    &desired,
                     parser_version,
                     extractor_version,
-                    &content,
-                )
-                .with_context(|| format!("extracting `{}` into sync cache format", desired.path))?
-                else {
-                    counters.parse_errors += 1;
-                    continue;
-                };
+                );
 
                 sync::content_cache::store_cached_content(
                     relational,
@@ -726,6 +733,27 @@ fn determine_retention_class(desired: &sync::types::DesiredFileState) -> &'stati
     }
 }
 
+fn extraction_or_parse_error(
+    extraction: Option<sync::content_cache::CachedExtraction>,
+    counters: &mut sync::types::SyncCounters,
+    desired: &sync::types::DesiredFileState,
+    parser_version: &str,
+    extractor_version: &str,
+) -> sync::content_cache::CachedExtraction {
+    match extraction {
+        Some(extraction) => extraction,
+        None => {
+            counters.parse_errors += 1;
+            sync::extraction::parse_error_to_cache_format(
+                &desired.effective_content_id,
+                &desired.language,
+                parser_version,
+                extractor_version,
+            )
+        }
+    }
+}
+
 fn is_missing_sync_schema_error(err: &anyhow::Error) -> bool {
     // Temporary safeguard while daemon-start schema bootstrap rolls out across workflows.
     // Keep this fallback so sync can still emit a direct remediation hint on legacy setups.
@@ -749,6 +777,21 @@ fn is_missing_sync_schema_error(err: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn desired_state_for_tests() -> sync::types::DesiredFileState {
+        sync::types::DesiredFileState {
+            path: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            head_content_id: Some("head".to_string()),
+            index_content_id: Some("index".to_string()),
+            worktree_content_id: Some("worktree".to_string()),
+            effective_content_id: "effective".to_string(),
+            effective_source: sync::types::EffectiveSource::Worktree,
+            exists_in_head: true,
+            exists_in_index: true,
+            exists_in_worktree: true,
+        }
+    }
 
     #[test]
     fn sync_reason_maps_auto_to_full() {
@@ -860,5 +903,50 @@ mod tests {
             Some(1)
         );
         assert_eq!(diff.by_path.get("src/main.rs").map(|d| d.stale), Some(1));
+    }
+
+    #[test]
+    fn extraction_or_parse_error_maps_none_to_parse_error_payload() {
+        let mut counters = sync::types::SyncCounters::default();
+        let desired = desired_state_for_tests();
+
+        let extraction =
+            extraction_or_parse_error(None, &mut counters, &desired, "parser-v1", "extractor-v1");
+
+        assert_eq!(counters.parse_errors, 1);
+        assert_eq!(
+            extraction.parse_status,
+            sync::extraction::PARSE_STATUS_PARSE_ERROR
+        );
+        assert_eq!(extraction.content_id, desired.effective_content_id);
+        assert_eq!(extraction.language, desired.language);
+        assert!(extraction.artefacts.is_empty());
+        assert!(extraction.edges.is_empty());
+    }
+
+    #[test]
+    fn extraction_or_parse_error_preserves_success_payload_without_incrementing_errors() {
+        let mut counters = sync::types::SyncCounters::default();
+        let desired = desired_state_for_tests();
+        let expected = sync::content_cache::CachedExtraction {
+            content_id: desired.effective_content_id.clone(),
+            language: desired.language.clone(),
+            parser_version: "parser-v1".to_string(),
+            extractor_version: "extractor-v1".to_string(),
+            parse_status: sync::extraction::PARSE_STATUS_OK.to_string(),
+            artefacts: vec![],
+            edges: vec![],
+        };
+
+        let extraction = extraction_or_parse_error(
+            Some(expected.clone()),
+            &mut counters,
+            &desired,
+            "parser-v1",
+            "extractor-v1",
+        );
+
+        assert_eq!(counters.parse_errors, 0);
+        assert_eq!(extraction, expected);
     }
 }

--- a/bitloops/src/host/devql/sync/content_cache.rs
+++ b/bitloops/src/host/devql/sync/content_cache.rs
@@ -520,7 +520,7 @@ WHERE content_id = '{}' AND language = 'rust' AND parser_version = 'parser-v1' A
             language: "rust".to_string(),
             parser_version: "parser-v1".to_string(),
             extractor_version: "extractor-v1".to_string(),
-            parse_status: "parsed".to_string(),
+            parse_status: "ok".to_string(),
             artefacts: vec![],
             edges: vec![],
         };
@@ -561,7 +561,7 @@ WHERE content_id = '{}' AND language = 'rust' AND parser_version = 'parser-v1' A
             language: "rust".to_string(),
             parser_version: "parser-v1".to_string(),
             extractor_version: "extractor-v1".to_string(),
-            parse_status: "parsed".to_string(),
+            parse_status: "ok".to_string(),
             artefacts: vec![
                 CachedArtefact {
                     artifact_key: "file::src/lib.rs".to_string(),

--- a/bitloops/src/host/devql/sync/extraction.rs
+++ b/bitloops/src/host/devql/sync/extraction.rs
@@ -5,6 +5,9 @@ use serde_json::json;
 
 use super::content_cache::{CachedArtefact, CachedEdge, CachedExtraction};
 
+pub(crate) const PARSE_STATUS_OK: &str = "ok";
+pub(crate) const PARSE_STATUS_PARSE_ERROR: &str = "parse_error";
+
 struct ExtractionInput<'a> {
     path: &'a str,
     content_id: &'a str,
@@ -57,6 +60,23 @@ pub(crate) fn extract_to_cache_format(
         items,
         edges,
     )))
+}
+
+pub(crate) fn parse_error_to_cache_format(
+    content_id: &str,
+    language: &str,
+    parser_version: &str,
+    extractor_version: &str,
+) -> CachedExtraction {
+    CachedExtraction {
+        content_id: content_id.to_string(),
+        language: language.to_string(),
+        parser_version: parser_version.to_string(),
+        extractor_version: extractor_version.to_string(),
+        parse_status: PARSE_STATUS_PARSE_ERROR.to_string(),
+        artefacts: Vec::new(),
+        edges: Vec::new(),
+    }
 }
 
 fn map_extraction_to_cache_format(
@@ -127,7 +147,7 @@ fn map_extraction_to_cache_format(
         language: input.language.to_string(),
         parser_version: input.parser_version.to_string(),
         extractor_version: input.extractor_version.to_string(),
-        parse_status: "parsed".to_string(),
+        parse_status: PARSE_STATUS_OK.to_string(),
         artefacts,
         edges,
     }
@@ -347,5 +367,20 @@ mod tests {
         );
 
         assert_eq!(ordered, reversed);
+        assert_eq!(ordered.parse_status, PARSE_STATUS_OK);
+    }
+
+    #[test]
+    fn parse_error_cache_payload_has_empty_extraction_data() {
+        let parse_error =
+            parse_error_to_cache_format("content-id", "typescript", "parser-v1", "extractor-v1");
+
+        assert_eq!(parse_error.content_id, "content-id");
+        assert_eq!(parse_error.language, "typescript");
+        assert_eq!(parse_error.parser_version, "parser-v1");
+        assert_eq!(parse_error.extractor_version, "extractor-v1");
+        assert_eq!(parse_error.parse_status, PARSE_STATUS_PARSE_ERROR);
+        assert!(parse_error.artefacts.is_empty());
+        assert!(parse_error.edges.is_empty());
     }
 }

--- a/bitloops/src/host/devql/sync/gc.rs
+++ b/bitloops/src/host/devql/sync/gc.rs
@@ -150,7 +150,7 @@ mod tests {
             language: "rust".to_string(),
             parser_version: "parser-v1".to_string(),
             extractor_version: "extractor-v1".to_string(),
-            parse_status: "parsed".to_string(),
+            parse_status: "ok".to_string(),
             artefacts: vec![CachedArtefact {
                 artifact_key: format!("file::{content_id}"),
                 canonical_kind: Some("file".to_string()),

--- a/bitloops/src/host/devql/sync/materializer.rs
+++ b/bitloops/src/host/devql/sync/materializer.rs
@@ -657,7 +657,7 @@ mod tests {
             language: "rust".to_string(),
             parser_version: "parser-v1".to_string(),
             extractor_version: "extractor-v1".to_string(),
-            parse_status: "parsed".to_string(),
+            parse_status: "ok".to_string(),
             artefacts: vec![
                 CachedArtefact {
                     artifact_key: "file::a-old".to_string(),
@@ -755,7 +755,7 @@ mod tests {
             language: "rust".to_string(),
             parser_version: "parser-v1".to_string(),
             extractor_version: "extractor-v1".to_string(),
-            parse_status: "parsed".to_string(),
+            parse_status: "ok".to_string(),
             artefacts: vec![CachedArtefact {
                 artifact_key: "file::src/lib.rs".to_string(),
                 canonical_kind: Some("file".to_string()),

--- a/bitloops/src/host/devql/tests/sync_tests.rs
+++ b/bitloops/src/host/devql/tests/sync_tests.rs
@@ -807,7 +807,7 @@ async fn content_cache_store_then_lookup_roundtrips_payload() {
         language: "rust".to_string(),
         parser_version: "parser-v1".to_string(),
         extractor_version: "extractor-v1".to_string(),
-        parse_status: "parsed".to_string(),
+        parse_status: "ok".to_string(),
         artefacts: vec![crate::host::devql::sync::content_cache::CachedArtefact {
             artifact_key: "file::src/lib.rs".to_string(),
             canonical_kind: Some("file".to_string()),
@@ -867,7 +867,7 @@ async fn content_cache_lookup_respects_parser_and_extractor_versions() {
         language: "rust".to_string(),
         parser_version: "parser-a".to_string(),
         extractor_version: "extractor-a".to_string(),
-        parse_status: "parsed".to_string(),
+        parse_status: "ok".to_string(),
         artefacts: vec![crate::host::devql::sync::content_cache::CachedArtefact {
             artifact_key: "fn::demo".to_string(),
             canonical_kind: Some("function".to_string()),
@@ -948,7 +948,7 @@ function localHelper(): number {
     assert_eq!(extraction.language, "typescript");
     assert_eq!(extraction.parser_version, "tree-sitter-ts@1");
     assert_eq!(extraction.extractor_version, "ts-language-pack@1");
-    assert_eq!(extraction.parse_status, "parsed");
+    assert_eq!(extraction.parse_status, "ok");
 
     let repeated = crate::host::devql::sync::extraction::extract_to_cache_format(
         &cfg,
@@ -2164,6 +2164,112 @@ async fn dirty_then_commit_unchanged_is_cache_hit() {
         )
         .expect("read content_cache retention class");
     assert_eq!(retention_class, "git_backed");
+}
+
+#[tokio::test]
+async fn cached_parse_error_hit_updates_manifest_and_clears_materialized_rows() {
+    let repo = seed_full_sync_repo();
+    let cfg = sync_test_cfg_for_repo(repo.path());
+    let sqlite_path = repo.path().join("devql.sqlite");
+    let relational = sqlite_relational_store_with_sync_schema(&sqlite_path).await;
+    let path = "src/lib.rs";
+    let broken_content = "fn broken( {\n";
+
+    let baseline = crate::host::devql::execute_sync(
+        &cfg,
+        &relational,
+        crate::host::devql::sync::types::SyncMode::Full,
+    )
+    .await
+    .expect("execute baseline full sync");
+
+    let db = Connection::open(&sqlite_path).expect("open sqlite db");
+    let baseline_rows: i64 = db
+        .query_row(
+            "SELECT COUNT(*) FROM artefacts_current WHERE repo_id = ?1 AND path = ?2",
+            [cfg.repo.repo_id.as_str(), path],
+            |row| row.get(0),
+        )
+        .expect("count baseline rows for parse-error path");
+    assert!(
+        baseline_rows > 0,
+        "baseline sync should materialize at least one row for parse-error path"
+    );
+
+    fs::write(repo.path().join(path), broken_content).expect("write broken source content");
+    let broken_content_id =
+        crate::host::devql::sync::content_identity::compute_blob_oid(broken_content.as_bytes());
+    let parse_error_payload = crate::host::devql::sync::content_cache::CachedExtraction {
+        content_id: broken_content_id.clone(),
+        language: "rust".to_string(),
+        parser_version: baseline.parser_version.clone(),
+        extractor_version: baseline.extractor_version.clone(),
+        parse_status: crate::host::devql::sync::extraction::PARSE_STATUS_PARSE_ERROR.to_string(),
+        artefacts: vec![],
+        edges: vec![],
+    };
+    crate::host::devql::sync::content_cache::store_cached_content(
+        &relational,
+        &parse_error_payload,
+        "worktree_only",
+    )
+    .await
+    .expect("store parse-error cache payload");
+
+    let summary = crate::host::devql::execute_sync(
+        &cfg,
+        &relational,
+        crate::host::devql::sync::types::SyncMode::Full,
+    )
+    .await
+    .expect("execute full sync with cached parse-error payload");
+
+    assert_eq!(summary.paths_changed, 1);
+    assert_eq!(summary.cache_hits, 1);
+    assert_eq!(summary.cache_misses, 0);
+    assert_eq!(summary.parse_errors, 1);
+
+    let rows_after: i64 = db
+        .query_row(
+            "SELECT COUNT(*) FROM artefacts_current WHERE repo_id = ?1 AND path = ?2",
+            [cfg.repo.repo_id.as_str(), path],
+            |row| row.get(0),
+        )
+        .expect("count rows after parse-error materialization");
+    assert_eq!(
+        rows_after, 0,
+        "parse-error payload should clear materialized rows for the path"
+    );
+
+    let current_state: (String, String) = db
+        .query_row(
+            "SELECT effective_content_id, effective_source \
+             FROM current_file_state \
+             WHERE repo_id = ?1 AND path = ?2",
+            [cfg.repo.repo_id.as_str(), path],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read current_file_state after parse-error sync");
+    assert_eq!(current_state.0, broken_content_id);
+    assert_eq!(current_state.1, "worktree");
+
+    let parse_status: String = db
+        .query_row(
+            "SELECT parse_status FROM content_cache \
+             WHERE content_id = ?1 AND language = ?2 AND parser_version = ?3 AND extractor_version = ?4",
+            [
+                current_state.0.as_str(),
+                "rust",
+                summary.parser_version.as_str(),
+                summary.extractor_version.as_str(),
+            ],
+            |row| row.get(0),
+        )
+        .expect("read parse_status for parse-error cache row");
+    assert_eq!(
+        parse_status,
+        crate::host::devql::sync::extraction::PARSE_STATUS_PARSE_ERROR
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [x] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

