### PR TITLE
CLI-1581 Stop Daemon on Uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Stop Daemon on Uninstall**: made sure that the Bitloops daemon is stopped when the service is uninstalled in order to release the port.
 - **Sandbox-safe local test lanes**: isolated the remaining environment-sensitive test cases so repository-root default lanes stay clean in sandboxed runs. Socket-bound tests now skip cleanly when loopback binds are not permitted, and git-fixture tests disable local commit/tag signing so host SSH signing configuration does not leak into test repos.
 - **Queue-adoption regressions in current-state refresh flows**: restored deterministic host-side test behaviour for watcher capture and manual-commit DevQL refresh paths with test-only inline sync execution, hardened sync worker lifecycle handling when test runtimes drop, corrected malformed SQL in the modularised `commands_sync` shared and validation queries, and cleaned the follow-up Clippy warnings in the new CLI and sync queue paths.
 - **Daemon liveness detection on macOS**: the CLI now treats Unix `kill(pid, 0)` permission errors (`EPERM`) as evidence that the daemon process still exists instead of assuming the process is gone. This fixes cases where a live Bitloops daemon was misreported as stopped, which could break daemon status and lifecycle flows.

--- a/bitloops/src/api/dashboard_runtime.rs
+++ b/bitloops/src/api/dashboard_runtime.rs
@@ -45,6 +45,7 @@ pub(super) async fn run(
         .and_then(normalized_host)
         .map(str::to_string);
     let startup_mode = select_startup_mode(&config, local_dashboard_cfg, explicit_host.as_deref())?;
+    log::info!("dashboard startup phase: initialising database pools");
     let db_init = db::init_dashboard_db().await;
     if db_init.startup_health.has_failures() {
         bail!(

--- a/bitloops/src/api/db/init.rs
+++ b/bitloops/src/api/db/init.rs
@@ -7,6 +7,7 @@ use super::sqlite::SqlitePool;
 use super::{DashboardDbInit, DashboardDbPools, POSTGRES_POOL_SIZE};
 
 pub(super) async fn init_dashboard_db() -> DashboardDbInit {
+    log::info!("dashboard db init: resolving backend configuration");
     let cfg = match DashboardDbConfig::from_env() {
         Ok(cfg) => cfg,
         Err(err) => {

--- a/bitloops/src/cli/uninstall.rs
+++ b/bitloops/src/cli/uninstall.rs
@@ -92,7 +92,17 @@ async fn run_with_context(
             UninstallTarget::Data => uninstall_data(&scope.repo_data_roots, out),
             UninstallTarget::Caching => uninstall_cache(out),
             UninstallTarget::Config => uninstall_config(out),
-            UninstallTarget::Service => uninstall_service(out, context.service_uninstaller),
+            UninstallTarget::Service => {
+                if let Err(err) = crate::daemon::stop().await
+                    && !err.to_string().contains("not running")
+                {
+                    writeln!(
+                        err_out,
+                        "Warning: unable to stop Bitloops daemon before removing the service: {err:#}"
+                    )?;
+                }
+                uninstall_service(out, context.service_uninstaller)
+            }
             UninstallTarget::Binaries => uninstall_binaries(out, context.binary_candidates),
         };
 

--- a/bitloops/src/cli/uninstall.rs
+++ b/bitloops/src/cli/uninstall.rs
@@ -1,5 +1,7 @@
+use std::future::Future;
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::pin::Pin;
 
 use anyhow::{Result, bail};
 
@@ -30,9 +32,12 @@ type UninstallSelector =
     dyn Fn(&[UninstallTarget]) -> std::result::Result<Vec<UninstallTarget>, String>;
 type ServiceUninstaller = dyn Fn() -> Result<()>;
 type BinaryCandidatesFn = dyn Fn() -> Result<Vec<PathBuf>>;
+type DaemonStopFuture = Pin<Box<dyn Future<Output = Result<()>> + Send>>;
+type DaemonStopper = dyn Fn() -> DaemonStopFuture;
 
 struct RunContext<'a> {
     select_fn: Option<&'a UninstallSelector>,
+    daemon_stopper: &'a DaemonStopper,
     service_uninstaller: &'a ServiceUninstaller,
     binary_candidates: &'a BinaryCandidatesFn,
 }
@@ -44,6 +49,7 @@ pub async fn run(args: UninstallArgs) -> Result<()> {
     let mut err = stderr.lock();
     let context = RunContext {
         select_fn: None,
+        daemon_stopper: &|| Box::pin(crate::daemon::stop()),
         service_uninstaller: &default_service_uninstaller,
         binary_candidates: &known_binary_candidates,
     };
@@ -93,8 +99,8 @@ async fn run_with_context(
             UninstallTarget::Caching => uninstall_cache(out),
             UninstallTarget::Config => uninstall_config(out),
             UninstallTarget::Service => {
-                if let Err(err) = crate::daemon::stop().await
-                    && !err.to_string().contains("not running")
+                if let Err(err) = (context.daemon_stopper)().await
+                    && !is_daemon_not_running_error(&err)
                 {
                     writeln!(
                         err_out,
@@ -126,3 +132,7 @@ async fn run_with_context(
 
 #[cfg(test)]
 mod tests;
+
+fn is_daemon_not_running_error(err: &anyhow::Error) -> bool {
+    err.to_string() == "Bitloops daemon is not running. Start it with `bitloops daemon start`."
+}

--- a/bitloops/src/cli/uninstall/tests.rs
+++ b/bitloops/src/cli/uninstall/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use clap::Parser;
@@ -10,8 +11,8 @@ use super::targets::{
     ALL_TARGETS, UninstallTarget, collect_requested_targets, validate_scope_flags,
 };
 use super::{
-    BinaryCandidatesFn, NO_FLAGS_ERROR, RunContext, ServiceUninstaller, UninstallArgs,
-    UninstallSelector, run_with_context,
+    BinaryCandidatesFn, DaemonStopper, NO_FLAGS_ERROR, RunContext, ServiceUninstaller,
+    UninstallArgs, UninstallSelector, run_with_context,
 };
 use crate::adapters::agents::claude_code::git_hooks;
 use crate::adapters::agents::codex::hooks as codex_hooks;
@@ -100,6 +101,7 @@ fn run_uninstall_for_test(
     args: UninstallArgs,
     cwd: Option<&Path>,
     select_fn: Option<&UninstallSelector>,
+    daemon_stopper: &DaemonStopper,
     service_uninstaller: &ServiceUninstaller,
     binary_candidates: &BinaryCandidatesFn,
 ) -> Result<String> {
@@ -111,6 +113,7 @@ fn run_uninstall_for_test(
     let mut err = Vec::new();
     let context = RunContext {
         select_fn,
+        daemon_stopper,
         service_uninstaller,
         binary_candidates,
     };
@@ -262,6 +265,7 @@ fn uninstall_git_hooks_uses_all_known_repos_by_default() {
             },
             None,
             None,
+            &|| Box::pin(async { Ok(()) }),
             &|| Ok(()),
             &|| Ok(Vec::new()),
         )
@@ -309,6 +313,7 @@ fn only_current_project_limits_hook_removal() {
                 },
                 None,
                 None,
+                &|| Box::pin(async { Ok(()) }),
                 &|| Ok(()),
                 &|| Ok(Vec::new()),
             )
@@ -342,6 +347,7 @@ fn data_target_removes_only_data() {
             },
             None,
             None,
+            &|| Box::pin(async { Ok(()) }),
             &|| Ok(()),
             &|| Ok(Vec::new()),
         )
@@ -408,6 +414,7 @@ fn full_uninstall_removes_supported_temp_artefacts() {
                 },
                 None,
                 None,
+                &|| Box::pin(async { Ok(()) }),
                 &move || {
                     service_called_ref.store(true, std::sync::atomic::Ordering::SeqCst);
                     Ok(())
@@ -440,8 +447,9 @@ fn service_uninstall_stops_daemon_best_effort_then_runs_service_uninstaller() {
     let home = tempfile::tempdir().unwrap();
 
     with_platform_dirs(&config, &data, &cache, &state, &home, None, || {
-        let service_called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let service_called_ref = service_called.clone();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let stop_events = events.clone();
+        let service_events = events.clone();
 
         run_uninstall_for_test(
             UninstallArgs {
@@ -452,13 +460,21 @@ fn service_uninstall_stops_daemon_best_effort_then_runs_service_uninstaller() {
             None,
             None,
             &move || {
-                service_called_ref.store(true, std::sync::atomic::Ordering::SeqCst);
+                let stop_events = stop_events.clone();
+                Box::pin(async move {
+                    stop_events.lock().unwrap().push("stop");
+                    Ok(())
+                })
+            },
+            &move || {
+                service_events.lock().unwrap().push("service");
                 Ok(())
             },
             &|| Ok(Vec::new()),
         )
         .unwrap();
 
-        assert!(service_called.load(std::sync::atomic::Ordering::SeqCst));
+        let recorded = events.lock().unwrap().clone();
+        assert_eq!(recorded, vec!["stop", "service"]);
     });
 }

--- a/bitloops/src/cli/uninstall/tests.rs
+++ b/bitloops/src/cli/uninstall/tests.rs
@@ -430,3 +430,35 @@ fn full_uninstall_removes_supported_temp_artefacts() {
         },
     );
 }
+
+#[test]
+fn service_uninstall_stops_daemon_best_effort_then_runs_service_uninstaller() {
+    let config = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+
+    with_platform_dirs(&config, &data, &cache, &state, &home, None, || {
+        let service_called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let service_called_ref = service_called.clone();
+
+        run_uninstall_for_test(
+            UninstallArgs {
+                service: true,
+                force: true,
+                ..UninstallArgs::default()
+            },
+            None,
+            None,
+            &move || {
+                service_called_ref.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            },
+            &|| Ok(Vec::new()),
+        )
+        .unwrap();
+
+        assert!(service_called.load(std::sync::atomic::Ordering::SeqCst));
+    });
+}


### PR DESCRIPTION
## Summary

- Updated the uninstall process to include error handling for stopping the Bitloops daemon, ensuring a more robust service uninstallation experience.
- Introduced a test to verify that the service uninstaller is called after attempting to stop the daemon, enhancing test coverage for the uninstall functionality.
- Added logging statements to provide insights during the dashboard startup phase and database initialisation, improving traceability and debugging capabilities.

## Validation

- [X] I ran the relevant tests locally.

## Jira

- [X] Linked Jira issue(s) are updated with implementation notes and test results. CLI-1581

