### PR TITLE
summary on deps

### DIFF
--- a/bitloops/schema.graphql
+++ b/bitloops/schema.graphql
@@ -310,7 +310,7 @@ type DepsSummary {
 input DepsSummaryFilterInput {
 	kind: EdgeKind
 	direction: DepsDirection
-	unresolved: DepsSummaryUnresolvedMode
+	unresolved: Boolean! = false
 }
 
 type DepsSummaryKindCounts {
@@ -320,12 +320,6 @@ type DepsSummaryKindCounts {
 	extends: Int!
 	implements: Int!
 	exports: Int!
-}
-
-enum DepsSummaryUnresolvedMode {
-	ALL
-	RESOLVED
-	UNRESOLVED
 }
 
 enum EdgeKind {

--- a/bitloops/schema.graphql
+++ b/bitloops/schema.graphql
@@ -40,6 +40,7 @@ type Artefact {
 	children(first: Int, after: String, last: Int, before: String): ArtefactConnection!
 	outgoingDeps(filter: DepsFilterInput, first: Int, after: String, last: Int, before: String): DependencyEdgeConnection!
 	incomingDeps(filter: DepsFilterInput, first: Int, after: String, last: Int, before: String): DependencyEdgeConnection!
+	depsSummary(filter: DepsSummaryFilterInput): DepsSummary!
 	clones(filter: ClonesFilterInput, first: Int, after: String, last: Int, before: String): CloneConnection!
 	chatHistory(first: Int, after: String, last: Int, before: String): ChatEntryConnection!
 	tests(minConfidence: Float, linkageSource: String, first: Int! = 25): [TestHarnessTestsResult!]!
@@ -299,6 +300,34 @@ input DepsFilterInput {
 	includeUnresolved: Boolean! = false
 }
 
+type DepsSummary {
+	totalCount: Int!
+	incomingCount: Int!
+	outgoingCount: Int!
+	kindCounts: DepsSummaryKindCounts!
+}
+
+input DepsSummaryFilterInput {
+	kind: EdgeKind
+	direction: DepsDirection
+	unresolved: DepsSummaryUnresolvedMode
+}
+
+type DepsSummaryKindCounts {
+	imports: Int!
+	calls: Int!
+	references: Int!
+	extends: Int!
+	implements: Int!
+	exports: Int!
+}
+
+enum DepsSummaryUnresolvedMode {
+	ALL
+	RESOLVED
+	UNRESOLVED
+}
+
 enum EdgeKind {
 	IMPORTS
 	CALLS
@@ -551,7 +580,7 @@ type MigrationRecord {
 type MutationRoot {
 	updateCliTelemetryConsent(cliVersion: String!, telemetry: Boolean): UpdateCliTelemetryConsentResult!
 	initSchema: InitSchemaResult!
-	ingest(input: IngestInput!): IngestResult!
+	ingest(input: IngestInput): IngestResult!
 	enqueueSync(input: EnqueueSyncInput!): EnqueueSyncResult!
 	addKnowledge(input: AddKnowledgeInput!): AddKnowledgeResult!
 	associateKnowledge(input: AssociateKnowledgeInput!): AssociateKnowledgeResult!

--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -310,7 +310,7 @@ type DepsSummary {
 input DepsSummaryFilterInput {
 	kind: EdgeKind
 	direction: DepsDirection
-	unresolved: DepsSummaryUnresolvedMode
+	unresolved: Boolean! = false
 }
 
 type DepsSummaryKindCounts {
@@ -320,12 +320,6 @@ type DepsSummaryKindCounts {
 	extends: Int!
 	implements: Int!
 	exports: Int!
-}
-
-enum DepsSummaryUnresolvedMode {
-	ALL
-	RESOLVED
-	UNRESOLVED
 }
 
 enum EdgeKind {

--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -40,6 +40,7 @@ type Artefact {
 	children(first: Int, after: String, last: Int, before: String): ArtefactConnection!
 	outgoingDeps(filter: DepsFilterInput, first: Int, after: String, last: Int, before: String): DependencyEdgeConnection!
 	incomingDeps(filter: DepsFilterInput, first: Int, after: String, last: Int, before: String): DependencyEdgeConnection!
+	depsSummary(filter: DepsSummaryFilterInput): DepsSummary!
 	clones(filter: ClonesFilterInput, first: Int, after: String, last: Int, before: String): CloneConnection!
 	chatHistory(first: Int, after: String, last: Int, before: String): ChatEntryConnection!
 	tests(minConfidence: Float, linkageSource: String, first: Int! = 25): [TestHarnessTestsResult!]!
@@ -299,6 +300,34 @@ input DepsFilterInput {
 	includeUnresolved: Boolean! = false
 }
 
+type DepsSummary {
+	totalCount: Int!
+	incomingCount: Int!
+	outgoingCount: Int!
+	kindCounts: DepsSummaryKindCounts!
+}
+
+input DepsSummaryFilterInput {
+	kind: EdgeKind
+	direction: DepsDirection
+	unresolved: DepsSummaryUnresolvedMode
+}
+
+type DepsSummaryKindCounts {
+	imports: Int!
+	calls: Int!
+	references: Int!
+	extends: Int!
+	implements: Int!
+	exports: Int!
+}
+
+enum DepsSummaryUnresolvedMode {
+	ALL
+	RESOLVED
+	UNRESOLVED
+}
+
 enum EdgeKind {
 	IMPORTS
 	CALLS
@@ -509,7 +538,7 @@ type MigrationRecord {
 type MutationRoot {
 	updateCliTelemetryConsent(cliVersion: String!, telemetry: Boolean): UpdateCliTelemetryConsentResult!
 	initSchema: InitSchemaResult!
-	ingest(input: IngestInput!): IngestResult!
+	ingest(input: IngestInput): IngestResult!
 	enqueueSync(input: EnqueueSyncInput!): EnqueueSyncResult!
 	addKnowledge(input: AddKnowledgeInput!): AddKnowledgeResult!
 	associateKnowledge(input: AssociateKnowledgeInput!): AssociateKnowledgeResult!

--- a/bitloops/src/api/tests/devql_repository_graph/artefacts.rs
+++ b/bitloops/src/api/tests/devql_repository_graph/artefacts.rs
@@ -783,7 +783,7 @@ async fn devql_dependency_summary_queries_resolve_direction_unresolved_kind_and_
                           incomingCount
                           outgoingCount
                         }
-                        unresolvedOnly: depsSummary(filter: { unresolved: UNRESOLVED }) {
+                        includeUnresolved: depsSummary(filter: { unresolved: true }) {
                           totalCount
                           incomingCount
                           outgoingCount
@@ -791,7 +791,7 @@ async fn devql_dependency_summary_queries_resolve_direction_unresolved_kind_and_
                             calls
                           }
                         }
-                        resolvedOnly: depsSummary(filter: { unresolved: RESOLVED }) {
+                        resolvedOnly: depsSummary(filter: { unresolved: false }) {
                           totalCount
                           incomingCount
                           outgoingCount
@@ -892,8 +892,8 @@ async fn devql_dependency_summary_queries_resolve_direction_unresolved_kind_and_
         1
     );
     assert_eq!(
-        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["unresolvedOnly"]["totalCount"],
-        0
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["includeUnresolved"]["totalCount"],
+        1
     );
 
     assert_eq!(
@@ -902,22 +902,22 @@ async fn devql_dependency_summary_queries_resolve_direction_unresolved_kind_and_
     );
     assert_eq!(
         json["repo"]["file"]["artefacts"]["edges"][1]["node"]["depsSummary"]["totalCount"],
-        1
+        0
     );
     assert_eq!(
         json["repo"]["file"]["artefacts"]["edges"][1]["node"]["outOnly"]["outgoingCount"],
-        1
+        0
     );
     assert_eq!(
         json["repo"]["file"]["artefacts"]["edges"][1]["node"]["resolvedOnly"]["totalCount"],
         0
     );
     assert_eq!(
-        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["unresolvedOnly"]["totalCount"],
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["includeUnresolved"]["totalCount"],
         1
     );
     assert_eq!(
-        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["unresolvedOnly"]["kindCounts"]["calls"],
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["includeUnresolved"]["kindCounts"]["calls"],
         1
     );
 

--- a/bitloops/src/api/tests/devql_repository_graph/artefacts.rs
+++ b/bitloops/src/api/tests/devql_repository_graph/artefacts.rs
@@ -747,6 +747,199 @@ async fn devql_dependency_queries_resolve_direction_and_unresolved_targets() {
 }
 
 #[tokio::test]
+async fn devql_dependency_summary_queries_resolve_direction_unresolved_kind_and_line_scope() {
+    let repo = seed_graphql_devql_repo();
+    let schema = crate::graphql::build_schema(crate::graphql::DevqlGraphqlContext::new(
+        repo.path().to_path_buf(),
+        super::super::super::db::DashboardDbPools::default(),
+    ));
+
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            {
+              repo(name: "demo") {
+                file(path: "src/caller.ts") {
+                  artefacts(filter: { kind: FUNCTION }) {
+                    totalCount
+                    edges {
+                      node {
+                        symbolFqn
+                        depsSummary {
+                          totalCount
+                          incomingCount
+                          outgoingCount
+                          kindCounts {
+                            imports
+                            calls
+                            references
+                            extends
+                            implements
+                            exports
+                          }
+                        }
+                        outOnly: depsSummary(filter: { direction: OUT }) {
+                          totalCount
+                          incomingCount
+                          outgoingCount
+                        }
+                        unresolvedOnly: depsSummary(filter: { unresolved: UNRESOLVED }) {
+                          totalCount
+                          incomingCount
+                          outgoingCount
+                          kindCounts {
+                            calls
+                          }
+                        }
+                        resolvedOnly: depsSummary(filter: { unresolved: RESOLVED }) {
+                          totalCount
+                          incomingCount
+                          outgoingCount
+                        }
+                        importsOnly: depsSummary(filter: { kind: IMPORTS }) {
+                          totalCount
+                          incomingCount
+                          outgoingCount
+                        }
+                      }
+                    }
+                  }
+                  lineScoped: artefacts(filter: { kind: FUNCTION, lines: { start: 1, end: 3 } }) {
+                    totalCount
+                    edges {
+                      node {
+                        symbolFqn
+                        depsSummary {
+                          totalCount
+                          outgoingCount
+                        }
+                      }
+                    }
+                  }
+                }
+                artefacts(filter: { symbolFqn: "src/target.ts::target" }) {
+                  edges {
+                    node {
+                      inOnly: depsSummary(filter: { direction: IN }) {
+                        totalCount
+                        incomingCount
+                        outgoingCount
+                        kindCounts {
+                          calls
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "graphql errors: {:?}",
+        response.errors
+    );
+
+    let json = response.data.into_json().expect("graphql data to json");
+    assert_eq!(json["repo"]["file"]["artefacts"]["totalCount"], 2);
+    assert_eq!(json["repo"]["file"]["lineScoped"]["totalCount"], 1);
+    assert_eq!(
+        json["repo"]["file"]["lineScoped"]["edges"][0]["node"]["symbolFqn"],
+        "src/caller.ts::caller"
+    );
+    assert_eq!(
+        json["repo"]["file"]["lineScoped"]["edges"][0]["node"]["depsSummary"]["totalCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["lineScoped"]["edges"][0]["node"]["depsSummary"]["outgoingCount"],
+        1
+    );
+
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["symbolFqn"],
+        "src/caller.ts::caller"
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["depsSummary"]["totalCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["depsSummary"]["incomingCount"],
+        0
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["depsSummary"]["outgoingCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["depsSummary"]["kindCounts"]["calls"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["depsSummary"]["kindCounts"]["imports"],
+        0
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["importsOnly"]["totalCount"],
+        0
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["resolvedOnly"]["totalCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][0]["node"]["unresolvedOnly"]["totalCount"],
+        0
+    );
+
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["symbolFqn"],
+        "src/caller.ts::helper"
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["depsSummary"]["totalCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["outOnly"]["outgoingCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["resolvedOnly"]["totalCount"],
+        0
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["unresolvedOnly"]["totalCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["file"]["artefacts"]["edges"][1]["node"]["unresolvedOnly"]["kindCounts"]["calls"],
+        1
+    );
+
+    assert_eq!(
+        json["repo"]["artefacts"]["edges"][0]["node"]["inOnly"]["totalCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["artefacts"]["edges"][0]["node"]["inOnly"]["incomingCount"],
+        1
+    );
+    assert_eq!(
+        json["repo"]["artefacts"]["edges"][0]["node"]["inOnly"]["outgoingCount"],
+        0
+    );
+    assert_eq!(
+        json["repo"]["artefacts"]["edges"][0]["node"]["inOnly"]["kindCounts"]["calls"],
+        1
+    );
+}
+
+#[tokio::test]
 async fn devql_graphql_artefact_resolvers_validate_paths_and_line_ranges() {
     let repo = seed_graphql_devql_repo();
     let schema = crate::graphql::build_schema(crate::graphql::DevqlGraphqlContext::new(

--- a/bitloops/src/api/tests/support_graphql_knowledge.rs
+++ b/bitloops/src/api/tests/support_graphql_knowledge.rs
@@ -190,26 +190,19 @@ pub(super) fn seed_graphql_devql_repo() -> TempDir {
         };
         conn.execute(
             "INSERT INTO artefacts (
-                artefact_id, symbol_id, repo_id, blob_sha, path, language, canonical_kind,
-                language_kind, symbol_fqn, parent_artefact_id, start_line, end_line,
-                start_byte, end_byte, signature, modifiers, docstring, content_hash, created_at
+                artefact_id, symbol_id, repo_id, language, canonical_kind,
+                language_kind, symbol_fqn, signature, modifiers, docstring, content_hash, created_at
             ) VALUES (
-                ?1, ?2, ?3, ?4, ?5, 'typescript', ?6,
-                ?7, ?8, ?9, ?10, ?11, 0, ?12, NULL, ?13, ?14, ?15, '2026-03-26T09:00:00Z'
+                ?1, ?2, ?3, 'typescript', ?4,
+                ?5, ?6, NULL, ?7, ?8, ?9, '2026-03-26T09:00:00Z'
             )",
             rusqlite::params![
                 artefact_id,
                 symbol_id,
                 repo_id.as_str(),
-                blob_sha,
-                path,
                 canonical_kind,
                 language_kind,
                 symbol_fqn,
-                parent_artefact_id,
-                start_line,
-                end_line,
-                end_line * 10,
                 if canonical_kind == "file" {
                     "[]"
                 } else {
@@ -224,6 +217,26 @@ pub(super) fn seed_graphql_devql_repo() -> TempDir {
             ],
         )
         .expect("insert artefact row");
+        conn.execute(
+            "INSERT INTO artefact_snapshots (
+                repo_id, blob_sha, path, artefact_id, parent_artefact_id,
+                start_line, end_line, start_byte, end_byte, created_at
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5,
+                ?6, ?7, 0, ?8, '2026-03-26T09:00:00Z'
+            )",
+            rusqlite::params![
+                repo_id.as_str(),
+                blob_sha,
+                path,
+                artefact_id,
+                parent_artefact_id,
+                start_line,
+                end_line,
+                end_line * 10,
+            ],
+        )
+        .expect("insert artefact snapshot row");
         conn.execute(
             "INSERT INTO artefacts_current (
                 repo_id, path, content_id, symbol_id, artefact_id,

--- a/bitloops/src/graphql/types.rs
+++ b/bitloops/src/graphql/types.rs
@@ -30,7 +30,10 @@ pub use connection::{
     KnowledgeRelationConnection, KnowledgeRelationEdge, KnowledgeVersionConnection,
     KnowledgeVersionEdge, TelemetryEventConnection, TelemetryEventEdge, paginate_items,
 };
-pub use dependency_edge::{DependencyEdge, DepsDirection, DepsFilterInput, EdgeKind};
+pub use dependency_edge::{
+    DependencyEdge, DepsDirection, DepsFilterInput, DepsSummary, DepsSummaryFilterInput,
+    DepsSummaryUnresolvedMode, EdgeKind,
+};
 pub use file_context::FileContext;
 pub use health::{HealthBackendStatus, HealthStatus};
 pub use ingestion::IngestionProgressEvent;

--- a/bitloops/src/graphql/types.rs
+++ b/bitloops/src/graphql/types.rs
@@ -31,8 +31,7 @@ pub use connection::{
     KnowledgeVersionEdge, TelemetryEventConnection, TelemetryEventEdge, paginate_items,
 };
 pub use dependency_edge::{
-    DependencyEdge, DepsDirection, DepsFilterInput, DepsSummary, DepsSummaryFilterInput,
-    DepsSummaryUnresolvedMode, EdgeKind,
+    DependencyEdge, DepsDirection, DepsFilterInput, DepsSummary, DepsSummaryFilterInput, EdgeKind,
 };
 pub use file_context::FileContext;
 pub use health::{HealthBackendStatus, HealthStatus};

--- a/bitloops/src/graphql/types/artefact.rs
+++ b/bitloops/src/graphql/types/artefact.rs
@@ -10,8 +10,9 @@ use crate::graphql::{
 use super::{
     ArtefactConnection, ArtefactEdge, ChatEntryConnection, ChatEntryEdge, CloneConnection,
     CloneEdge, CloneSummary, ClonesFilterInput, ConnectionPagination, DateTimeScalar,
-    DependencyConnectionEdge, DependencyEdgeConnection, DepsFilterInput, TestHarnessCoverageResult,
-    TestHarnessTestsResult, paginate_items,
+    DependencyConnectionEdge, DependencyEdge, DependencyEdgeConnection, DepsDirection,
+    DepsFilterInput, DepsSummary, DepsSummaryFilterInput, DepsSummaryUnresolvedMode,
+    TestHarnessCoverageResult, TestHarnessTestsResult, paginate_items,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
@@ -296,6 +297,56 @@ impl Artefact {
         ))
     }
 
+    #[graphql(name = "depsSummary")]
+    async fn deps_summary(
+        &self,
+        ctx: &Context<'_>,
+        filter: Option<DepsSummaryFilterInput>,
+    ) -> Result<DepsSummary> {
+        let filter = filter.unwrap_or_default();
+        let direction = filter.direction.unwrap_or(DepsDirection::Both);
+        let unresolved_mode = filter.unresolved.unwrap_or(DepsSummaryUnresolvedMode::All);
+        let include_unresolved = !matches!(unresolved_mode, DepsSummaryUnresolvedMode::Resolved);
+        let deps_filter = DepsFilterInput {
+            kind: filter.kind,
+            direction,
+            include_unresolved,
+        };
+
+        let loaders = ctx.data_unchecked::<DataLoaders>();
+        let outgoing = if matches!(direction, DepsDirection::Out | DepsDirection::Both) {
+            let edges = loaders
+                .load_outgoing_edges(self.id.as_ref(), Some(deps_filter), &self.scope)
+                .await
+                .map_err(|err| {
+                    backend_error(format!(
+                        "failed to resolve outgoing dependency summary for {}: {err:#}",
+                        self.id.as_ref()
+                    ))
+                })?;
+            filter_edges_by_unresolved_mode(edges, unresolved_mode)
+        } else {
+            Vec::new()
+        };
+
+        let incoming = if matches!(direction, DepsDirection::In | DepsDirection::Both) {
+            let edges = loaders
+                .load_incoming_edges(self.id.as_ref(), Some(deps_filter), &self.scope)
+                .await
+                .map_err(|err| {
+                    backend_error(format!(
+                        "failed to resolve incoming dependency summary for {}: {err:#}",
+                        self.id.as_ref()
+                    ))
+                })?;
+            filter_edges_by_unresolved_mode(edges, unresolved_mode)
+        } else {
+            Vec::new()
+        };
+
+        Ok(DepsSummary::from_edges(&incoming, &outgoing))
+    }
+
     async fn clones(
         &self,
         ctx: &Context<'_>,
@@ -440,6 +491,23 @@ fn stage_limit(first: i32) -> Result<usize> {
         return Err(bad_user_input_error("`first` must be greater than 0"));
     }
     Ok(first as usize)
+}
+
+fn filter_edges_by_unresolved_mode(
+    edges: Vec<DependencyEdge>,
+    unresolved_mode: DepsSummaryUnresolvedMode,
+) -> Vec<DependencyEdge> {
+    match unresolved_mode {
+        DepsSummaryUnresolvedMode::All => edges,
+        DepsSummaryUnresolvedMode::Resolved => edges
+            .into_iter()
+            .filter(|edge| edge.to_artefact_id.is_some())
+            .collect(),
+        DepsSummaryUnresolvedMode::Unresolved => edges
+            .into_iter()
+            .filter(|edge| edge.to_artefact_id.is_none())
+            .collect(),
+    }
 }
 
 fn build_tests_stage_args(

--- a/bitloops/src/graphql/types/artefact.rs
+++ b/bitloops/src/graphql/types/artefact.rs
@@ -10,9 +10,9 @@ use crate::graphql::{
 use super::{
     ArtefactConnection, ArtefactEdge, ChatEntryConnection, ChatEntryEdge, CloneConnection,
     CloneEdge, CloneSummary, ClonesFilterInput, ConnectionPagination, DateTimeScalar,
-    DependencyConnectionEdge, DependencyEdge, DependencyEdgeConnection, DepsDirection,
-    DepsFilterInput, DepsSummary, DepsSummaryFilterInput, DepsSummaryUnresolvedMode,
-    TestHarnessCoverageResult, TestHarnessTestsResult, paginate_items,
+    DependencyConnectionEdge, DependencyEdgeConnection, DepsDirection, DepsFilterInput,
+    DepsSummary, DepsSummaryFilterInput, TestHarnessCoverageResult, TestHarnessTestsResult,
+    paginate_items,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
@@ -305,17 +305,15 @@ impl Artefact {
     ) -> Result<DepsSummary> {
         let filter = filter.unwrap_or_default();
         let direction = filter.direction.unwrap_or(DepsDirection::Both);
-        let unresolved_mode = filter.unresolved.unwrap_or(DepsSummaryUnresolvedMode::All);
-        let include_unresolved = !matches!(unresolved_mode, DepsSummaryUnresolvedMode::Resolved);
         let deps_filter = DepsFilterInput {
             kind: filter.kind,
             direction,
-            include_unresolved,
+            include_unresolved: filter.unresolved,
         };
 
         let loaders = ctx.data_unchecked::<DataLoaders>();
         let outgoing = if matches!(direction, DepsDirection::Out | DepsDirection::Both) {
-            let edges = loaders
+            loaders
                 .load_outgoing_edges(self.id.as_ref(), Some(deps_filter), &self.scope)
                 .await
                 .map_err(|err| {
@@ -323,14 +321,13 @@ impl Artefact {
                         "failed to resolve outgoing dependency summary for {}: {err:#}",
                         self.id.as_ref()
                     ))
-                })?;
-            filter_edges_by_unresolved_mode(edges, unresolved_mode)
+                })?
         } else {
             Vec::new()
         };
 
         let incoming = if matches!(direction, DepsDirection::In | DepsDirection::Both) {
-            let edges = loaders
+            loaders
                 .load_incoming_edges(self.id.as_ref(), Some(deps_filter), &self.scope)
                 .await
                 .map_err(|err| {
@@ -338,8 +335,7 @@ impl Artefact {
                         "failed to resolve incoming dependency summary for {}: {err:#}",
                         self.id.as_ref()
                     ))
-                })?;
-            filter_edges_by_unresolved_mode(edges, unresolved_mode)
+                })?
         } else {
             Vec::new()
         };
@@ -491,23 +487,6 @@ fn stage_limit(first: i32) -> Result<usize> {
         return Err(bad_user_input_error("`first` must be greater than 0"));
     }
     Ok(first as usize)
-}
-
-fn filter_edges_by_unresolved_mode(
-    edges: Vec<DependencyEdge>,
-    unresolved_mode: DepsSummaryUnresolvedMode,
-) -> Vec<DependencyEdge> {
-    match unresolved_mode {
-        DepsSummaryUnresolvedMode::All => edges,
-        DepsSummaryUnresolvedMode::Resolved => edges
-            .into_iter()
-            .filter(|edge| edge.to_artefact_id.is_some())
-            .collect(),
-        DepsSummaryUnresolvedMode::Unresolved => edges
-            .into_iter()
-            .filter(|edge| edge.to_artefact_id.is_none())
-            .collect(),
-    }
 }
 
 fn build_tests_stage_args(

--- a/bitloops/src/graphql/types/dependency_edge.rs
+++ b/bitloops/src/graphql/types/dependency_edge.rs
@@ -35,13 +35,6 @@ pub enum DepsDirection {
     Both,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
-pub enum DepsSummaryUnresolvedMode {
-    All,
-    Resolved,
-    Unresolved,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, InputObject)]
 pub struct DepsFilterInput {
     pub kind: Option<EdgeKind>,
@@ -65,7 +58,8 @@ impl Default for DepsFilterInput {
 pub struct DepsSummaryFilterInput {
     pub kind: Option<EdgeKind>,
     pub direction: Option<DepsDirection>,
-    pub unresolved: Option<DepsSummaryUnresolvedMode>,
+    #[graphql(default)]
+    pub unresolved: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, SimpleObject)]

--- a/bitloops/src/graphql/types/dependency_edge.rs
+++ b/bitloops/src/graphql/types/dependency_edge.rs
@@ -35,6 +35,13 @@ pub enum DepsDirection {
     Both,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+pub enum DepsSummaryUnresolvedMode {
+    All,
+    Resolved,
+    Unresolved,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, InputObject)]
 pub struct DepsFilterInput {
     pub kind: Option<EdgeKind>,
@@ -50,6 +57,80 @@ impl Default for DepsFilterInput {
             kind: None,
             direction: DepsDirection::Out,
             include_unresolved: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, InputObject, Default)]
+pub struct DepsSummaryFilterInput {
+    pub kind: Option<EdgeKind>,
+    pub direction: Option<DepsDirection>,
+    pub unresolved: Option<DepsSummaryUnresolvedMode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, SimpleObject)]
+pub struct DepsSummaryKindCounts {
+    pub imports: i32,
+    pub calls: i32,
+    pub references: i32,
+    pub extends: i32,
+    pub implements: i32,
+    pub exports: i32,
+}
+
+impl DepsSummaryKindCounts {
+    pub(crate) fn increment(&mut self, kind: EdgeKind) {
+        match kind {
+            EdgeKind::Imports => self.imports = self.imports.saturating_add(1),
+            EdgeKind::Calls => self.calls = self.calls.saturating_add(1),
+            EdgeKind::References => self.references = self.references.saturating_add(1),
+            EdgeKind::Extends => self.extends = self.extends.saturating_add(1),
+            EdgeKind::Implements => self.implements = self.implements.saturating_add(1),
+            EdgeKind::Exports => self.exports = self.exports.saturating_add(1),
+        }
+    }
+
+    pub(crate) fn merge(&mut self, other: &Self) {
+        self.imports = self.imports.saturating_add(other.imports);
+        self.calls = self.calls.saturating_add(other.calls);
+        self.references = self.references.saturating_add(other.references);
+        self.extends = self.extends.saturating_add(other.extends);
+        self.implements = self.implements.saturating_add(other.implements);
+        self.exports = self.exports.saturating_add(other.exports);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, SimpleObject)]
+pub struct DepsSummary {
+    pub total_count: i32,
+    pub incoming_count: i32,
+    pub outgoing_count: i32,
+    pub kind_counts: DepsSummaryKindCounts,
+}
+
+impl DepsSummary {
+    pub(crate) fn from_edges(incoming: &[DependencyEdge], outgoing: &[DependencyEdge]) -> Self {
+        fn count_kind(edges: &[DependencyEdge]) -> DepsSummaryKindCounts {
+            let mut counts = DepsSummaryKindCounts::default();
+            for edge in edges {
+                counts.increment(edge.edge_kind);
+            }
+            counts
+        }
+
+        let incoming_count = i32::try_from(incoming.len()).unwrap_or(i32::MAX);
+        let outgoing_count = i32::try_from(outgoing.len()).unwrap_or(i32::MAX);
+        let total_count = incoming_count.saturating_add(outgoing_count);
+        let incoming_kind_counts = count_kind(incoming);
+        let outgoing_kind_counts = count_kind(outgoing);
+        let mut kind_counts = incoming_kind_counts;
+        kind_counts.merge(&outgoing_kind_counts);
+
+        Self {
+            total_count,
+            incoming_count,
+            outgoing_count,
+            kind_counts,
         }
     }
 }

--- a/bitloops/src/host/devql/query/dsl_compiler/args.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/args.rs
@@ -111,18 +111,14 @@ pub(super) fn compile_deps_summary_args(spec: DepsSummaryStageSpec) -> Vec<Graph
         };
         fields.push(format!("direction: {}", enum_literal(direction)));
     }
-    if let Some(unresolved) = spec.unresolved {
-        let unresolved = match unresolved {
-            super::types::DepsSummaryUnresolvedSelector::All => "all",
-            super::types::DepsSummaryUnresolvedSelector::Resolved => "resolved",
-            super::types::DepsSummaryUnresolvedSelector::Unresolved => "unresolved",
-        };
-        fields.push(format!("unresolved: {}", enum_literal(unresolved)));
-    }
-
-    if fields.is_empty() {
-        return Vec::new();
-    }
+    fields.push(format!(
+        "unresolved: {}",
+        if spec.unresolved.unwrap_or(false) {
+            "true"
+        } else {
+            "false"
+        }
+    ));
 
     vec![GraphqlArgument::new(
         "filter",

--- a/bitloops/src/host/devql/query/dsl_compiler/args.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/args.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 use super::document_builder::{GraphqlArgument, GraphqlField, GraphqlSelection};
 use super::field_mapping::{compile_datetime_literal, enum_literal, quote_graphql_string};
+use super::types::DepsSummaryStageSpec;
 use super::{ParsedDevqlQuery, RegisteredStageCall};
 
 pub(super) fn compile_artefact_args(
@@ -87,6 +88,46 @@ pub(super) fn compile_clone_summary_args(
         args.push(GraphqlArgument::new("cloneFilter", clone_filter));
     }
     Ok(args)
+}
+
+pub(super) fn compile_deps_summary_args(spec: DepsSummaryStageSpec) -> Vec<GraphqlArgument> {
+    let mut fields = Vec::new();
+    if let Some(kind) = spec.kind {
+        let kind = match kind {
+            super::super::DepsKind::Imports => "imports",
+            super::super::DepsKind::Calls => "calls",
+            super::super::DepsKind::References => "references",
+            super::super::DepsKind::Extends => "extends",
+            super::super::DepsKind::Implements => "implements",
+            super::super::DepsKind::Exports => "exports",
+        };
+        fields.push(format!("kind: {}", enum_literal(kind)));
+    }
+    if let Some(direction) = spec.direction {
+        let direction = match direction {
+            super::super::DepsDirection::Out => "out",
+            super::super::DepsDirection::In => "in",
+            super::super::DepsDirection::Both => "both",
+        };
+        fields.push(format!("direction: {}", enum_literal(direction)));
+    }
+    if let Some(unresolved) = spec.unresolved {
+        let unresolved = match unresolved {
+            super::types::DepsSummaryUnresolvedSelector::All => "all",
+            super::types::DepsSummaryUnresolvedSelector::Resolved => "resolved",
+            super::types::DepsSummaryUnresolvedSelector::Unresolved => "unresolved",
+        };
+        fields.push(format!("unresolved: {}", enum_literal(unresolved)));
+    }
+
+    if fields.is_empty() {
+        return Vec::new();
+    }
+
+    vec![GraphqlArgument::new(
+        "filter",
+        format!("{{ {} }}", fields.join(", ")),
+    )]
 }
 
 pub(super) fn compile_knowledge_args(

--- a/bitloops/src/host/devql/query/dsl_compiler/field_mapping.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/field_mapping.rs
@@ -261,6 +261,27 @@ pub(super) fn clone_summary_selections() -> Vec<GraphqlSelection> {
     ]
 }
 
+pub(super) fn deps_summary_selections() -> Vec<GraphqlSelection> {
+    vec![
+        GraphqlSelection::scalar("totalCount"),
+        GraphqlSelection::scalar("incomingCount"),
+        GraphqlSelection::scalar("outgoingCount"),
+        GraphqlField::new(
+            "kindCounts",
+            Vec::new(),
+            vec![
+                GraphqlSelection::scalar("imports"),
+                GraphqlSelection::scalar("calls"),
+                GraphqlSelection::scalar("references"),
+                GraphqlSelection::scalar("extends"),
+                GraphqlSelection::scalar("implements"),
+                GraphqlSelection::scalar("exports"),
+            ],
+        )
+        .into(),
+    ]
+}
+
 fn map_selected_field(leaf: SelectableLeaf, field: &str) -> Result<String> {
     let graphql = dsl_field_to_graphql(field);
     if allowed_fields_for_leaf(leaf).contains(&graphql.as_str()) {

--- a/bitloops/src/host/devql/query/dsl_compiler/leaves.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/leaves.rs
@@ -2,13 +2,14 @@ use anyhow::{Result, bail};
 
 use super::args::{
     compile_artefact_args, compile_checkpoint_args, compile_clone_summary_args,
-    compile_clones_args, compile_coverage_args, compile_deps_args, compile_knowledge_args,
-    compile_telemetry_args, compile_tests_args, connection_field, first_arg,
+    compile_clones_args, compile_coverage_args, compile_deps_args, compile_deps_summary_args,
+    compile_knowledge_args, compile_telemetry_args, compile_tests_args, connection_field,
+    first_arg,
 };
 use super::document_builder::{GraphqlArgument, GraphqlField};
 use super::field_mapping::{
     KNOWLEDGE_STAGE_NAME, SelectableLeaf, clone_result_selections, clone_summary_selections,
-    compile_as_of_input, coverage_result_selections, quote_graphql_string,
+    compile_as_of_input, coverage_result_selections, deps_summary_selections, quote_graphql_string,
     scalar_selections_for_leaf, tests_result_selections, tests_summary_result_selections,
 };
 use super::{GraphqlCompileMode, ParsedDevqlQuery, RegisteredStageCall, RegisteredStageKind};
@@ -61,6 +62,11 @@ pub(super) fn compile_project_stage_leaf(
     match registered_stage {
         RegisteredStageKind::CloneSummary => {
             bail!("summary() is not a project-level registered stage in the GraphQL compiler")
+        }
+        RegisteredStageKind::DepsSummary(_) => {
+            bail!(
+                "summary(deps:true, ...) is not a project-level registered stage in the GraphQL compiler"
+            )
         }
         RegisteredStageKind::Tests(stage) => Ok(GraphqlField::new(
             "tests",
@@ -197,6 +203,14 @@ fn compile_artefacts_leaf(
             RegisteredStageKind::CloneSummary => {
                 bail!("summary() cannot be nested under artefacts() in the GraphQL compiler")
             }
+            RegisteredStageKind::DepsSummary(spec) => node_selections.push(
+                GraphqlField::new(
+                    "depsSummary",
+                    compile_deps_summary_args(spec),
+                    deps_summary_selections(),
+                )
+                .into(),
+            ),
             RegisteredStageKind::TestsSummary => {
                 bail!("test_harness_tests_summary() cannot be nested under artefacts()")
             }

--- a/bitloops/src/host/devql/query/dsl_compiler/tests.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/tests.rs
@@ -131,6 +131,166 @@ fn compile_clone_summary_stage_rejects_invalid_since_literal() {
 }
 
 #[test]
+fn compile_deps_summary_stage_under_artefacts() {
+    let parsed = parse_devql_query(
+        r#"repo("bitloops-cli")->file("src/main.rs")->artefacts(lines:1..20,kind:"function")->summary(deps:true,direction:"both",unresolved:"all",kind:"calls")->limit(5)"#,
+    )
+    .expect("query parses");
+
+    let graphql = compile_devql_to_graphql(&parsed).expect("graphql compiles");
+
+    assert_eq!(
+        graphql,
+        r#"query {
+  repo(name: "bitloops-cli") {
+    file(path: "src/main.rs") {
+      artefacts(filter: { kind: FUNCTION, lines: { start: 1, end: 20 } }) {
+        edges {
+          node {
+            id
+            path
+            symbolFqn
+            canonicalKind
+            languageKind
+            startLine
+            endLine
+            language
+            depsSummary(filter: { kind: CALLS, direction: BOTH, unresolved: ALL }) {
+              totalCount
+              incomingCount
+              outgoingCount
+              kindCounts {
+                imports
+                calls
+                references
+                extends
+                implements
+                exports
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}"#
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_requires_artefacts() {
+    let parsed =
+        parse_devql_query(r#"repo("bitloops-cli")->summary(deps:true)"#).expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("summary deps requires artefacts");
+    assert!(
+        err.to_string()
+            .contains("summary(deps:true, ...) requires an artefacts() stage"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_rejects_invalid_arguments() {
+    let parsed = parse_devql_query(
+        r#"repo("bitloops-cli")->artefacts()->summary(deps:true,unsupported:"x")"#,
+    )
+    .expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("unsupported summary arg must fail");
+    assert!(
+        err.to_string()
+            .contains("received unsupported argument `unsupported`"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_requires_deps_true() {
+    let parsed = parse_devql_query(r#"repo("bitloops-cli")->artefacts()->summary(deps:false)"#)
+        .expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("deps must be true");
+    assert!(
+        err.to_string()
+            .contains("summary(deps:...) requires deps:true"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_rejects_invalid_direction_value() {
+    let parsed = parse_devql_query(
+        r#"repo("bitloops-cli")->artefacts()->summary(deps:true,direction:"sideways")"#,
+    )
+    .expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("invalid direction value must fail");
+    assert!(
+        err.to_string()
+            .contains("summary(direction:...) must be one of: out, in, both"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_rejects_invalid_kind_value() {
+    let parsed =
+        parse_devql_query(r#"repo("bitloops-cli")->artefacts()->summary(deps:true,kind:"bogus")"#)
+            .expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("invalid kind value must fail");
+    assert!(
+        err.to_string()
+            .contains("summary(kind:...) must be one of: imports, calls, references, extends, implements, exports"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_rejects_invalid_unresolved_value() {
+    let parsed = parse_devql_query(
+        r#"repo("bitloops-cli")->artefacts()->summary(deps:true,unresolved:"maybe")"#,
+    )
+    .expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("invalid unresolved value must fail");
+    assert!(
+        err.to_string()
+            .contains("summary(unresolved:...) must be one of: all, resolved, unresolved"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_rejects_combination_with_deps_stage() {
+    let parsed =
+        parse_devql_query(r#"repo("bitloops-cli")->artefacts()->deps()->summary(deps:true)"#)
+            .expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("deps + deps summary should fail");
+    assert!(
+        err.to_string()
+            .contains("summary(deps:true, ...) cannot be combined with deps() stage"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_rejects_combination_with_clones_stage() {
+    let parsed =
+        parse_devql_query(r#"repo("bitloops-cli")->artefacts()->clones()->summary(deps:true)"#)
+            .expect("query parses");
+
+    let err = compile_devql_to_graphql(&parsed).expect_err("clones + deps summary should fail");
+    assert!(
+        err.to_string()
+            .contains("summary(deps:true, ...) cannot be combined with clones() stage"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
 fn compile_file_artefacts_with_chat_history_enrichment() {
     let parsed = parse_devql_query(
         r#"repo("bitloops-cli")->file("src/main.rs")->artefacts(lines:1..20,kind:"function")->chatHistory()->limit(5)"#,

--- a/bitloops/src/host/devql/query/dsl_compiler/tests.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/tests.rs
@@ -133,7 +133,7 @@ fn compile_clone_summary_stage_rejects_invalid_since_literal() {
 #[test]
 fn compile_deps_summary_stage_under_artefacts() {
     let parsed = parse_devql_query(
-        r#"repo("bitloops-cli")->file("src/main.rs")->artefacts(lines:1..20,kind:"function")->summary(deps:true,direction:"both",unresolved:"all",kind:"calls")->limit(5)"#,
+        r#"repo("bitloops-cli")->file("src/main.rs")->artefacts(lines:1..20,kind:"function")->summary(deps:true,direction:"both",unresolved:true,kind:"calls")->limit(5)"#,
     )
     .expect("query parses");
 
@@ -155,7 +155,7 @@ fn compile_deps_summary_stage_under_artefacts() {
             startLine
             endLine
             language
-            depsSummary(filter: { kind: CALLS, direction: BOTH, unresolved: ALL }) {
+            depsSummary(filter: { kind: CALLS, direction: BOTH, unresolved: true }) {
               totalCount
               incomingCount
               outgoingCount
@@ -174,6 +174,21 @@ fn compile_deps_summary_stage_under_artefacts() {
     }
   }
 }"#
+    );
+}
+
+#[test]
+fn compile_deps_summary_stage_defaults_to_resolved_when_unresolved_is_omitted() {
+    let parsed = parse_devql_query(
+        r#"repo("bitloops-cli")->file("src/main.rs")->artefacts(lines:1..20,kind:"function")->summary(deps:true,direction:"both",kind:"calls")->limit(5)"#,
+    )
+    .expect("query parses");
+
+    let graphql = compile_devql_to_graphql(&parsed).expect("graphql compiles");
+    assert!(
+        graphql
+            .contains("depsSummary(filter: { kind: CALLS, direction: BOTH, unresolved: false })"),
+        "unexpected graphql: {graphql}"
     );
 }
 
@@ -257,7 +272,7 @@ fn compile_deps_summary_stage_rejects_invalid_unresolved_value() {
     let err = compile_devql_to_graphql(&parsed).expect_err("invalid unresolved value must fail");
     assert!(
         err.to_string()
-            .contains("summary(unresolved:...) must be one of: all, resolved, unresolved"),
+            .contains("summary(unresolved:...) must be boolean true/false"),
         "unexpected error: {err:#}"
     );
 }

--- a/bitloops/src/host/devql/query/dsl_compiler/types.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/types.rs
@@ -7,17 +7,10 @@ pub(crate) enum GraphqlCompileMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum DepsSummaryUnresolvedSelector {
-    All,
-    Resolved,
-    Unresolved,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct DepsSummaryStageSpec {
     pub(super) kind: Option<DepsKind>,
     pub(super) direction: Option<DepsDirection>,
-    pub(super) unresolved: Option<DepsSummaryUnresolvedSelector>,
+    pub(super) unresolved: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/bitloops/src/host/devql/query/dsl_compiler/types.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/types.rs
@@ -1,12 +1,29 @@
+use super::{DepsDirection, DepsKind};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GraphqlCompileMode {
     Global,
     Slim,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DepsSummaryUnresolvedSelector {
+    All,
+    Resolved,
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DepsSummaryStageSpec {
+    pub(super) kind: Option<DepsKind>,
+    pub(super) direction: Option<DepsDirection>,
+    pub(super) unresolved: Option<DepsSummaryUnresolvedSelector>,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(super) enum RegisteredStageKind<'a> {
     CloneSummary,
+    DepsSummary(DepsSummaryStageSpec),
     Tests(&'a super::RegisteredStageCall),
     Coverage,
     TestsSummary,

--- a/bitloops/src/host/devql/query/dsl_compiler/validation.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/validation.rs
@@ -4,7 +4,8 @@ use super::field_mapping::{
     CLONE_SUMMARY_STAGE_NAME, KNOWLEDGE_STAGE_NAME, TESTS_SUMMARY_STAGE_NAME,
     is_coverage_stage_name, is_tests_stage_name,
 };
-use super::{GraphqlCompileMode, ParsedDevqlQuery, RegisteredStageKind};
+use super::types::{DepsSummaryStageSpec, DepsSummaryUnresolvedSelector};
+use super::{GraphqlCompileMode, ParsedDevqlQuery, RegisteredStageCall, RegisteredStageKind};
 
 pub(super) fn resolve_registered_stage(
     parsed: &ParsedDevqlQuery,
@@ -20,7 +21,7 @@ pub(super) fn resolve_registered_stage(
     };
 
     if stage.stage_name == CLONE_SUMMARY_STAGE_NAME {
-        return Ok(Some(RegisteredStageKind::CloneSummary));
+        return Ok(Some(resolve_summary_stage_kind(stage)?));
     }
     if is_tests_stage_name(&stage.stage_name) {
         return Ok(Some(RegisteredStageKind::Tests(stage)));
@@ -39,6 +40,78 @@ pub(super) fn resolve_registered_stage(
         "the GraphQL compiler does not support capability-pack stage `{}`; register an explicit typed GraphQL/DSL contribution",
         stage.stage_name
     )
+}
+
+fn resolve_summary_stage_kind(stage: &RegisteredStageCall) -> Result<RegisteredStageKind<'_>> {
+    let Some(deps_arg) = stage.args.get("deps") else {
+        if !stage.args.is_empty() {
+            bail!(
+                "summary() for clones does not accept arguments; use summary(deps:true, ...) for dependency summary"
+            );
+        }
+        return Ok(RegisteredStageKind::CloneSummary);
+    };
+
+    let deps_enabled = super::super::parse_bool_literal("summary deps", deps_arg)?;
+    if !deps_enabled {
+        bail!("summary(deps:...) requires deps:true");
+    }
+
+    for key in stage.args.keys() {
+        match key.as_str() {
+            "deps" | "kind" | "direction" | "unresolved" => {}
+            _ => {
+                bail!(
+                    "summary(deps:true, ...) received unsupported argument `{key}`; allowed args: deps, kind, direction, unresolved"
+                );
+            }
+        }
+    }
+
+    let kind = if let Some(kind) = stage.args.get("kind") {
+        Some(super::super::DepsKind::from_str(kind).ok_or_else(|| {
+            anyhow::anyhow!(
+                "summary(kind:...) must be one of: {}",
+                super::super::DepsKind::all_names().join(", ")
+            )
+        })?)
+    } else {
+        None
+    };
+
+    let direction = if let Some(direction) = stage.args.get("direction") {
+        Some(
+            super::super::DepsDirection::from_str(direction).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "summary(direction:...) must be one of: {}",
+                    super::super::DepsDirection::all_names().join(", ")
+                )
+            })?,
+        )
+    } else {
+        None
+    };
+
+    let unresolved = if let Some(unresolved) = stage.args.get("unresolved") {
+        Some(parse_summary_unresolved_selector(unresolved)?)
+    } else {
+        None
+    };
+
+    Ok(RegisteredStageKind::DepsSummary(DepsSummaryStageSpec {
+        kind,
+        direction,
+        unresolved,
+    }))
+}
+
+fn parse_summary_unresolved_selector(value: &str) -> Result<DepsSummaryUnresolvedSelector> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "all" => Ok(DepsSummaryUnresolvedSelector::All),
+        "resolved" => Ok(DepsSummaryUnresolvedSelector::Resolved),
+        "unresolved" => Ok(DepsSummaryUnresolvedSelector::Unresolved),
+        _ => bail!("summary(unresolved:...) must be one of: all, resolved, unresolved"),
+    }
 }
 
 pub(super) fn validate_graphql_compiler_support(
@@ -91,6 +164,8 @@ pub(super) fn validate_graphql_compiler_support(
     let has_coverage_stage = matches!(registered_stage, Some(RegisteredStageKind::Coverage));
     let has_clone_summary_stage =
         matches!(registered_stage, Some(RegisteredStageKind::CloneSummary));
+    let has_deps_summary_stage =
+        matches!(registered_stage, Some(RegisteredStageKind::DepsSummary(_)));
     let has_tests_summary_stage =
         matches!(registered_stage, Some(RegisteredStageKind::TestsSummary));
 
@@ -100,6 +175,18 @@ pub(super) fn validate_graphql_compiler_support(
 
     if has_clone_summary_stage && !parsed.select_fields.is_empty() {
         bail!("summary() does not support select() in the GraphQL compiler yet");
+    }
+
+    if has_deps_summary_stage && !parsed.has_artefacts_stage {
+        bail!("summary(deps:true, ...) requires an artefacts() stage in the query");
+    }
+
+    if has_deps_summary_stage && parsed.has_deps_stage {
+        bail!("summary(deps:true, ...) cannot be combined with deps() stage");
+    }
+
+    if has_deps_summary_stage && parsed.has_clones_stage {
+        bail!("summary(deps:true, ...) cannot be combined with clones() stage");
     }
 
     if has_tests_stage && !parsed.has_artefacts_stage {
@@ -223,7 +310,9 @@ pub(super) fn validate_graphql_compiler_support(
         || parsed.has_deps_stage
         || matches!(
             registered_stage,
-            Some(RegisteredStageKind::Knowledge(_)) | Some(RegisteredStageKind::TestsSummary)
+            Some(RegisteredStageKind::Knowledge(_))
+                | Some(RegisteredStageKind::TestsSummary)
+                | Some(RegisteredStageKind::DepsSummary(_))
         )
     {
         return Ok(());
@@ -253,6 +342,7 @@ pub(super) fn should_compile_project_stage(
 
     match registered_stage {
         RegisteredStageKind::CloneSummary => false,
+        RegisteredStageKind::DepsSummary(_) => false,
         RegisteredStageKind::Tests(_)
         | RegisteredStageKind::Coverage
         | RegisteredStageKind::TestsSummary => parsed.project_path.is_some(),

--- a/bitloops/src/host/devql/query/dsl_compiler/validation.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/validation.rs
@@ -1,10 +1,10 @@
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 
 use super::field_mapping::{
     CLONE_SUMMARY_STAGE_NAME, KNOWLEDGE_STAGE_NAME, TESTS_SUMMARY_STAGE_NAME,
     is_coverage_stage_name, is_tests_stage_name,
 };
-use super::types::{DepsSummaryStageSpec, DepsSummaryUnresolvedSelector};
+use super::types::DepsSummaryStageSpec;
 use super::{GraphqlCompileMode, ParsedDevqlQuery, RegisteredStageCall, RegisteredStageKind};
 
 pub(super) fn resolve_registered_stage(
@@ -93,7 +93,7 @@ fn resolve_summary_stage_kind(stage: &RegisteredStageCall) -> Result<RegisteredS
     };
 
     let unresolved = if let Some(unresolved) = stage.args.get("unresolved") {
-        Some(parse_summary_unresolved_selector(unresolved)?)
+        Some(parse_summary_unresolved_flag(unresolved)?)
     } else {
         None
     };
@@ -105,13 +105,9 @@ fn resolve_summary_stage_kind(stage: &RegisteredStageCall) -> Result<RegisteredS
     }))
 }
 
-fn parse_summary_unresolved_selector(value: &str) -> Result<DepsSummaryUnresolvedSelector> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "all" => Ok(DepsSummaryUnresolvedSelector::All),
-        "resolved" => Ok(DepsSummaryUnresolvedSelector::Resolved),
-        "unresolved" => Ok(DepsSummaryUnresolvedSelector::Unresolved),
-        _ => bail!("summary(unresolved:...) must be one of: all, resolved, unresolved"),
-    }
+fn parse_summary_unresolved_flag(value: &str) -> Result<bool> {
+    super::super::parse_bool_literal("summary unresolved", value)
+        .map_err(|_| anyhow!("summary(unresolved:...) must be boolean true/false"))
 }
 
 pub(super) fn validate_graphql_compiler_support(

--- a/bitloops/src/host/devql/query/executor/validation.rs
+++ b/bitloops/src/host/devql/query/executor/validation.rs
@@ -86,7 +86,17 @@ pub(crate) async fn execute_devql_query(
 
     let has_tests_stage = has_registered_tests_stage(parsed);
     let has_coverage_stage = has_registered_coverage_stage(parsed);
+    let has_deps_summary_stage = has_registered_deps_summary_stage(parsed)?;
     let has_clone_summary_stage = has_registered_clone_summary_stage(parsed);
+
+    if has_deps_summary_stage {
+        log_devql_validation_failure(
+            parsed,
+            "deps_summary_graphql_only",
+            "summary(deps:true, ...) is only supported by the GraphQL compiler path",
+        );
+        bail!("summary(deps:true, ...) is only supported by the GraphQL compiler path");
+    }
 
     if has_clone_summary_stage && !parsed.has_clones_stage {
         log_devql_validation_failure(
@@ -276,10 +286,60 @@ pub(crate) fn has_registered_coverage_stage(parsed: &ParsedDevqlQuery) -> bool {
 }
 
 pub(crate) fn has_registered_clone_summary_stage(parsed: &ParsedDevqlQuery) -> bool {
-    parsed
-        .registered_stages
-        .iter()
-        .any(|stage| is_clone_summary_stage_name(&stage.stage_name))
+    parsed.registered_stages.iter().any(|stage| {
+        is_clone_summary_stage_name(&stage.stage_name) && !stage.args.contains_key("deps")
+    })
+}
+
+pub(crate) fn has_registered_deps_summary_stage(parsed: &ParsedDevqlQuery) -> Result<bool> {
+    for stage in &parsed.registered_stages {
+        if !is_clone_summary_stage_name(&stage.stage_name) {
+            continue;
+        }
+
+        let Some(deps_arg) = stage.args.get("deps") else {
+            continue;
+        };
+        let deps_enabled = super::super::parse_bool_literal("summary deps", deps_arg)?;
+        if !deps_enabled {
+            bail!("summary(deps:...) requires deps:true");
+        }
+        for key in stage.args.keys() {
+            match key.as_str() {
+                "deps" | "kind" | "direction" | "unresolved" => {}
+                _ => {
+                    bail!(
+                        "summary(deps:true, ...) received unsupported argument `{key}`; allowed args: deps, kind, direction, unresolved"
+                    );
+                }
+            }
+        }
+        if let Some(kind) = stage.args.get("kind")
+            && super::super::DepsKind::from_str(kind).is_none()
+        {
+            bail!(
+                "summary(kind:...) must be one of: {}",
+                super::super::DepsKind::all_names().join(", ")
+            );
+        }
+        if let Some(direction) = stage.args.get("direction")
+            && super::super::DepsDirection::from_str(direction).is_none()
+        {
+            bail!(
+                "summary(direction:...) must be one of: {}",
+                super::super::DepsDirection::all_names().join(", ")
+            );
+        }
+        if let Some(unresolved) = stage.args.get("unresolved") {
+            match unresolved.trim().to_ascii_lowercase().as_str() {
+                "all" | "resolved" | "unresolved" => {}
+                _ => bail!("summary(unresolved:...) must be one of: all, resolved, unresolved"),
+            }
+        }
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 pub(crate) fn has_non_tests_or_coverage_registered_stage(parsed: &ParsedDevqlQuery) -> bool {

--- a/bitloops/src/host/devql/query/executor/validation.rs
+++ b/bitloops/src/host/devql/query/executor/validation.rs
@@ -331,10 +331,9 @@ pub(crate) fn has_registered_deps_summary_stage(parsed: &ParsedDevqlQuery) -> Re
             );
         }
         if let Some(unresolved) = stage.args.get("unresolved") {
-            match unresolved.trim().to_ascii_lowercase().as_str() {
-                "all" | "resolved" | "unresolved" => {}
-                _ => bail!("summary(unresolved:...) must be one of: all, resolved, unresolved"),
-            }
+            super::super::parse_bool_literal("summary unresolved", unresolved).map_err(|_| {
+                anyhow::anyhow!("summary(unresolved:...) must be boolean true/false")
+            })?;
         }
         return Ok(true);
     }

--- a/bitloops/src/host/devql/tests/devql_tests/query_pipeline/summary_stage.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/query_pipeline/summary_stage.rs
@@ -48,6 +48,40 @@ async fn execute_devql_query_rejects_summary_with_additional_registered_stages()
 }
 
 #[tokio::test]
+async fn execute_devql_query_rejects_deps_summary_mode_in_non_graphql_executor() {
+    let cfg = test_cfg();
+    let events_cfg = default_events_cfg();
+    let parsed = parse_devql_query(r#"repo("temp2")->artefacts()->summary(deps:true)"#)
+        .expect("parse deps summary query");
+
+    let err = execute_devql_query(&cfg, &parsed, &events_cfg, None)
+        .await
+        .expect_err("deps summary must be rejected by relational executor");
+
+    assert!(
+        err.to_string()
+            .contains("summary(deps:true, ...) is only supported by the GraphQL compiler path")
+    );
+}
+
+#[tokio::test]
+async fn execute_devql_query_rejects_deps_summary_mode_when_deps_flag_is_false() {
+    let cfg = test_cfg();
+    let events_cfg = default_events_cfg();
+    let parsed = parse_devql_query(r#"repo("temp2")->artefacts()->summary(deps:false)"#)
+        .expect("parse deps summary query");
+
+    let err = execute_devql_query(&cfg, &parsed, &events_cfg, None)
+        .await
+        .expect_err("deps false should fail");
+
+    assert!(
+        err.to_string()
+            .contains("summary(deps:...) requires deps:true")
+    );
+}
+
+#[tokio::test]
 async fn execute_registered_summary_stage_returns_grouped_counts() {
     let cfg = test_cfg();
     let parsed = parse_devql_query(r#"repo("temp2")->artefacts()->clones()->summary()"#)

--- a/documentation/docs/guides/devql-graphql.md
+++ b/documentation/docs/guides/devql-graphql.md
@@ -130,9 +130,41 @@ Do not mix the two modes in the same field call.
 }
 ```
 
+### DevQL `summary()` stage
+
+In the DevQL DSL, `summary()` is overloaded: it either aggregates **clone detection** results or attaches **dependency edge counts** to each artefact row. Both shapes compile to typed GraphQL; they are not interchangeable.
+
+**Clone aggregate (project-level `cloneSummary`).** Use a plain `summary()` with **no arguments** immediately after `clones(...)`. Earlier `artefacts(...)` and `clones(...)` arguments become the `filter` / `cloneFilter` passed to GraphQL `cloneSummary`. You must include `clones()`; `summary()` does not accept `select()` in this path yet.
+
+```bash
+# Same idea as raw GraphQL cloneSummary(filter:, cloneFilter:)
+bitloops devql query 'repo("bitloops")->artefacts(kind:"function")->clones(min_score:0.75)->summary()'
+
+bitloops devql query 'repo("bitloops")->file("bitloops/src/main.rs")->artefacts(kind:"function",symbol_fqn:"bitloops/src/main.rs::main")->clones(min_score:0.8)->summary()'
+```
+
+**Per-artefact dependency counts (`depsSummary`).** Use `summary(deps:true, ...)`. This requires an `artefacts()` stage and **must not** be combined with `deps()` or `clones()` in the same query. Optional arguments (all string literals in the DSL):
+
+| Argument | Values | Role |
+| --- | --- | --- |
+| `deps` | `true` only | Selects dependency-summary mode (`deps:false` is rejected). |
+| `kind` | `imports`, `calls`, `references`, `extends`, `implements`, `exports` | Restrict counts to one edge kind; omit for all kinds. |
+| `direction` | `out`, `in`, `both` | Which directions to include; if omitted in raw GraphQL, `depsSummary` defaults to both directions. |
+| `unresolved` | `all`, `resolved`, `unresolved` | Whether unresolved targets are included in the counts. |
+
+The compiler emits `artefacts { edges { node { depsSummary(filter: ...) { ... } } } }`. Counts are **for each returned artefact’s edges** in the current dependency graph (same data plane as `outgoingDeps` / `incomingDeps`). Filters on `artefacts(...)` only restrict **which artefacts appear** as rows, not “edges only to other rows on this page.”
+
+```bash
+bitloops devql query 'repo("bitloops")->file("bitloops/src/lib.rs")->artefacts(kind:"function")->summary(deps:true,direction:"both",unresolved:"all",kind:"calls")'
+```
+
+`summary(deps:true, ...)` is **only** supported when the pipeline is compiled and executed on the **GraphQL** path (the default for DSL queries that contain `->`). The relational executor rejects this shape.
+
+**Note:** When `summary(deps:true, ...)` is present, the DSL `limit()` stage is not currently forwarded as `first` on the `artefacts` connection; use raw GraphQL with `artefacts(first: N)` if you need pagination.
+
 ### Semantic clone summaries
 
-Use `cloneSummary(...)` when you want one aggregate summary over the whole filtered artefact set:
+The DSL form `...->artefacts(...)->clones(...)->summary()` compiles to the `cloneSummary` field shown below. Use `cloneSummary(...)` when you want one aggregate summary over the whole filtered artefact set:
 
 ```graphql
 {
@@ -173,6 +205,38 @@ Use nested `clones { summary { ... } }` when you want the summary for one resolv
                   relationKind
                   count
                 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Per-artefact dependency summaries (same field the DSL `summary(deps:true, ...)` selects on each node):
+
+```graphql
+{
+  repo(name: "bitloops") {
+    file(path: "bitloops/src/lib.rs") {
+      artefacts(first: 10, filter: { kind: FUNCTION }) {
+        edges {
+          node {
+            path
+            symbolFqn
+            depsSummary(filter: { kind: CALLS, direction: BOTH, unresolved: ALL }) {
+              totalCount
+              incomingCount
+              outgoingCount
+              kindCounts {
+                imports
+                calls
+                references
+                extends
+                implements
+                exports
               }
             }
           }

--- a/documentation/docs/guides/devql-graphql.md
+++ b/documentation/docs/guides/devql-graphql.md
@@ -143,19 +143,19 @@ bitloops devql query 'repo("bitloops")->artefacts(kind:"function")->clones(min_s
 bitloops devql query 'repo("bitloops")->file("bitloops/src/main.rs")->artefacts(kind:"function",symbol_fqn:"bitloops/src/main.rs::main")->clones(min_score:0.8)->summary()'
 ```
 
-**Per-artefact dependency counts (`depsSummary`).** Use `summary(deps:true, ...)`. This requires an `artefacts()` stage and **must not** be combined with `deps()` or `clones()` in the same query. Optional arguments (all string literals in the DSL):
+**Per-artefact dependency counts (`depsSummary`).** Use `summary(deps:true, ...)`. This requires an `artefacts()` stage and **must not** be combined with `deps()` or `clones()` in the same query.
 
 | Argument | Values | Role |
 | --- | --- | --- |
 | `deps` | `true` only | Selects dependency-summary mode (`deps:false` is rejected). |
 | `kind` | `imports`, `calls`, `references`, `extends`, `implements`, `exports` | Restrict counts to one edge kind; omit for all kinds. |
-| `direction` | `out`, `in`, `both` | Which directions to include; if omitted in raw GraphQL, `depsSummary` defaults to both directions. |
-| `unresolved` | `all`, `resolved`, `unresolved` | Whether unresolved targets are included in the counts. |
+| `direction` | `out`, `in`, `both` | Which directions to include; default is `both`. |
+| `unresolved` | `true`, `false` | Include unresolved targets when `true`; default is `false` (resolved-only). |
 
 The compiler emits `artefacts { edges { node { depsSummary(filter: ...) { ... } } } }`. Counts are **for each returned artefact’s edges** in the current dependency graph (same data plane as `outgoingDeps` / `incomingDeps`). Filters on `artefacts(...)` only restrict **which artefacts appear** as rows, not “edges only to other rows on this page.”
 
 ```bash
-bitloops devql query 'repo("bitloops")->file("bitloops/src/lib.rs")->artefacts(kind:"function")->summary(deps:true,direction:"both",unresolved:"all",kind:"calls")'
+bitloops devql query 'repo("bitloops")->file("bitloops/src/lib.rs")->artefacts(kind:"function")->summary(deps:true,direction:"both",unresolved:true,kind:"calls")'
 ```
 
 `summary(deps:true, ...)` is **only** supported when the pipeline is compiled and executed on the **GraphQL** path (the default for DSL queries that contain `->`). The relational executor rejects this shape.
@@ -226,7 +226,7 @@ Per-artefact dependency summaries (same field the DSL `summary(deps:true, ...)` 
           node {
             path
             symbolFqn
-            depsSummary(filter: { kind: CALLS, direction: BOTH, unresolved: ALL }) {
+            depsSummary(filter: { kind: CALLS, direction: BOTH, unresolved: false }) {
               totalCount
               incomingCount
               outgoingCount
@@ -246,6 +246,8 @@ Per-artefact dependency summaries (same field the DSL `summary(deps:true, ...)` 
   }
 }
 ```
+
+Raw GraphQL note: `depsSummary.filter.unresolved` is a `Boolean` (`false` by default). It controls only `depsSummary`. `outgoingDeps` / `incomingDeps` are separate fields and use their own `includeUnresolved` filter.
 
 ```graphql
 {


### PR DESCRIPTION
## Summary

Added summary for deps. 

Example query
```
bitloops devql query --graphql 'query  {                                                                                                                                                                   
    file(path: "backend/bl-output/src/api/authorization.service.ts") {
      artefacts(filter: { kind: METHOD, lines: { start: 102, end: 122 } }) {
        edges {
          node {
            symbolFqn
            depsSummary(filter: { direction: BOTH, unresolved: false }) {   
              totalCount
              incomingCount
              outgoingCount
              kindCounts { imports calls references extends implements exports }
            }
            outgoingDeps(filter: { includeUnresolved: true }, first: 500) {
              totalCount
              edges { node { edgeKind toArtefactId toSymbolRef startLine } }
            }
            incomingDeps(filter: { includeUnresolved: true }, first: 500) {
              totalCount
              edges { node { edgeKind fromArtefactId startLine } }
            }
          }
        }
      }
    }
}
```

## Validation

- [x] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

