### PR TITLE
Fix edges calls in macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Dashboard git blob REST endpoint**: added `GET /api/blobs/{repo_id}/{blob_sha}` so clients can fetch raw bytes for Git blob objects identified by 40- or 64-character hex ids (matching DevQL `blobSha` values from normal ingest). Checkout resolution is shared through `handlers/repo` with the repo-aware checkpoint route, git subprocess calls run under `tokio::task::spawn_blocking`, existence and type are verified with `git cat-file -t` (non-blob objects return 400), size is enforced with `git cat-file -s` before materialising content (default maximum 10 MiB with 413 `payload_too_large` via `ApiError::payload_too_large`), and successful responses use `application/octet-stream`. The route is registered in the dashboard OpenAPI document and covered by regression tests for happy path, oid validation, missing objects, non-blob revisions, and oversize blobs.
 - **Daemon structured logging and log inspection CLI**: added a dedicated daemon-owned `daemon.log` under the Bitloops state directory together with `bitloops daemon logs` for raw JSONL inspection via `--tail`, `--follow`, and `--path`. Daemon, supervisor, and daemon lifecycle CLI flows now emit structured start/stop/restart records with process and mode metadata, `bitloops daemon status` reports the log file path, and daemon log level now resolves from `BITLOOPS_LOG_LEVEL` first and daemon config `[logging].level` second.
 - QAT for devql ingestion was added
+- Capture calls edges inside macros for Rust 
 
 ### Changed
 
@@ -61,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Java adapter edge and test-support stability fixes**: Java import-edge extraction now deduplicates repeated import declarations within a file, field type-reference edges now resolve the exact field owner deterministically from the enclosing type and declarator instead of relying on `HashMap` iteration order, and Java test-path detection now recognizes repo-relative `src/test/java/...` files even when they do not end with `*Test.java`, `*Tests.java`, or `*IT.java`.
 - **Language-kind ambiguity regression coverage**: strengthened `LanguageKind::try_from` tests so shared raw tree-sitter kinds such as Java/TS `class_declaration`, `interface_declaration`, and `enum_declaration`, plus Go/Java `method_declaration`, are explicitly asserted as ambiguous while per-language parsers remain the language-aware escape hatch.
 - **Transcript read resilience in turn-end handler**: replaced the misleading parent-directory existence check with explicit retry-with-timeout logic (3 s, 50 ms intervals) that only retries `NotFound` errors when the parent directory exists, giving agents time to flush asynchronous transcript writes while immediately failing on permission errors or truly missing paths.
+-
 
 ### Changed
 

--- a/bitloops/schema.graphql
+++ b/bitloops/schema.graphql
@@ -301,7 +301,7 @@ enum DepsDirection {
 input DepsFilterInput {
 	kind: EdgeKind
 	direction: DepsDirection! = OUT
-	includeUnresolved: Boolean! = false
+	includeUnresolved: Boolean! = true
 }
 
 type DepsSummary {

--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -85,7 +85,7 @@ type ArtefactSelection {
 	artefacts(first: Int! = 20): [Artefact!]!
 	checkpoints(agent: String, since: DateTime): CheckpointStageResult!
 	clones(relationKind: String, minScore: Float): CloneStageResult!
-	deps(kind: EdgeKind, direction: DepsDirection! = BOTH, includeUnresolved: Boolean! = false): DependencyStageResult!
+	deps(kind: EdgeKind, direction: DepsDirection! = BOTH, includeUnresolved: Boolean! = true): DependencyStageResult!
 	tests(minConfidence: Float, linkageSource: String): TestsStageResult!
 }
 
@@ -335,7 +335,7 @@ enum DepsDirection {
 input DepsFilterInput {
 	kind: EdgeKind
 	direction: DepsDirection! = OUT
-	includeUnresolved: Boolean! = false
+	includeUnresolved: Boolean! = true
 }
 
 type DepsSummary {

--- a/bitloops/src/adapters/languages/rust/edges.rs
+++ b/bitloops/src/adapters/languages/rust/edges.rs
@@ -137,6 +137,7 @@ pub(crate) fn collect_rust_edges_recursive(
         && let Some(owner) = smallest_enclosing_callable(start_line, ctx.callables)
         && let Some((target_name, call_form)) = rust_call_target(node, content)
     {
+        let edge_count_before = ec.out.len();
         push_rust_call_edge(
             ec,
             &owner.symbol_fqn,
@@ -146,6 +147,33 @@ pub(crate) fn collect_rust_edges_recursive(
             ctx,
             false,
         );
+
+        // When a call is written with a module-qualified path (e.g. `log::banner()`),
+        // there is no `use` binding for the callee name and we should still emit a
+        // stable calls edge keyed by that explicit path.
+        if ec.out.len() == edge_count_before
+            && let Some(to_symbol_ref) = rust_module_qualified_call_symbol_ref(node, content)
+        {
+            let key = format!(
+                "{}|{}|{}|{}|{}",
+                owner.symbol_fqn,
+                to_symbol_ref,
+                start_line,
+                Resolution::Import.as_str(),
+                call_form.as_str()
+            );
+            if ec.seen.insert(key) {
+                ec.out.push(DependencyEdge {
+                    edge_kind: EdgeKind::Calls,
+                    from_symbol_fqn: owner.symbol_fqn,
+                    to_target_symbol_fqn: None,
+                    to_symbol_ref: Some(to_symbol_ref),
+                    start_line: Some(start_line),
+                    end_line: Some(start_line),
+                    metadata: EdgeMetadata::call(call_form, Resolution::Import),
+                });
+            }
+        }
     }
 
     if kind == "macro_invocation"
@@ -161,6 +189,28 @@ pub(crate) fn collect_rust_edges_recursive(
             ctx,
             false,
         );
+
+        for to_symbol_ref in rust_module_qualified_calls_in_macro(node, content) {
+            let key = format!(
+                "{}|{}|{}|{}|{}",
+                owner.symbol_fqn,
+                to_symbol_ref,
+                start_line,
+                Resolution::Import.as_str(),
+                CallForm::Associated.as_str()
+            );
+            if ec.seen.insert(key) {
+                ec.out.push(DependencyEdge {
+                    edge_kind: EdgeKind::Calls,
+                    from_symbol_fqn: owner.symbol_fqn.clone(),
+                    to_target_symbol_fqn: None,
+                    to_symbol_ref: Some(to_symbol_ref),
+                    start_line: Some(start_line),
+                    end_line: Some(start_line),
+                    metadata: EdgeMetadata::call(CallForm::Associated, Resolution::Import),
+                });
+            }
+        }
     }
 
     if kind == "impl_item"
@@ -259,6 +309,96 @@ pub(crate) fn rust_macro_target(
             .trim_end_matches('!'),
     )?;
     Some((target_name, CallForm::Macro))
+}
+
+fn rust_module_qualified_call_symbol_ref(node: tree_sitter::Node, content: &str) -> Option<String> {
+    if node.kind() != "call_expression" {
+        return None;
+    }
+
+    let function_node = node.child_by_field_name("function")?;
+    let function_text = function_node.utf8_text(content.as_bytes()).ok()?.trim();
+    if function_text.contains('.') || function_text.contains('<') || function_text.contains('!') {
+        return None;
+    }
+
+    let mut segments = function_text.split("::").map(str::trim);
+    let module = segments.next()?;
+    let callable = segments.next()?;
+    if segments.next().is_some() {
+        return None;
+    }
+
+    if !is_rust_plain_identifier(module) || !is_rust_plain_identifier(callable) {
+        return None;
+    }
+
+    let module_is_allowed = module
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_lowercase())
+        || matches!(module, "self" | "super" | "crate");
+    if !module_is_allowed {
+        return None;
+    }
+
+    Some(format!("{module}::{callable}"))
+}
+
+fn is_rust_plain_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+fn rust_module_qualified_calls_in_macro(node: tree_sitter::Node, content: &str) -> Vec<String> {
+    let Ok(text) = node.utf8_text(content.as_bytes()) else {
+        return Vec::new();
+    };
+    let Ok(re) =
+        Regex::new(r"(?P<module>(?:self|super|crate|[a-z_][A-Za-z0-9_]*))::(?P<call>[A-Za-z_][A-Za-z0-9_]*)\s*\(")
+    else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for captures in re.captures_iter(text) {
+        let Some(full_match) = captures.get(0) else {
+            continue;
+        };
+
+        if full_match.start() > 0
+            && text
+                .as_bytes()
+                .get(full_match.start().saturating_sub(1))
+                .is_some_and(|byte| *byte == b':')
+        {
+            continue;
+        }
+
+        let Some(module) = captures.name("module").map(|value| value.as_str()) else {
+            continue;
+        };
+        let Some(callable) = captures.name("call").map(|value| value.as_str()) else {
+            continue;
+        };
+        if !is_rust_plain_identifier(module) || !is_rust_plain_identifier(callable) {
+            continue;
+        }
+
+        let symbol_ref = format!("{module}::{callable}");
+        if seen.insert(symbol_ref.clone()) {
+            out.push(symbol_ref);
+        }
+    }
+
+    out
 }
 
 pub(crate) fn rust_callable_name_from_text(text: &str) -> Option<String> {

--- a/bitloops/src/adapters/languages/rust/edges.rs
+++ b/bitloops/src/adapters/languages/rust/edges.rs
@@ -360,9 +360,9 @@ fn rust_module_qualified_calls_in_macro(node: tree_sitter::Node, content: &str) 
     let Ok(text) = node.utf8_text(content.as_bytes()) else {
         return Vec::new();
     };
-    let Ok(re) =
-        Regex::new(r"(?P<module>(?:self|super|crate|[a-z_][A-Za-z0-9_]*))::(?P<call>[A-Za-z_][A-Za-z0-9_]*)\s*\(")
-    else {
+    let Ok(re) = Regex::new(
+        r"(?P<module>(?:self|super|crate|[a-z_][A-Za-z0-9_]*))::(?P<call>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+    ) else {
         return Vec::new();
     };
 

--- a/bitloops/src/api/tests/devql_mutations_and_health.rs
+++ b/bitloops/src/api/tests/devql_mutations_and_health.rs
@@ -140,6 +140,284 @@ fn enter_isolated_app_process_state(
     (app_root, guard)
 }
 
+fn seed_graphql_rust_select_artefacts_repo() -> TempDir {
+    let dir = TempDir::new().expect("temp dir");
+    let repo_root = dir.path();
+
+    init_test_repo(repo_root, "main", "Alice", "alice@example.com");
+    fs::write(
+        repo_root.join("treleas.rs"),
+        r#"mod greeting;
+mod log;
+
+const APP_VERSION: &str = "0.1.0";
+
+fn treleas() {
+    log::banner();
+    println!("{}", greeting::greet());
+    println!("Version: {}", APP_VERSION);
+}
+"#,
+    )
+    .expect("write treleas.rs");
+    git_ok(repo_root, &["add", "."]);
+    git_ok(
+        repo_root,
+        &["commit", "-m", "Seed GraphQL Rust selectArtefacts repo"],
+    );
+    let commit_sha = git_ok(repo_root, &["rev-parse", "HEAD"]);
+
+    let sqlite_path = repo_root
+        .join(".bitloops")
+        .join("stores")
+        .join("graphql-rust.sqlite");
+    crate::storage::init::init_database(&sqlite_path, false, &commit_sha)
+        .expect("initialise GraphQL sqlite store");
+    write_envelope_config(
+        repo_root,
+        json!({
+            "stores": {
+                "relational": {
+                    "sqlite_path": sqlite_path.to_string_lossy()
+                }
+            }
+        }),
+    );
+
+    let repo_id = crate::host::devql::resolve_repo_id(repo_root).expect("resolve repo id");
+    let conn = rusqlite::Connection::open(&sqlite_path).expect("open GraphQL sqlite store");
+    conn.execute(
+        "INSERT INTO repositories (repo_id, provider, organization, name, default_branch)
+         VALUES (?1, 'local', 'local', 'demo', 'main')",
+        rusqlite::params![repo_id.as_str()],
+    )
+    .expect("insert repository row");
+    conn.execute(
+        "INSERT INTO commits (commit_sha, repo_id, author_name, author_email, commit_message, committed_at)
+         VALUES (?1, ?2, 'Alice', 'alice@example.com', 'Seed GraphQL Rust selectArtefacts repo', '2026-04-09T09:00:00Z')",
+        rusqlite::params![commit_sha.as_str(), repo_id.as_str()],
+    )
+    .expect("insert commit row");
+
+    conn.execute(
+        "INSERT INTO file_state (repo_id, commit_sha, path, blob_sha)
+         VALUES (?1, ?2, 'treleas.rs', 'blob-treleas')",
+        rusqlite::params![repo_id.as_str(), commit_sha.as_str()],
+    )
+    .expect("insert file_state row");
+    conn.execute(
+        "INSERT INTO current_file_state (
+            repo_id, path, language,
+            head_content_id, index_content_id, worktree_content_id,
+            effective_content_id, effective_source,
+            parser_version, extractor_version,
+            exists_in_head, exists_in_index, exists_in_worktree,
+            last_synced_at
+        ) VALUES (?1, 'treleas.rs', 'rust', 'blob-treleas', 'blob-treleas', 'blob-treleas', 'blob-treleas', 'head', 'test', 'test', 1, 1, 1, '2026-04-09T09:00:00Z')",
+        rusqlite::params![repo_id.as_str()],
+    )
+    .expect("insert current_file_state row");
+
+    let artefacts = [
+        (
+            "file::treleas",
+            "artefact::file-treleas",
+            "file",
+            "source_file",
+            "treleas.rs",
+            Option::<&str>::None,
+            Option::<&str>::None,
+            1_i64,
+            10_i64,
+        ),
+        (
+            "sym::app_version",
+            "artefact::app-version",
+            "value",
+            "const_item",
+            "treleas.rs::APP_VERSION",
+            Some("file::treleas"),
+            Some("artefact::file-treleas"),
+            4_i64,
+            4_i64,
+        ),
+        (
+            "sym::treleas",
+            "artefact::treleas",
+            "function",
+            "function_item",
+            "treleas.rs::treleas",
+            Some("file::treleas"),
+            Some("artefact::file-treleas"),
+            6_i64,
+            10_i64,
+        ),
+    ];
+
+    for (
+        symbol_id,
+        artefact_id,
+        canonical_kind,
+        language_kind,
+        symbol_fqn,
+        parent_symbol_id,
+        parent_artefact_id,
+        start_line,
+        end_line,
+    ) in artefacts
+    {
+        conn.execute(
+            "INSERT INTO artefacts (
+                artefact_id, symbol_id, repo_id, language, canonical_kind,
+                language_kind, symbol_fqn, signature, modifiers, docstring, content_hash, created_at
+            ) VALUES (
+                ?1, ?2, ?3, 'rust', ?4,
+                ?5, ?6, NULL, ?7, NULL, ?8, '2026-04-09T09:00:00Z'
+            )",
+            rusqlite::params![
+                artefact_id,
+                symbol_id,
+                repo_id.as_str(),
+                canonical_kind,
+                language_kind,
+                symbol_fqn,
+                if canonical_kind == "file" {
+                    "[]"
+                } else {
+                    "[\"pub\"]"
+                },
+                format!("hash-{artefact_id}"),
+            ],
+        )
+        .expect("insert artefact metadata row");
+        conn.execute(
+            "INSERT INTO artefact_snapshots (
+                repo_id, blob_sha, path, artefact_id, parent_artefact_id,
+                start_line, end_line, start_byte, end_byte, created_at
+            ) VALUES (
+                ?1, 'blob-treleas', 'treleas.rs', ?2, ?3,
+                ?4, ?5, 0, ?6, '2026-04-09T09:00:00Z'
+            )",
+            rusqlite::params![
+                repo_id.as_str(),
+                artefact_id,
+                parent_artefact_id,
+                start_line,
+                end_line,
+                end_line * 10,
+            ],
+        )
+        .expect("insert artefact snapshot row");
+        conn.execute(
+            "INSERT INTO artefacts_current (
+                repo_id, path, content_id, symbol_id, artefact_id,
+                language, canonical_kind, language_kind,
+                symbol_fqn, parent_symbol_id, parent_artefact_id, start_line, end_line,
+                start_byte, end_byte, signature, modifiers, docstring, updated_at
+            ) VALUES (
+                ?1, 'treleas.rs', 'blob-treleas', ?2, ?3,
+                'rust', ?4, ?5,
+                ?6, ?7, ?8, ?9, ?10,
+                0, ?11, NULL, ?12, NULL, '2026-04-09T09:00:00Z'
+            )",
+            rusqlite::params![
+                repo_id.as_str(),
+                symbol_id,
+                artefact_id,
+                canonical_kind,
+                language_kind,
+                symbol_fqn,
+                parent_symbol_id,
+                parent_artefact_id,
+                start_line,
+                end_line,
+                end_line * 10,
+                if canonical_kind == "file" {
+                    "[]"
+                } else {
+                    "[\"pub\"]"
+                },
+            ],
+        )
+        .expect("insert artefact current row");
+    }
+
+    for (
+        edge_id,
+        edge_kind,
+        from_symbol_id,
+        from_artefact_id,
+        to_symbol_id,
+        to_artefact_id,
+        to_symbol_ref,
+        line,
+        metadata,
+    ) in [
+        (
+            "edge-call-log",
+            "calls",
+            "sym::treleas",
+            "artefact::treleas",
+            Option::<&str>::None,
+            Option::<&str>::None,
+            Some("log::banner"),
+            7_i64,
+            "{\"resolution\":\"import\",\"call_form\":\"associated\"}",
+        ),
+        (
+            "edge-call-greet",
+            "calls",
+            "sym::treleas",
+            "artefact::treleas",
+            Option::<&str>::None,
+            Option::<&str>::None,
+            Some("greeting::greet"),
+            8_i64,
+            "{\"resolution\":\"import\",\"call_form\":\"associated\"}",
+        ),
+        (
+            "edge-ref-app-version",
+            "references",
+            "sym::treleas",
+            "artefact::treleas",
+            Some("sym::app_version"),
+            Some("artefact::app-version"),
+            Some("treleas.rs::APP_VERSION"),
+            9_i64,
+            "{\"resolution\":\"local\",\"ref_kind\":\"value\"}",
+        ),
+    ] {
+        conn.execute(
+            "INSERT INTO artefact_edges_current (
+                edge_id, repo_id, path, content_id,
+                from_symbol_id, from_artefact_id,
+                to_symbol_id, to_artefact_id, to_symbol_ref, edge_kind, language,
+                start_line, end_line, metadata, updated_at
+            ) VALUES (
+                ?1, ?2, 'treleas.rs', 'blob-treleas',
+                ?3, ?4,
+                ?5, ?6, ?7, ?8, 'rust',
+                ?9, ?9, ?10, '2026-04-09T09:00:00Z'
+            )",
+            rusqlite::params![
+                edge_id,
+                repo_id.as_str(),
+                from_symbol_id,
+                from_artefact_id,
+                to_symbol_id,
+                to_artefact_id,
+                to_symbol_ref,
+                edge_kind,
+                line,
+                metadata,
+            ],
+        )
+        .expect("insert edge current row");
+    }
+
+    dir
+}
+
 #[tokio::test]
 async fn devql_schema_builds_and_executes_in_process() {
     let temp = TempDir::new().expect("temp dir");
@@ -1448,5 +1726,137 @@ async fn slim_select_artefacts_summary_aggregates_categories_and_deps_expose_ite
     assert_eq!(
         deps_items[1]["toSymbolRef"],
         "packages/web/src/page.ts::render"
+    );
+}
+
+#[tokio::test]
+async fn slim_select_artefacts_deps_include_unresolved_false_true_and_default() {
+    let repo = seed_graphql_rust_select_artefacts_repo();
+    let schema = slim_schema_for_repo(repo.path());
+
+    let response_false = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            {
+              selectArtefacts(by: { path: "treleas.rs", lines: { start: 1, end: 10 } }) {
+                deps(includeUnresolved: false) {
+                  items(first: 10) {
+                    edgeKind
+                    toSymbolRef
+                    toArtefact {
+                      symbolFqn
+                    }
+                  }
+                }
+              }
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        response_false.errors.is_empty(),
+        "graphql errors: {:?}",
+        response_false.errors
+    );
+
+    let json_false = response_false
+        .data
+        .into_json()
+        .expect("graphql data (false) to json");
+    let items_false = json_false["selectArtefacts"]["deps"]["items"]
+        .as_array()
+        .expect("deps false items array");
+    assert_eq!(items_false.len(), 1);
+    assert_eq!(items_false[0]["edgeKind"], "REFERENCES");
+    assert_eq!(
+        items_false[0]["toArtefact"]["symbolFqn"],
+        "treleas.rs::APP_VERSION"
+    );
+
+    let response_true = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            {
+              selectArtefacts(by: { path: "treleas.rs", lines: { start: 1, end: 10 } }) {
+                deps(includeUnresolved: true) {
+                  items(first: 10) {
+                    edgeKind
+                    toSymbolRef
+                    toArtefact {
+                      symbolFqn
+                    }
+                  }
+                }
+              }
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        response_true.errors.is_empty(),
+        "graphql errors: {:?}",
+        response_true.errors
+    );
+
+    let json_true = response_true
+        .data
+        .into_json()
+        .expect("graphql data (true) to json");
+    let items_true = json_true["selectArtefacts"]["deps"]["items"]
+        .as_array()
+        .expect("deps true items array");
+    assert_eq!(items_true.len(), 3);
+    assert!(
+        items_true
+            .iter()
+            .any(|item| item["edgeKind"] == "CALLS" && item["toSymbolRef"] == "log::banner")
+    );
+    assert!(
+        items_true
+            .iter()
+            .any(|item| item["edgeKind"] == "CALLS" && item["toSymbolRef"] == "greeting::greet")
+    );
+    assert!(items_true.iter().any(|item| {
+        item["edgeKind"] == "REFERENCES"
+            && item["toArtefact"]["symbolFqn"] == "treleas.rs::APP_VERSION"
+    }));
+
+    let response_default = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            {
+              selectArtefacts(by: { path: "treleas.rs", lines: { start: 1, end: 10 } }) {
+                deps {
+                  items(first: 10) {
+                    edgeKind
+                    toSymbolRef
+                    toArtefact {
+                      symbolFqn
+                    }
+                  }
+                }
+              }
+            }
+            "#,
+        ))
+        .await;
+    assert!(
+        response_default.errors.is_empty(),
+        "graphql errors: {:?}",
+        response_default.errors
+    );
+
+    let json_default = response_default
+        .data
+        .into_json()
+        .expect("graphql data (default) to json");
+    let items_default = json_default["selectArtefacts"]["deps"]["items"]
+        .as_array()
+        .expect("deps default items array");
+
+    assert_eq!(items_default.len(), items_true.len());
+    assert_eq!(
+        items_default, items_true,
+        "default includeUnresolved behaviour should match includeUnresolved: true"
     );
 }

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -427,7 +427,7 @@ async fn devql_post_route_executes_slim_repository_file_and_dependency_queries()
     assert_eq!(payload["data"]["file"]["language"], "typescript");
     assert_eq!(payload["data"]["file"]["blobSha"], "blob-caller");
     assert_eq!(payload["data"]["file"]["artefacts"]["totalCount"], 2);
-    assert_eq!(payload["data"]["file"]["deps"]["totalCount"], 1);
+    assert_eq!(payload["data"]["file"]["deps"]["totalCount"], 2);
     assert_eq!(payload["data"]["files"].as_array().map(Vec::len), Some(3));
     assert_eq!(payload["data"]["artefacts"]["totalCount"], 4);
     assert_eq!(

--- a/bitloops/src/graphql/types/artefact_selection.rs
+++ b/bitloops/src/graphql/types/artefact_selection.rs
@@ -210,7 +210,7 @@ impl ArtefactSelection {
         let checkpoints = self.resolve_checkpoint_stage_data(ctx, None, None).await?;
         let clones = self.resolve_clone_stage_data(ctx, None).await?;
         let deps = self
-            .resolve_dependency_stage_data(ctx, None, DepsDirection::Both, false)
+            .resolve_dependency_stage_data(ctx, None, DepsDirection::Both, true)
             .await?;
         let tests = self.resolve_tests_stage_data(ctx, None, None).await?;
 

--- a/bitloops/src/graphql/types/artefact_selection.rs
+++ b/bitloops/src/graphql/types/artefact_selection.rs
@@ -260,7 +260,7 @@ impl ArtefactSelection {
         ctx: &Context<'_>,
         kind: Option<EdgeKind>,
         #[graphql(default_with = "DepsDirection::Both")] direction: DepsDirection,
-        #[graphql(name = "includeUnresolved", default = false)] include_unresolved: bool,
+        #[graphql(name = "includeUnresolved", default = true)] include_unresolved: bool,
     ) -> Result<DependencyStageResult> {
         Ok(self
             .resolve_dependency_stage_data(ctx, kind, direction, include_unresolved)
@@ -746,7 +746,7 @@ type Clone {
 }"#;
 
 const DEPENDENCY_STAGE_SCHEMA: &str = r#"type ArtefactSelection {
-  deps(kind: EdgeKind, direction: DepsDirection! = BOTH, includeUnresolved: Boolean! = false): DependencyStageResult!
+  deps(kind: EdgeKind, direction: DepsDirection! = BOTH, includeUnresolved: Boolean! = true): DependencyStageResult!
 }
 
 type DependencyStageResult {

--- a/bitloops/src/graphql/types/dependency_edge.rs
+++ b/bitloops/src/graphql/types/dependency_edge.rs
@@ -40,7 +40,7 @@ pub struct DepsFilterInput {
     pub kind: Option<EdgeKind>,
     #[graphql(default)]
     pub direction: DepsDirection,
-    #[graphql(default)]
+    #[graphql(default = true)]
     pub include_unresolved: bool,
 }
 
@@ -49,8 +49,21 @@ impl Default for DepsFilterInput {
         Self {
             kind: None,
             direction: DepsDirection::Out,
-            include_unresolved: false,
+            include_unresolved: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DepsFilterInput;
+
+    #[test]
+    fn deps_filter_default_includes_unresolved_edges() {
+        assert!(
+            DepsFilterInput::default().include_unresolved,
+            "default deps filter should include unresolved edges"
+        );
     }
 }
 

--- a/bitloops/src/host/devql/query/dsl_compiler/args.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/args.rs
@@ -116,9 +116,14 @@ pub(super) fn compile_selection_deps_args(parsed: &ParsedDevqlQuery) -> Vec<Grap
             enum_literal(parsed.deps.direction.as_str()),
         ));
     }
-    if parsed.deps.include_unresolved {
-        args.push(GraphqlArgument::new("includeUnresolved", "true"));
-    }
+    args.push(GraphqlArgument::new(
+        "includeUnresolved",
+        if parsed.deps.include_unresolved {
+            "true"
+        } else {
+            "false"
+        },
+    ));
     args
 }
 
@@ -295,9 +300,14 @@ pub(super) fn compile_deps_filter_input(parsed: &ParsedDevqlQuery) -> Option<Str
         "direction: {}",
         enum_literal(parsed.deps.direction.as_str())
     ));
-    if parsed.deps.include_unresolved {
-        fields.push("includeUnresolved: true".to_string());
-    }
+    fields.push(format!(
+        "includeUnresolved: {}",
+        if parsed.deps.include_unresolved {
+            "true"
+        } else {
+            "false"
+        }
+    ));
 
     (!fields.is_empty()).then(|| format!("{{ {} }}", fields.join(", ")))
 }

--- a/bitloops/src/host/devql/query/dsl_compiler/tests.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/tests.rs
@@ -504,6 +504,39 @@ fn compile_project_deps_pipeline() {
 }
 
 #[test]
+fn compile_project_deps_pipeline_preserves_explicit_include_unresolved_false() {
+    let parsed = parse_devql_query(
+        r#"repo("bitloops-cli")->project("packages/api")->deps(kind:"imports",direction:"out",include_unresolved:false)->limit(100)"#,
+    )
+    .expect("query parses");
+
+    let graphql = compile_devql_to_graphql(&parsed).expect("graphql compiles");
+
+    assert_eq!(
+        graphql,
+        r#"query {
+  repo(name: "bitloops-cli") {
+    project(path: "packages/api") {
+      deps(filter: { kind: IMPORTS, direction: OUT, includeUnresolved: false }, first: 100) {
+        edges {
+          node {
+            id
+            edgeKind
+            fromArtefactId
+            toArtefactId
+            toSymbolRef
+            startLine
+            endLine
+          }
+        }
+      }
+    }
+  }
+}"#
+    );
+}
+
+#[test]
 fn compile_repository_knowledge_pipeline() {
     let parsed =
         parse_devql_query(r#"repo("bitloops-cli")->knowledge()->limit(10)"#).expect("query parses");
@@ -582,7 +615,7 @@ fn compile_slim_select_artefacts_deps_supports_schema_projection() {
         graphql,
         r#"query {
   selectArtefacts(by: { symbolFqn: "src/main.rs::main" }) {
-    deps {
+    deps(includeUnresolved: true) {
       summary
       schema
     }
@@ -606,6 +639,29 @@ fn compile_slim_select_artefacts_preserves_explicit_deps_stage_before_selector()
         r#"query {
   selectArtefacts(by: { path: "src/main.rs" }) {
     deps(direction: IN, includeUnresolved: true) {
+      summary
+      schema
+    }
+  }
+}"#
+    );
+}
+
+#[test]
+fn compile_slim_select_artefacts_preserves_explicit_include_unresolved_false() {
+    let parsed = parse_devql_query(
+        r#"deps(direction:"in",include_unresolved:false)->selectArtefacts(path:"src/main.rs")->select(summary,schema)"#,
+    )
+    .expect("query parses");
+
+    let graphql = compile_devql_to_graphql_with_mode(&parsed, GraphqlCompileMode::Slim)
+        .expect("slim graphql compiles");
+
+    assert_eq!(
+        graphql,
+        r#"query {
+  selectArtefacts(by: { path: "src/main.rs" }) {
+    deps(direction: IN, includeUnresolved: false) {
       summary
       schema
     }

--- a/bitloops/src/host/devql/query/parser.rs
+++ b/bitloops/src/host/devql/query/parser.rs
@@ -158,7 +158,7 @@ pub(crate) fn parse_devql_query(query: &str) -> Result<ParsedDevqlQuery> {
             let args = parse_named_args(inner)?;
             if !parsed.has_deps_stage {
                 parsed.deps.direction = DepsDirection::Both;
-                parsed.deps.include_unresolved = false;
+                parsed.deps.include_unresolved = true;
             }
             parsed.select_artefacts = Some(SelectArtefactsFilter {
                 symbol_fqn: args.get("symbol_fqn").cloned(),

--- a/bitloops/src/host/devql/tests/devql_tests/extraction_rust.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/extraction_rust.rs
@@ -600,3 +600,39 @@ fn boot() {
         "AppServer::new() call should not also emit a references edge for AppServer (duplicate)"
     );
 }
+
+#[test]
+fn extract_rust_dependency_edges_emit_two_calls_for_module_qualified_main_calls() {
+    let content = r#"mod greeting;
+mod log;
+
+const APP_VERSION: &str = "0.1.0";
+
+fn main() {
+    log::banner();
+    println!("{}", greeting::greet());
+    println!("Version: {}", APP_VERSION);
+}
+"#;
+    let artefacts = extract_rust_artefacts(content, "rust-app/src/main.rs").unwrap();
+    let edges = extract_rust_dependency_edges(content, "rust-app/src/main.rs", &artefacts).unwrap();
+
+    let call_edges = edges
+        .iter()
+        .filter(|edge| edge.edge_kind == "calls")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        call_edges.len(),
+        2,
+        "expected calls edges for log::banner and greeting::greet"
+    );
+
+    assert!(call_edges.iter().any(|edge| {
+        edge.from_symbol_fqn == "rust-app/src/main.rs::main"
+            && edge.to_symbol_ref.as_deref() == Some("log::banner")
+    }));
+    assert!(call_edges.iter().any(|edge| {
+        edge.from_symbol_fqn == "rust-app/src/main.rs::main"
+            && edge.to_symbol_ref.as_deref() == Some("greeting::greet")
+    }));
+}

--- a/documentation/docs/guides/select-artefacts.md
+++ b/documentation/docs/guides/select-artefacts.md
@@ -97,7 +97,7 @@ type ArtefactSelection {
   artefacts(first: Int! = 20): [Artefact!]!
   checkpoints(agent: String, since: DateTime): CheckpointStageResult!
   clones(relationKind: String, minScore: Float): CloneStageResult!
-  deps(kind: EdgeKind, direction: DepsDirection! = BOTH, includeUnresolved: Boolean! = false): DependencyStageResult!
+  deps(kind: EdgeKind, direction: DepsDirection! = BOTH, includeUnresolved: Boolean! = true): DependencyStageResult!
   tests(minConfidence: Float, linkageSource: String): TestsStageResult!
 }
 ```


### PR DESCRIPTION
## Summary

1. Support call deps inside macors
2. Changed includes unresoved edges to be by default true and added relevant tests for that.

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

