### PR TITLE
Code and Summary Embeddings

### DIFF
--- a/bitloops/src/capability_packs/semantic_clones.rs
+++ b/bitloops/src/capability_packs/semantic_clones.rs
@@ -22,12 +22,12 @@ mod stage_semantic_features;
 pub(crate) use stage_embeddings::{
     RepoEmbeddingSyncAction, clear_current_symbol_embedding_rows_for_path,
     clear_repo_active_embedding_setup, clear_repo_active_embedding_setup_for_representation,
-    clear_repo_symbol_embedding_rows, determine_repo_embedding_sync_action,
-    ensure_semantic_embeddings_schema, init_postgres_semantic_embeddings_schema,
-    init_sqlite_semantic_embeddings_schema, load_active_embedding_setup,
-    load_current_repo_embedding_states, persist_active_embedding_setup,
-    refresh_current_repo_symbol_embeddings_and_clone_edges, upsert_current_symbol_embedding_rows,
-    upsert_symbol_embedding_rows,
+    clear_repo_symbol_embedding_rows, clear_repo_symbol_embedding_rows_for_representation,
+    determine_repo_embedding_sync_action, ensure_semantic_embeddings_schema,
+    init_postgres_semantic_embeddings_schema, init_sqlite_semantic_embeddings_schema,
+    load_active_embedding_setup, load_current_repo_embedding_states,
+    persist_active_embedding_setup, refresh_current_repo_symbol_embeddings_and_clone_edges,
+    upsert_current_symbol_embedding_rows, upsert_symbol_embedding_rows,
 };
 pub(crate) use stage_semantic_features::{
     clear_current_semantic_feature_rows_for_path, ensure_semantic_features_schema,

--- a/bitloops/src/capability_packs/semantic_clones.rs
+++ b/bitloops/src/capability_packs/semantic_clones.rs
@@ -21,13 +21,13 @@ mod stage_semantic_features;
 #[allow(unused_imports)]
 pub(crate) use stage_embeddings::{
     RepoEmbeddingSyncAction, clear_current_symbol_embedding_rows_for_path,
-    clear_repo_active_embedding_setup, clear_repo_symbol_embedding_rows,
-    clear_repo_active_embedding_setup_for_representation,
-    determine_repo_embedding_sync_action, ensure_semantic_embeddings_schema,
-    init_postgres_semantic_embeddings_schema, init_sqlite_semantic_embeddings_schema,
-    load_active_embedding_setup, load_current_repo_embedding_states,
-    persist_active_embedding_setup, refresh_current_repo_symbol_embeddings_and_clone_edges,
-    upsert_current_symbol_embedding_rows, upsert_symbol_embedding_rows,
+    clear_repo_active_embedding_setup, clear_repo_active_embedding_setup_for_representation,
+    clear_repo_symbol_embedding_rows, determine_repo_embedding_sync_action,
+    ensure_semantic_embeddings_schema, init_postgres_semantic_embeddings_schema,
+    init_sqlite_semantic_embeddings_schema, load_active_embedding_setup,
+    load_current_repo_embedding_states, persist_active_embedding_setup,
+    refresh_current_repo_symbol_embeddings_and_clone_edges, upsert_current_symbol_embedding_rows,
+    upsert_symbol_embedding_rows,
 };
 pub(crate) use stage_semantic_features::{
     clear_current_semantic_feature_rows_for_path, ensure_semantic_features_schema,

--- a/bitloops/src/capability_packs/semantic_clones.rs
+++ b/bitloops/src/capability_packs/semantic_clones.rs
@@ -18,9 +18,11 @@ pub mod types;
 mod stage_embeddings;
 mod stage_semantic_features;
 
+#[allow(unused_imports)]
 pub(crate) use stage_embeddings::{
     RepoEmbeddingSyncAction, clear_current_symbol_embedding_rows_for_path,
     clear_repo_active_embedding_setup, clear_repo_symbol_embedding_rows,
+    clear_repo_active_embedding_setup_for_representation,
     determine_repo_embedding_sync_action, ensure_semantic_embeddings_schema,
     init_postgres_semantic_embeddings_schema, init_sqlite_semantic_embeddings_schema,
     load_active_embedding_setup, load_current_repo_embedding_states,

--- a/bitloops/src/capability_packs/semantic_clones/embeddings.rs
+++ b/bitloops/src/capability_packs/semantic_clones/embeddings.rs
@@ -263,7 +263,10 @@ pub fn build_symbol_embedding_input_hash(
                 );
                 map.insert(
                     "body".to_string(),
-                    json!(truncate_chars(normalize_whitespace(&input.body), MAX_EMBEDDING_BODY_CHARS)),
+                    json!(truncate_chars(
+                        normalize_whitespace(&input.body),
+                        MAX_EMBEDDING_BODY_CHARS
+                    )),
                 );
             }
             EmbeddingRepresentationKind::Summary => {}
@@ -521,14 +524,14 @@ mod tests {
             ("import-1".to_string(), "Import statement.".to_string()),
         ]);
 
-        let rows = build_symbol_embedding_inputs(
-            &inputs,
-            EmbeddingRepresentationKind::Code,
-            &summaries,
-        );
+        let rows =
+            build_symbol_embedding_inputs(&inputs, EmbeddingRepresentationKind::Code, &summaries);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].artefact_id, "function-1");
-        assert_eq!(rows[0].representation_kind, EmbeddingRepresentationKind::Code);
+        assert_eq!(
+            rows[0].representation_kind,
+            EmbeddingRepresentationKind::Code
+        );
     }
 
     #[test]
@@ -581,11 +584,8 @@ mod tests {
             ("function-2".to_string(), "   ".to_string()),
         ]);
 
-        let rows = build_symbol_embedding_inputs(
-            &inputs,
-            EmbeddingRepresentationKind::Code,
-            &summaries,
-        );
+        let rows =
+            build_symbol_embedding_inputs(&inputs, EmbeddingRepresentationKind::Code, &summaries);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].artefact_id, "function-1");
     }

--- a/bitloops/src/capability_packs/semantic_clones/embeddings.rs
+++ b/bitloops/src/capability_packs/semantic_clones/embeddings.rs
@@ -238,7 +238,7 @@ pub fn build_symbol_embedding_input_hash(
 ) -> String {
     let mut value = json!({
         "fingerprint_version": EMBEDDING_FINGERPRINT_VERSION,
-        "provider": provider.cache_key(),
+        "provider": embedding_provider_hash_identity(provider),
         "artefact_id": &input.artefact_id,
         "repo_id": &input.repo_id,
         "blob_sha": &input.blob_sha,
@@ -273,6 +273,21 @@ pub fn build_symbol_embedding_input_hash(
         }
     }
     sha256_hex(&value.to_string())
+}
+
+fn embedding_provider_hash_identity(provider: &dyn EmbeddingProvider) -> serde_json::Value {
+    match provider.output_dimension() {
+        Some(dimension) => json!({
+            "provider": provider.provider_name(),
+            "model": provider.model_name(),
+            "dimension": dimension,
+        }),
+        None => json!({
+            "provider": provider.provider_name(),
+            "model": provider.model_name(),
+            "cache_key": provider.cache_key(),
+        }),
+    }
 }
 
 pub fn symbol_embeddings_require_reindex(
@@ -664,6 +679,22 @@ mod tests {
         assert_ne!(
             build_symbol_embedding_input_hash(&base, &provider),
             build_symbol_embedding_input_hash(&changed, &provider)
+        );
+    }
+
+    #[test]
+    fn symbol_embedding_hash_ignores_profile_rename_when_runtime_setup_matches() {
+        let input = sample_input();
+        let first = MockEmbeddingSetupProvider {
+            cache_key: "runtime_profile=local-a::provider=openai::model=text-embedding-3-large::dimension=3072".to_string(),
+        };
+        let second = MockEmbeddingSetupProvider {
+            cache_key: "runtime_profile=local-b::provider=openai::model=text-embedding-3-large::dimension=3072".to_string(),
+        };
+
+        assert_eq!(
+            build_symbol_embedding_input_hash(&input, &first),
+            build_symbol_embedding_input_hash(&input, &second)
         );
     }
 

--- a/bitloops/src/capability_packs/semantic_clones/embeddings.rs
+++ b/bitloops/src/capability_packs/semantic_clones/embeddings.rs
@@ -31,15 +31,25 @@ const MAX_EMBEDDING_BODY_CHARS: usize = 8_000;
 #[serde(rename_all = "snake_case")]
 pub enum EmbeddingRepresentationKind {
     #[default]
-    Baseline,
-    Enriched,
+    #[serde(alias = "baseline", alias = "enriched")]
+    Code,
+    Summary,
 }
 
 impl fmt::Display for EmbeddingRepresentationKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Baseline => write!(f, "baseline"),
-            Self::Enriched => write!(f, "enriched"),
+            Self::Code => write!(f, "code"),
+            Self::Summary => write!(f, "summary"),
+        }
+    }
+}
+
+impl EmbeddingRepresentationKind {
+    pub const fn storage_values(self) -> &'static [&'static str] {
+        match self {
+            Self::Code => &["code", "baseline", "enriched"],
+            Self::Summary => &["summary"],
         }
     }
 }
@@ -115,6 +125,7 @@ pub struct SymbolEmbeddingRow {
     pub repo_id: String,
     pub blob_sha: String,
     pub representation_kind: EmbeddingRepresentationKind,
+    pub setup_fingerprint: String,
     pub provider: String,
     pub model: String,
     pub dimension: usize,
@@ -215,59 +226,50 @@ pub fn build_symbol_embedding_inputs(
 }
 
 pub fn build_symbol_embedding_text(input: &SymbolEmbeddingInput) -> String {
-    let body = truncate_chars(normalize_whitespace(&input.body), MAX_EMBEDDING_BODY_CHARS);
-    let signature = input
-        .signature
-        .as_deref()
-        .map(normalize_whitespace)
-        .unwrap_or_default();
-    let dependencies = render_dependency_context(&input.dependency_signals);
-
-    // Keep the clone semantic basis focused on symbol behavior rather than location.
-    format!(
-        "kind: {kind}\n\
-language: {language}\n\
-language_kind: {language_kind}\n\
-name: {name}\n\
-signature: {signature}\n\
-summary: {summary}\n\
-dependencies: {dependencies}\n\
-body:\n{body}",
-        kind = input.canonical_kind,
-        language = input.language,
-        language_kind = input.language_kind,
-        name = input.name,
-        signature = signature,
-        summary = normalize_whitespace(&input.summary),
-        dependencies = dependencies,
-        body = body,
-    )
+    match input.representation_kind {
+        EmbeddingRepresentationKind::Code => build_code_embedding_text(input),
+        EmbeddingRepresentationKind::Summary => build_summary_embedding_text(input),
+    }
 }
 
 pub fn build_symbol_embedding_input_hash(
     input: &SymbolEmbeddingInput,
     provider: &dyn EmbeddingProvider,
 ) -> String {
-    sha256_hex(
-        &json!({
-            "fingerprint_version": EMBEDDING_FINGERPRINT_VERSION,
-            "provider": provider.cache_key(),
-            "artefact_id": &input.artefact_id,
-            "repo_id": &input.repo_id,
-            "blob_sha": &input.blob_sha,
-            "representation_kind": input.representation_kind,
-            "language": input.language.to_ascii_lowercase(),
-            "canonical_kind": input.canonical_kind.to_ascii_lowercase(),
-            "language_kind": input.language_kind.to_ascii_lowercase(),
-            "name": &input.name,
-            "signature": input.signature.as_deref().map(normalize_whitespace),
-            "summary": normalize_whitespace(&input.summary),
-            "dependency_signals": &input.dependency_signals,
-            "body": truncate_chars(normalize_whitespace(&input.body), MAX_EMBEDDING_BODY_CHARS),
-            "content_hash": &input.content_hash,
-        })
-        .to_string(),
-    )
+    let mut value = json!({
+        "fingerprint_version": EMBEDDING_FINGERPRINT_VERSION,
+        "provider": provider.cache_key(),
+        "artefact_id": &input.artefact_id,
+        "repo_id": &input.repo_id,
+        "blob_sha": &input.blob_sha,
+        "representation_kind": input.representation_kind,
+        "language": input.language.to_ascii_lowercase(),
+        "canonical_kind": input.canonical_kind.to_ascii_lowercase(),
+        "language_kind": input.language_kind.to_ascii_lowercase(),
+        "name": &input.name,
+        "summary": normalize_whitespace(&input.summary),
+        "content_hash": &input.content_hash,
+    });
+    if let Some(map) = value.as_object_mut() {
+        match input.representation_kind {
+            EmbeddingRepresentationKind::Code => {
+                map.insert(
+                    "signature".to_string(),
+                    json!(input.signature.as_deref().map(normalize_whitespace)),
+                );
+                map.insert(
+                    "dependency_signals".to_string(),
+                    json!(&input.dependency_signals),
+                );
+                map.insert(
+                    "body".to_string(),
+                    json!(truncate_chars(normalize_whitespace(&input.body), MAX_EMBEDDING_BODY_CHARS)),
+                );
+            }
+            EmbeddingRepresentationKind::Summary => {}
+        }
+    }
+    sha256_hex(&value.to_string())
 }
 
 pub fn symbol_embeddings_require_reindex(
@@ -292,6 +294,7 @@ pub fn build_symbol_embedding_row(
     input: &SymbolEmbeddingInput,
     provider: &dyn EmbeddingProvider,
 ) -> Result<SymbolEmbeddingRow> {
+    let setup = resolve_embedding_setup(provider)?;
     let embedding = provider.embed(
         &build_symbol_embedding_text(input),
         crate::adapters::model_providers::embeddings::EmbeddingInputType::Document,
@@ -305,12 +308,56 @@ pub fn build_symbol_embedding_row(
         repo_id: input.repo_id.clone(),
         blob_sha: input.blob_sha.clone(),
         representation_kind: input.representation_kind,
-        provider: provider.provider_name().to_string(),
-        model: provider.model_name().to_string(),
-        dimension: embedding.len(),
+        setup_fingerprint: setup.setup_fingerprint.clone(),
+        provider: setup.provider,
+        model: setup.model,
+        dimension: setup.dimension,
         embedding_input_hash: build_symbol_embedding_input_hash(input, provider),
         embedding,
     })
+}
+
+fn build_code_embedding_text(input: &SymbolEmbeddingInput) -> String {
+    let body = truncate_chars(normalize_whitespace(&input.body), MAX_EMBEDDING_BODY_CHARS);
+    let signature = input
+        .signature
+        .as_deref()
+        .map(normalize_whitespace)
+        .unwrap_or_default();
+    let dependencies = render_dependency_context(&input.dependency_signals);
+
+    // Keep the code representation anchored in implementation details plus the best summary.
+    format!(
+        "kind: {kind}\n\
+language: {language}\n\
+language_kind: {language_kind}\n\
+name: {name}\n\
+signature: {signature}\n\
+summary: {summary}\n\
+dependencies: {dependencies}\n\
+body:\n{body}",
+        kind = input.canonical_kind,
+        language = input.language,
+        language_kind = input.language_kind,
+        name = input.name,
+        signature = signature,
+        summary = normalize_whitespace(&input.summary),
+        dependencies = dependencies,
+        body = body,
+    )
+}
+
+fn build_summary_embedding_text(input: &SymbolEmbeddingInput) -> String {
+    format!(
+        "kind: {kind}\n\
+language: {language}\n\
+name: {name}\n\
+summary: {summary}",
+        kind = input.canonical_kind,
+        language = input.language,
+        name = input.name,
+        summary = normalize_whitespace(&input.summary),
+    )
 }
 
 fn truncate_chars(input: String, max_chars: usize) -> String {
@@ -335,13 +382,11 @@ fn sha256_hex(input: &str) -> String {
 }
 
 fn build_embedding_setup_fingerprint(provider: &str, model: &str, dimension: usize) -> String {
-    sha256_hex(
-        &json!({
-            "provider": provider,
-            "model": model,
-            "dimension": dimension,
-        })
-        .to_string(),
+    format!(
+        "provider={provider}|model={model}|dimension={dimension}",
+        provider = provider,
+        model = model,
+        dimension = dimension,
     )
 }
 
@@ -406,7 +451,7 @@ mod tests {
             artefact_id: "artefact-1".to_string(),
             repo_id: "repo-1".to_string(),
             blob_sha: "blob-1".to_string(),
-            representation_kind: EmbeddingRepresentationKind::Baseline,
+            representation_kind: EmbeddingRepresentationKind::Code,
             path: "src/services/user.ts".to_string(),
             language: "typescript".to_string(),
             canonical_kind: "function".to_string(),
@@ -478,15 +523,12 @@ mod tests {
 
         let rows = build_symbol_embedding_inputs(
             &inputs,
-            EmbeddingRepresentationKind::Baseline,
+            EmbeddingRepresentationKind::Code,
             &summaries,
         );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].artefact_id, "function-1");
-        assert_eq!(
-            rows[0].representation_kind,
-            EmbeddingRepresentationKind::Baseline
-        );
+        assert_eq!(rows[0].representation_kind, EmbeddingRepresentationKind::Code);
     }
 
     #[test]
@@ -541,7 +583,7 @@ mod tests {
 
         let rows = build_symbol_embedding_inputs(
             &inputs,
-            EmbeddingRepresentationKind::Baseline,
+            EmbeddingRepresentationKind::Code,
             &summaries,
         );
         assert_eq!(rows.len(), 1);
@@ -617,12 +659,35 @@ mod tests {
         let provider = MockEmbeddingProvider;
         let base = sample_input();
         let mut changed = base.clone();
-        changed.representation_kind = EmbeddingRepresentationKind::Enriched;
+        changed.representation_kind = EmbeddingRepresentationKind::Summary;
 
         assert_ne!(
             build_symbol_embedding_input_hash(&base, &provider),
             build_symbol_embedding_input_hash(&changed, &provider)
         );
+    }
+
+    #[test]
+    fn summary_embedding_text_omits_body_and_dependencies() {
+        let mut input = sample_input();
+        input.representation_kind = EmbeddingRepresentationKind::Summary;
+
+        let text = build_symbol_embedding_text(&input);
+        assert!(text.contains("summary: Function normalize email."));
+        assert!(!text.contains("dependencies:"));
+        assert!(!text.contains("body:"));
+        assert!(!text.contains("signature:"));
+    }
+
+    #[test]
+    fn legacy_representation_aliases_map_to_code() {
+        let baseline = serde_json::from_str::<EmbeddingRepresentationKind>("\"baseline\"")
+            .expect("baseline alias");
+        let enriched = serde_json::from_str::<EmbeddingRepresentationKind>("\"enriched\"")
+            .expect("enriched alias");
+
+        assert_eq!(baseline, EmbeddingRepresentationKind::Code);
+        assert_eq!(enriched, EmbeddingRepresentationKind::Code);
     }
 
     #[test]

--- a/bitloops/src/capability_packs/semantic_clones/pipeline.rs
+++ b/bitloops/src/capability_packs/semantic_clones/pipeline.rs
@@ -316,38 +316,40 @@ async fn resolve_active_embedding_setup_for_clone_rebuild(
     projection: CloneProjection,
 ) -> Result<Option<embeddings::ActiveEmbeddingRepresentationState>> {
     if projection == CloneProjection::Current {
-        let current_states = load_current_repo_embedding_states(relational, repo_id, None).await?;
+        let current_states = load_current_repo_embedding_states(
+            relational,
+            repo_id,
+            Some(embeddings::EmbeddingRepresentationKind::Code),
+        )
+        .await?;
         return choose_current_projection_embedding_state(&current_states);
     }
 
-    if let Some(active_state) = load_active_embedding_setup(relational, repo_id).await? {
+    if let Some(active_state) = load_active_embedding_setup(
+        relational,
+        repo_id,
+        embeddings::EmbeddingRepresentationKind::Code,
+    )
+    .await?
+    {
         return Ok(Some(active_state));
     }
 
-    let current_states = load_current_repo_embedding_states(relational, repo_id, None).await?;
+    let current_states = load_current_repo_embedding_states(
+        relational,
+        repo_id,
+        Some(embeddings::EmbeddingRepresentationKind::Code),
+    )
+    .await?;
     match current_states.as_slice() {
         [state] => {
             persist_active_embedding_setup(relational, repo_id, state).await?;
             Ok(Some(state.clone()))
         }
         [] => Ok(None),
-        _ if current_states
-            .iter()
-            .all(|state| state.setup == current_states[0].setup) =>
-        {
-            let chosen = current_states
-                .iter()
-                .find(|state| {
-                    state.representation_kind == embeddings::EmbeddingRepresentationKind::Enriched
-                })
-                .unwrap_or(&current_states[0])
-                .clone();
-            persist_active_embedding_setup(relational, repo_id, &chosen).await?;
-            Ok(Some(chosen))
-        }
         _ => {
             log::warn!(
-                "semantic_clones clone rebuild skipped for repo {}: multiple embedding representations or setups exist but no active state is persisted",
+                "semantic_clones clone rebuild skipped for repo {}: multiple code embedding setups exist but no active state is persisted",
                 repo_id
             );
             Ok(None)
@@ -361,21 +363,6 @@ fn choose_current_projection_embedding_state(
     match current_states {
         [] => Ok(None),
         [state] => Ok(Some(state.clone())),
-        _ if current_states
-            .iter()
-            .all(|state| state.setup == current_states[0].setup) =>
-        {
-            Ok(Some(
-                current_states
-                    .iter()
-                    .find(|state| {
-                        state.representation_kind
-                            == embeddings::EmbeddingRepresentationKind::Enriched
-                    })
-                    .unwrap_or(&current_states[0])
-                    .clone(),
-            ))
-        }
         _ => Ok(None),
     }
 }
@@ -523,29 +510,59 @@ fn build_symbol_clone_candidate_lookup_sql(
     let features_table = projection.features_table();
     let embeddings_table = projection.embeddings_table();
     let snapshot_column = projection.blob_column();
+    let representation_predicate = representation_kind_sql_predicate(
+        "e.representation_kind",
+        active_state.representation_kind,
+    );
     format!(
-        "SELECT a.repo_id, a.symbol_id, a.artefact_id, a.path, \
+        "SELECT repo_id, symbol_id, artefact_id, path, canonical_kind, symbol_fqn, summary, \
+normalized_name, normalized_signature, identifier_tokens, normalized_body_tokens, parent_kind, context_tokens, \
+embedding_provider, embedding_model, embedding_dimension, embedding \
+FROM ( \
+SELECT a.repo_id, a.symbol_id, a.artefact_id, a.path, \
 LOWER(COALESCE(a.canonical_kind, COALESCE(a.language_kind, 'symbol'))) AS canonical_kind, \
 COALESCE(a.symbol_fqn, a.path) AS symbol_fqn, ss.summary, \
 sf.normalized_name, sf.normalized_signature, sf.identifier_tokens, sf.normalized_body_tokens, sf.parent_kind, sf.context_tokens, \
-e.provider AS embedding_provider, e.model AS embedding_model, e.dimension AS embedding_dimension, e.embedding \
+e.provider AS embedding_provider, e.model AS embedding_model, e.dimension AS embedding_dimension, e.embedding, \
+ROW_NUMBER() OVER ( \
+    PARTITION BY e.artefact_id, e.setup_fingerprint \
+    ORDER BY CASE e.representation_kind \
+        WHEN 'code' THEN 0 \
+        WHEN 'enriched' THEN 1 \
+        WHEN 'baseline' THEN 2 \
+        ELSE 3 \
+    END \
+) AS representation_rank \
 FROM {embeddings_table} e \
 JOIN {semantics_table} ss ON ss.repo_id = e.repo_id AND ss.artefact_id = e.artefact_id AND ss.{snapshot_column} = e.{snapshot_column} \
 JOIN {features_table} sf ON sf.repo_id = e.repo_id AND sf.artefact_id = e.artefact_id AND sf.{snapshot_column} = e.{snapshot_column} \
 JOIN {artefacts_table} a ON a.repo_id = e.repo_id AND a.artefact_id = e.artefact_id AND a.{snapshot_column} = e.{snapshot_column} \
-WHERE e.repo_id = '{}' AND e.provider = '{}' AND e.model = '{}' AND e.dimension = {} \
-AND e.representation_kind = '{}' \
-ORDER BY a.path, a.start_line, a.symbol_id",
+WHERE e.repo_id = '{}' AND e.setup_fingerprint = '{}' AND {} \
+) ranked \
+WHERE representation_rank = 1 \
+ORDER BY path, symbol_id",
         esc_pg(repo_id),
-        esc_pg(&active_state.setup.provider),
-        esc_pg(&active_state.setup.model),
-        active_state.setup.dimension,
-        esc_pg(&active_state.representation_kind.to_string()),
+        esc_pg(&active_state.setup.setup_fingerprint),
+        representation_predicate,
         artefacts_table = artefacts_table,
         semantics_table = semantics_table,
         features_table = features_table,
         embeddings_table = embeddings_table,
+        snapshot_column = snapshot_column,
     )
+}
+
+fn representation_kind_sql_predicate(
+    column: &str,
+    kind: embeddings::EmbeddingRepresentationKind,
+) -> String {
+    let values = kind
+        .storage_values()
+        .iter()
+        .map(|value| format!("'{}'", esc_pg(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{column} IN ({values})")
 }
 
 pub(crate) async fn delete_repo_symbol_clone_edges(
@@ -679,7 +696,7 @@ mod semantic_clone_pipeline_tests {
             "repo'1",
             CloneProjection::Current,
             &super::embeddings::ActiveEmbeddingRepresentationState::new(
-                super::embeddings::EmbeddingRepresentationKind::Baseline,
+                super::embeddings::EmbeddingRepresentationKind::Code,
                 super::embeddings::EmbeddingSetup::new("local_fastembed", "test-model", 3),
             ),
         );
@@ -687,28 +704,24 @@ mod semantic_clone_pipeline_tests {
         assert!(sql.contains("FROM symbol_embeddings_current e"));
         assert!(sql.contains("JOIN artefacts_current a"));
         assert!(sql.contains("repo''1"));
-        assert!(sql.contains("test-model"));
-        assert!(!sql.contains(" IN ("));
+        assert!(sql.contains("representation_rank = 1"));
+        assert!(sql.contains("setup_fingerprint"));
     }
 
     #[test]
-    fn current_projection_prefers_enriched_representation_when_setups_match() {
+    fn current_projection_returns_none_when_multiple_code_setups_exist() {
         let chosen = choose_current_projection_embedding_state(&[
             super::embeddings::ActiveEmbeddingRepresentationState::new(
-                super::embeddings::EmbeddingRepresentationKind::Baseline,
+                super::embeddings::EmbeddingRepresentationKind::Code,
                 super::embeddings::EmbeddingSetup::new("local_fastembed", "test-model", 3),
             ),
             super::embeddings::ActiveEmbeddingRepresentationState::new(
-                super::embeddings::EmbeddingRepresentationKind::Enriched,
-                super::embeddings::EmbeddingSetup::new("local_fastembed", "test-model", 3),
+                super::embeddings::EmbeddingRepresentationKind::Code,
+                super::embeddings::EmbeddingSetup::new("voyage", "voyage-code-3", 3),
             ),
         ])
-        .expect("choose current projection setup")
-        .expect("current projection setup");
+        .expect("choose current projection setup");
 
-        assert_eq!(
-            chosen.representation_kind,
-            super::embeddings::EmbeddingRepresentationKind::Enriched
-        );
+        assert!(chosen.is_none());
     }
 }

--- a/bitloops/src/capability_packs/semantic_clones/stage_embeddings.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_embeddings.rs
@@ -44,6 +44,7 @@ pub(crate) async fn upsert_symbol_embedding_rows(
     }
 
     ensure_semantic_embeddings_schema(relational).await?;
+    let setup = embeddings::resolve_embedding_setup(embedding_provider.as_ref())?;
 
     let artefact_ids = inputs
         .iter()
@@ -65,6 +66,7 @@ pub(crate) async fn upsert_symbol_embedding_rows(
             relational,
             &input.artefact_id,
             input.representation_kind,
+            &setup.setup_fingerprint,
         )
         .await?;
         if !embeddings::symbol_embeddings_require_reindex(&state, &next_input_hash) {
@@ -123,8 +125,8 @@ pub(crate) async fn upsert_current_symbol_embedding_rows(
         relational,
         &first.repo_id,
         path,
+        content_id,
         representation_kind,
-        &setup,
         &embedding_inputs
             .iter()
             .map(|input| input.artefact_id.clone())
@@ -145,6 +147,7 @@ pub(crate) async fn upsert_current_symbol_embedding_rows(
             relational,
             &input.artefact_id,
             input.representation_kind,
+            &setup.setup_fingerprint,
         )
         .await?;
         if !embeddings::symbol_embeddings_require_reindex(&state, &next_input_hash) {
@@ -176,6 +179,7 @@ pub(crate) async fn ensure_semantic_embeddings_schema(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub(crate) async fn clear_repo_symbol_embedding_rows(
     relational: &RelationalStorage,
     repo_id: &str,
@@ -222,13 +226,32 @@ pub(crate) async fn clear_repo_active_embedding_setup(
     relational.exec(&sql).await
 }
 
+pub(crate) async fn clear_repo_active_embedding_setup_for_representation(
+    relational: &RelationalStorage,
+    repo_id: &str,
+    representation_kind: embeddings::EmbeddingRepresentationKind,
+) -> Result<()> {
+    ensure_semantic_embeddings_schema(relational).await?;
+    let sql = format!(
+        "DELETE FROM semantic_clone_embedding_setup_state WHERE repo_id = '{repo_id}' AND {representation_predicate}",
+        repo_id = esc_pg(repo_id),
+        representation_predicate =
+            representation_kind_sql_predicate("representation_kind", representation_kind),
+    );
+    relational.exec(&sql).await
+}
+
 pub(crate) async fn load_active_embedding_setup(
     relational: &RelationalStorage,
     repo_id: &str,
+    representation_kind: embeddings::EmbeddingRepresentationKind,
 ) -> Result<Option<embeddings::ActiveEmbeddingRepresentationState>> {
     ensure_semantic_embeddings_schema(relational).await?;
     let rows = relational
-        .query_rows(&build_active_embedding_setup_lookup_sql(repo_id))
+        .query_rows(&build_active_embedding_setup_lookup_sql(
+            repo_id,
+            representation_kind,
+        ))
         .await?;
     Ok(parse_active_embedding_state_rows(&rows).into_iter().next())
 }
@@ -239,6 +262,7 @@ pub(crate) async fn persist_active_embedding_setup(
     active_state: &embeddings::ActiveEmbeddingRepresentationState,
 ) -> Result<()> {
     ensure_semantic_embeddings_schema(relational).await?;
+    persist_embedding_setup(relational, &active_state.setup).await?;
     let sql = build_active_embedding_setup_persist_sql(repo_id, active_state);
     relational.exec(&sql).await
 }
@@ -249,25 +273,21 @@ pub(crate) async fn determine_repo_embedding_sync_action(
     representation_kind: embeddings::EmbeddingRepresentationKind,
     setup: &embeddings::EmbeddingSetup,
 ) -> Result<RepoEmbeddingSyncAction> {
-    if let Some(active) = load_active_embedding_setup(relational, repo_id).await? {
-        return Ok(
-            if active.representation_kind == representation_kind && active.setup == *setup {
-                RepoEmbeddingSyncAction::Incremental
-            } else {
-                RepoEmbeddingSyncAction::RefreshCurrentRepo
-            },
-        );
+    if let Some(active) =
+        load_active_embedding_setup(relational, repo_id, representation_kind).await?
+    {
+        if active.setup == *setup {
+            return Ok(RepoEmbeddingSyncAction::Incremental);
+        }
     }
 
     let current_states =
         load_current_repo_embedding_states(relational, repo_id, Some(representation_kind)).await?;
-    Ok(
-        if current_states.len() == 1 && current_states[0].setup == *setup {
-            RepoEmbeddingSyncAction::AdoptExisting
-        } else {
-            RepoEmbeddingSyncAction::RefreshCurrentRepo
-        },
-    )
+    Ok(if current_states.iter().any(|state| state.setup == *setup) {
+        RepoEmbeddingSyncAction::AdoptExisting
+    } else {
+        RepoEmbeddingSyncAction::RefreshCurrentRepo
+    })
 }
 
 pub(crate) async fn refresh_current_repo_symbol_embeddings_and_clone_edges(
@@ -301,11 +321,14 @@ pub(crate) async fn refresh_current_repo_symbol_embeddings_and_clone_edges(
         &embeddings::ActiveEmbeddingRepresentationState::new(representation_kind, setup),
     )
     .await?;
-    let clone_build =
+    let clone_build = if representation_kind == embeddings::EmbeddingRepresentationKind::Code {
         crate::capability_packs::semantic_clones::pipeline::rebuild_symbol_clone_edges(
             relational, repo_id,
         )
-        .await?;
+        .await?
+    } else {
+        Default::default()
+    };
 
     Ok(CurrentRepoEmbeddingRefreshResult {
         embedding_stats,
@@ -317,12 +340,14 @@ async fn load_symbol_embedding_index_state(
     relational: &RelationalStorage,
     artefact_id: &str,
     representation_kind: embeddings::EmbeddingRepresentationKind,
+    setup_fingerprint: &str,
 ) -> Result<embeddings::SymbolEmbeddingIndexState> {
     let rows = relational
         .query_rows(&build_symbol_embedding_index_state_sql(
             artefact_id,
             "symbol_embeddings",
             representation_kind,
+            setup_fingerprint,
         ))
         .await?;
     Ok(parse_symbol_embedding_index_state_rows(&rows))
@@ -332,12 +357,14 @@ async fn load_current_symbol_embedding_index_state(
     relational: &RelationalStorage,
     artefact_id: &str,
     representation_kind: embeddings::EmbeddingRepresentationKind,
+    setup_fingerprint: &str,
 ) -> Result<embeddings::SymbolEmbeddingIndexState> {
     let rows = relational
         .query_rows(&build_symbol_embedding_index_state_sql(
             artefact_id,
             "symbol_embeddings_current",
             representation_kind,
+            setup_fingerprint,
         ))
         .await?;
     Ok(parse_symbol_embedding_index_state_rows(&rows))
@@ -376,7 +403,7 @@ async fn load_semantic_summary_map_from_table(
     relational: &RelationalStorage,
     artefact_ids: &[String],
     table: &str,
-    representation_kind: embeddings::EmbeddingRepresentationKind,
+    _representation_kind: embeddings::EmbeddingRepresentationKind,
 ) -> Result<HashMap<String, String>> {
     if artefact_ids.is_empty() {
         return Ok(HashMap::new());
@@ -390,7 +417,7 @@ async fn load_semantic_summary_map_from_table(
         let Some(artefact_id) = row.get("artefact_id").and_then(Value::as_str) else {
             continue;
         };
-        if let Some(summary) = resolve_embedding_summary(&row, representation_kind) {
+        if let Some(summary) = resolve_embedding_summary(&row) {
             out.insert(artefact_id.to_string(), summary);
         }
     }
@@ -401,6 +428,16 @@ async fn persist_symbol_embedding_row(
     relational: &RelationalStorage,
     row: &embeddings::SymbolEmbeddingRow,
 ) -> Result<()> {
+    persist_embedding_setup(
+        relational,
+        &embeddings::EmbeddingSetup {
+            provider: row.provider.clone(),
+            model: row.model.clone(),
+            dimension: row.dimension,
+            setup_fingerprint: row.setup_fingerprint.clone(),
+        },
+    )
+    .await?;
     let sql = build_sqlite_symbol_embedding_persist_sql(row)?;
     relational.exec(&sql).await
 }
@@ -413,6 +450,16 @@ async fn persist_current_symbol_embedding_row(
     content_id: &str,
     row: &embeddings::SymbolEmbeddingRow,
 ) -> Result<()> {
+    persist_embedding_setup(
+        relational,
+        &embeddings::EmbeddingSetup {
+            provider: row.provider.clone(),
+            model: row.model.clone(),
+            dimension: row.dimension,
+            setup_fingerprint: row.setup_fingerprint.clone(),
+        },
+    )
+    .await?;
     let sql = build_current_symbol_embedding_persist_sql(input, path, content_id, row)?;
     relational.exec(&sql).await
 }
@@ -421,14 +468,17 @@ fn build_symbol_embedding_index_state_sql(
     artefact_id: &str,
     table: &str,
     representation_kind: embeddings::EmbeddingRepresentationKind,
+    setup_fingerprint: &str,
 ) -> String {
     format!(
         "SELECT embedding_input_hash AS embedding_hash \
 FROM {table} \
-WHERE artefact_id = '{artefact_id}' AND representation_kind = '{representation_kind}'",
+WHERE artefact_id = '{artefact_id}' AND representation_kind = '{representation_kind}' \
+  AND setup_fingerprint = '{setup_fingerprint}'",
         table = table,
         artefact_id = esc_pg(artefact_id),
         representation_kind = esc_pg(&representation_kind.to_string()),
+        setup_fingerprint = esc_pg(setup_fingerprint),
     )
 }
 
@@ -436,8 +486,8 @@ async fn delete_stale_current_symbol_embedding_rows_for_path(
     relational: &RelationalStorage,
     repo_id: &str,
     path: &str,
+    content_id: &str,
     representation_kind: embeddings::EmbeddingRepresentationKind,
-    setup: &embeddings::EmbeddingSetup,
     keep_artefact_ids: &[String],
 ) -> Result<()> {
     let extra_delete_clause = if keep_artefact_ids.is_empty() {
@@ -450,25 +500,29 @@ async fn delete_stale_current_symbol_embedding_rows_for_path(
     };
     let sql = format!(
         "DELETE FROM symbol_embeddings_current \
-WHERE repo_id = '{repo_id}' AND path = '{path}' AND representation_kind = '{representation_kind}' \
-  AND (provider <> '{provider}' OR model <> '{model}' OR dimension <> {dimension}{extra_delete_clause})",
+WHERE repo_id = '{repo_id}' AND path = '{path}' AND {representation_predicate} \
+  AND (content_id <> '{content_id}'{extra_delete_clause})",
         repo_id = esc_pg(repo_id),
         path = esc_pg(path),
-        representation_kind = esc_pg(&representation_kind.to_string()),
-        provider = esc_pg(&setup.provider),
-        model = esc_pg(&setup.model),
-        dimension = setup.dimension,
+        content_id = esc_pg(content_id),
+        representation_predicate =
+            representation_kind_sql_predicate("representation_kind", representation_kind),
         extra_delete_clause = extra_delete_clause,
     );
     relational.exec(&sql).await
 }
 
-fn build_active_embedding_setup_lookup_sql(repo_id: &str) -> String {
+fn build_active_embedding_setup_lookup_sql(
+    repo_id: &str,
+    representation_kind: embeddings::EmbeddingRepresentationKind,
+) -> String {
     format!(
-        "SELECT representation_kind, provider, model, dimension \
+        "SELECT representation_kind, provider, model, dimension, setup_fingerprint \
 FROM semantic_clone_embedding_setup_state \
-WHERE repo_id = '{}'",
-        esc_pg(repo_id),
+WHERE repo_id = '{repo_id}' AND {representation_predicate}",
+        repo_id = esc_pg(repo_id),
+        representation_predicate =
+            representation_kind_sql_predicate("representation_kind", representation_kind),
     )
 }
 
@@ -477,27 +531,22 @@ fn build_current_repo_embedding_states_sql(
     representation_kind: Option<embeddings::EmbeddingRepresentationKind>,
 ) -> String {
     let representation_filter = representation_kind
-        .map(|kind| {
-            format!(
-                "AND e.representation_kind = '{}'",
-                esc_pg(&kind.to_string())
-            )
-        })
+        .map(|kind| format!("AND {}", representation_kind_sql_predicate("e.representation_kind", kind)))
         .unwrap_or_default();
     format!(
-        "SELECT representation_kind, provider, model, dimension \
+        "SELECT representation_kind, provider, model, dimension, setup_fingerprint \
 FROM ( \
-    SELECT e.representation_kind AS representation_kind, e.provider AS provider, e.model AS model, e.dimension AS dimension \
+    SELECT e.representation_kind AS representation_kind, e.provider AS provider, e.model AS model, e.dimension AS dimension, e.setup_fingerprint AS setup_fingerprint \
     FROM artefacts_current a \
     JOIN symbol_embeddings_current e ON e.repo_id = a.repo_id AND e.artefact_id = a.artefact_id \
     WHERE a.repo_id = '{repo_id}' {representation_filter} \
     UNION \
-    SELECT e.representation_kind AS representation_kind, e.provider AS provider, e.model AS model, e.dimension AS dimension \
+    SELECT e.representation_kind AS representation_kind, e.provider AS provider, e.model AS model, e.dimension AS dimension, e.setup_fingerprint AS setup_fingerprint \
     FROM artefacts_current a \
     JOIN symbol_embeddings e ON e.repo_id = a.repo_id AND e.artefact_id = a.artefact_id \
     WHERE a.repo_id = '{repo_id}' {representation_filter} \
 ) setups \
-ORDER BY representation_kind, provider, model, dimension",
+ORDER BY representation_kind, provider, model, dimension, setup_fingerprint",
         repo_id = esc_pg(repo_id),
         representation_filter = representation_filter,
     )
@@ -511,7 +560,7 @@ fn build_active_embedding_setup_persist_sql(
     format!(
         "INSERT INTO semantic_clone_embedding_setup_state (repo_id, representation_kind, provider, model, dimension, setup_fingerprint) \
 VALUES ('{repo_id}', '{representation_kind}', '{provider}', '{model}', {dimension}, '{setup_fingerprint}') \
-ON CONFLICT (repo_id) DO UPDATE SET representation_kind = excluded.representation_kind, provider = excluded.provider, model = excluded.model, dimension = excluded.dimension, setup_fingerprint = excluded.setup_fingerprint, updated_at = CURRENT_TIMESTAMP",
+ON CONFLICT (repo_id, representation_kind) DO UPDATE SET provider = excluded.provider, model = excluded.model, dimension = excluded.dimension, setup_fingerprint = excluded.setup_fingerprint, updated_at = CURRENT_TIMESTAMP",
         repo_id = esc_pg(repo_id),
         representation_kind = esc_pg(&active_state.representation_kind.to_string()),
         provider = esc_pg(&setup.provider),
@@ -561,20 +610,35 @@ fn parse_active_embedding_state_rows(
         else {
             continue;
         };
+        let setup_fingerprint = row
+            .get("setup_fingerprint")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                embeddings::EmbeddingSetup::new(provider, model, dimension).setup_fingerprint
+            });
         states.insert((
             representation_kind,
             provider.to_string(),
             model.to_string(),
             dimension,
+            setup_fingerprint,
         ));
     }
 
     states
         .into_iter()
-        .map(|(representation_kind, provider, model, dimension)| {
+        .map(|(representation_kind, provider, model, dimension, setup_fingerprint)| {
             embeddings::ActiveEmbeddingRepresentationState::new(
                 representation_kind,
-                embeddings::EmbeddingSetup::new(provider, model, dimension),
+                embeddings::EmbeddingSetup {
+                    provider,
+                    model,
+                    dimension,
+                    setup_fingerprint,
+                },
             )
         })
         .collect()
@@ -592,8 +656,8 @@ fn value_as_positive_usize(value: &Value) -> Option<usize> {
 
 fn parse_representation_kind(raw: &str) -> Option<embeddings::EmbeddingRepresentationKind> {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "baseline" => Some(embeddings::EmbeddingRepresentationKind::Baseline),
-        "enriched" => Some(embeddings::EmbeddingRepresentationKind::Enriched),
+        "code" | "baseline" | "enriched" => Some(embeddings::EmbeddingRepresentationKind::Code),
+        "summary" => Some(embeddings::EmbeddingRepresentationKind::Summary),
         _ => None,
     }
 }
@@ -608,10 +672,7 @@ WHERE artefact_id IN ({})",
     )
 }
 
-fn resolve_embedding_summary(
-    row: &Value,
-    representation_kind: embeddings::EmbeddingRepresentationKind,
-) -> Option<String> {
+fn resolve_embedding_summary(row: &Value) -> Option<String> {
     let template_summary = row
         .get("template_summary")
         .and_then(Value::as_str)
@@ -638,14 +699,18 @@ fn resolve_embedding_summary(
             .and_then(Value::as_str)
             .is_some_and(|value| !value.trim().is_empty());
 
-    match representation_kind {
-        embeddings::EmbeddingRepresentationKind::Baseline => Some(
-            semantic::synthesize_deterministic_summary(template_summary, docstring_summary),
-        ),
-        embeddings::EmbeddingRepresentationKind::Enriched if has_llm_enrichment => {
-            canonical_summary.map(str::to_string)
-        }
-        embeddings::EmbeddingRepresentationKind::Enriched => None,
+    if has_llm_enrichment {
+        canonical_summary.map(str::to_string).or_else(|| {
+            Some(semantic::synthesize_deterministic_summary(
+                template_summary,
+                docstring_summary,
+            ))
+        })
+    } else {
+        Some(semantic::synthesize_deterministic_summary(
+            template_summary,
+            docstring_summary,
+        ))
     }
 }
 
@@ -669,13 +734,14 @@ fn build_postgres_symbol_embedding_persist_sql(
 ) -> Result<String> {
     let embedding_expr = sql_vector_string(&row.embedding)?;
     Ok(format!(
-        "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, representation_kind, provider, model, dimension, embedding_input_hash, embedding) \
-VALUES ('{artefact_id}', '{repo_id}', '{blob_sha}', '{representation_kind}', '{provider}', '{model}', {dimension}, '{embedding_input_hash}', {embedding}) \
-ON CONFLICT (artefact_id, representation_kind) DO UPDATE SET repo_id = EXCLUDED.repo_id, blob_sha = EXCLUDED.blob_sha, provider = EXCLUDED.provider, model = EXCLUDED.model, dimension = EXCLUDED.dimension, embedding_input_hash = EXCLUDED.embedding_input_hash, embedding = EXCLUDED.embedding, generated_at = now()",
+        "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding) \
+VALUES ('{artefact_id}', '{repo_id}', '{blob_sha}', '{representation_kind}', '{setup_fingerprint}', '{provider}', '{model}', {dimension}, '{embedding_input_hash}', {embedding}) \
+ON CONFLICT (artefact_id, representation_kind, setup_fingerprint) DO UPDATE SET repo_id = EXCLUDED.repo_id, blob_sha = EXCLUDED.blob_sha, provider = EXCLUDED.provider, model = EXCLUDED.model, dimension = EXCLUDED.dimension, embedding_input_hash = EXCLUDED.embedding_input_hash, embedding = EXCLUDED.embedding, generated_at = now()",
         artefact_id = esc_pg(&row.artefact_id),
         repo_id = esc_pg(&row.repo_id),
         blob_sha = esc_pg(&row.blob_sha),
         representation_kind = esc_pg(&row.representation_kind.to_string()),
+        setup_fingerprint = esc_pg(&row.setup_fingerprint),
         provider = esc_pg(&row.provider),
         model = esc_pg(&row.model),
         dimension = row.dimension,
@@ -689,13 +755,14 @@ fn build_sqlite_symbol_embedding_persist_sql(
 ) -> Result<String> {
     let embedding_json = sql_json_string(&row.embedding)?;
     Ok(format!(
-        "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, representation_kind, provider, model, dimension, embedding_input_hash, embedding) \
-VALUES ('{artefact_id}', '{repo_id}', '{blob_sha}', '{representation_kind}', '{provider}', '{model}', {dimension}, '{embedding_input_hash}', '{embedding}') \
-ON CONFLICT (artefact_id, representation_kind) DO UPDATE SET repo_id = excluded.repo_id, blob_sha = excluded.blob_sha, provider = excluded.provider, model = excluded.model, dimension = excluded.dimension, embedding_input_hash = excluded.embedding_input_hash, embedding = excluded.embedding, generated_at = CURRENT_TIMESTAMP",
+        "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding) \
+VALUES ('{artefact_id}', '{repo_id}', '{blob_sha}', '{representation_kind}', '{setup_fingerprint}', '{provider}', '{model}', {dimension}, '{embedding_input_hash}', '{embedding}') \
+ON CONFLICT (artefact_id, representation_kind, setup_fingerprint) DO UPDATE SET repo_id = excluded.repo_id, blob_sha = excluded.blob_sha, provider = excluded.provider, model = excluded.model, dimension = excluded.dimension, embedding_input_hash = excluded.embedding_input_hash, embedding = excluded.embedding, generated_at = CURRENT_TIMESTAMP",
         artefact_id = esc_pg(&row.artefact_id),
         repo_id = esc_pg(&row.repo_id),
         blob_sha = esc_pg(&row.blob_sha),
         representation_kind = esc_pg(&row.representation_kind.to_string()),
+        setup_fingerprint = esc_pg(&row.setup_fingerprint),
         provider = esc_pg(&row.provider),
         model = esc_pg(&row.model),
         dimension = row.dimension,
@@ -718,21 +785,56 @@ fn build_current_symbol_embedding_persist_sql(
         .map(|value| format!("'{}'", esc_pg(value)))
         .unwrap_or_else(|| "NULL".to_string());
     Ok(format!(
-        "INSERT INTO symbol_embeddings_current (artefact_id, repo_id, path, content_id, symbol_id, representation_kind, provider, model, dimension, embedding_input_hash, embedding) \
-VALUES ('{artefact_id}', '{repo_id}', '{path}', '{content_id}', {symbol_id}, '{representation_kind}', '{provider}', '{model}', {dimension}, '{embedding_input_hash}', '{embedding}') \
-ON CONFLICT (artefact_id, representation_kind) DO UPDATE SET repo_id = excluded.repo_id, path = excluded.path, content_id = excluded.content_id, symbol_id = excluded.symbol_id, provider = excluded.provider, model = excluded.model, dimension = excluded.dimension, embedding_input_hash = excluded.embedding_input_hash, embedding = excluded.embedding, generated_at = CURRENT_TIMESTAMP",
+        "INSERT INTO symbol_embeddings_current (artefact_id, repo_id, path, content_id, symbol_id, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding) \
+VALUES ('{artefact_id}', '{repo_id}', '{path}', '{content_id}', {symbol_id}, '{representation_kind}', '{setup_fingerprint}', '{provider}', '{model}', {dimension}, '{embedding_input_hash}', '{embedding}') \
+ON CONFLICT (artefact_id, representation_kind, setup_fingerprint) DO UPDATE SET repo_id = excluded.repo_id, path = excluded.path, content_id = excluded.content_id, symbol_id = excluded.symbol_id, provider = excluded.provider, model = excluded.model, dimension = excluded.dimension, embedding_input_hash = excluded.embedding_input_hash, embedding = excluded.embedding, generated_at = CURRENT_TIMESTAMP",
         artefact_id = esc_pg(&row.artefact_id),
         repo_id = esc_pg(&row.repo_id),
         path = esc_pg(path),
         content_id = esc_pg(content_id),
         symbol_id = symbol_id_sql,
         representation_kind = esc_pg(&row.representation_kind.to_string()),
+        setup_fingerprint = esc_pg(&row.setup_fingerprint),
         provider = esc_pg(&row.provider),
         model = esc_pg(&row.model),
         dimension = row.dimension,
         embedding_input_hash = esc_pg(&row.embedding_input_hash),
         embedding = embedding_json,
     ))
+}
+
+async fn persist_embedding_setup(
+    relational: &RelationalStorage,
+    setup: &embeddings::EmbeddingSetup,
+) -> Result<()> {
+    relational
+        .exec(&build_embedding_setup_persist_sql(setup))
+        .await
+}
+
+fn build_embedding_setup_persist_sql(setup: &embeddings::EmbeddingSetup) -> String {
+    format!(
+        "INSERT INTO semantic_embedding_setups (setup_fingerprint, provider, model, dimension) \
+VALUES ('{setup_fingerprint}', '{provider}', '{model}', {dimension}) \
+ON CONFLICT (setup_fingerprint) DO UPDATE SET provider = excluded.provider, model = excluded.model, dimension = excluded.dimension",
+        setup_fingerprint = esc_pg(&setup.setup_fingerprint),
+        provider = esc_pg(&setup.provider),
+        model = esc_pg(&setup.model),
+        dimension = setup.dimension,
+    )
+}
+
+fn representation_kind_sql_predicate(
+    column: &str,
+    kind: embeddings::EmbeddingRepresentationKind,
+) -> String {
+    let values = kind
+        .storage_values()
+        .iter()
+        .map(|value| format!("'{}'", esc_pg(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{column} IN ({values})")
 }
 
 #[cfg(test)]

--- a/bitloops/src/capability_packs/semantic_clones/stage_embeddings.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_embeddings.rs
@@ -200,6 +200,29 @@ pub(crate) async fn clear_repo_symbol_embedding_rows(
         .await
 }
 
+pub(crate) async fn clear_repo_symbol_embedding_rows_for_representation(
+    relational: &RelationalStorage,
+    repo_id: &str,
+    representation_kind: embeddings::EmbeddingRepresentationKind,
+) -> Result<()> {
+    ensure_semantic_embeddings_schema(relational).await?;
+    let predicate = representation_kind_sql_predicate("representation_kind", representation_kind);
+    relational
+        .exec_batch_transactional(&[
+            format!(
+                "DELETE FROM symbol_embeddings WHERE repo_id = '{repo_id}' AND {predicate}",
+                repo_id = esc_pg(repo_id),
+                predicate = predicate,
+            ),
+            format!(
+                "DELETE FROM symbol_embeddings_current WHERE repo_id = '{repo_id}' AND {predicate}",
+                repo_id = esc_pg(repo_id),
+                predicate = predicate,
+            ),
+        ])
+        .await
+}
+
 #[allow(dead_code)]
 pub(crate) async fn clear_current_symbol_embedding_rows_for_path(
     relational: &RelationalStorage,
@@ -283,14 +306,13 @@ pub(crate) async fn determine_repo_embedding_sync_action(
     .await?;
     if let Some(active) =
         load_active_embedding_setup(relational, repo_id, representation_kind).await?
+        && active.setup == *setup
     {
-        if active.setup == *setup {
-            return Ok(if current_coverage_complete {
-                RepoEmbeddingSyncAction::Incremental
-            } else {
-                RepoEmbeddingSyncAction::RefreshCurrentRepo
-            });
-        }
+        return Ok(if current_coverage_complete {
+            RepoEmbeddingSyncAction::Incremental
+        } else {
+            RepoEmbeddingSyncAction::RefreshCurrentRepo
+        });
     }
 
     let current_states =
@@ -581,7 +603,12 @@ fn build_current_repo_embedding_states_sql(
     representation_kind: Option<embeddings::EmbeddingRepresentationKind>,
 ) -> String {
     let representation_filter = representation_kind
-        .map(|kind| format!("AND {}", representation_kind_sql_predicate("e.representation_kind", kind)))
+        .map(|kind| {
+            format!(
+                "AND {}",
+                representation_kind_sql_predicate("e.representation_kind", kind)
+            )
+        })
         .unwrap_or_default();
     format!(
         "SELECT representation_kind, provider, model, dimension, setup_fingerprint \
@@ -709,17 +736,19 @@ fn parse_active_embedding_state_rows(
 
     states
         .into_iter()
-        .map(|(representation_kind, provider, model, dimension, setup_fingerprint)| {
-            embeddings::ActiveEmbeddingRepresentationState::new(
-                representation_kind,
-                embeddings::EmbeddingSetup {
-                    provider,
-                    model,
-                    dimension,
-                    setup_fingerprint,
-                },
-            )
-        })
+        .map(
+            |(representation_kind, provider, model, dimension, setup_fingerprint)| {
+                embeddings::ActiveEmbeddingRepresentationState::new(
+                    representation_kind,
+                    embeddings::EmbeddingSetup {
+                        provider,
+                        model,
+                        dimension,
+                        setup_fingerprint,
+                    },
+                )
+            },
+        )
         .collect()
 }
 

--- a/bitloops/src/capability_packs/semantic_clones/stage_embeddings/schema.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_embeddings/schema.rs
@@ -315,46 +315,45 @@ async fn upgrade_sqlite_semantic_embeddings_schema(sqlite_path: &Path) -> Result
         let conn = rusqlite::Connection::open(&db_path)
             .with_context(|| format!("opening SQLite database at {}", db_path.display()))?;
 
-        let symbol_embeddings_needs_migration = sqlite_table_has_column(
-            &conn,
-            "symbol_embeddings",
-            "artefact_id",
-        )? && (!sqlite_table_has_column(&conn, "symbol_embeddings", "setup_fingerprint")?
-            || sqlite_table_primary_key_columns(&conn, "symbol_embeddings")?
-                != vec![
-                    "artefact_id".to_string(),
-                    "representation_kind".to_string(),
-                    "setup_fingerprint".to_string(),
-                ]);
+        let symbol_embeddings_needs_migration =
+            sqlite_table_has_column(&conn, "symbol_embeddings", "artefact_id")?
+                && (!sqlite_table_has_column(&conn, "symbol_embeddings", "setup_fingerprint")?
+                    || sqlite_table_primary_key_columns(&conn, "symbol_embeddings")?
+                        != vec![
+                            "artefact_id".to_string(),
+                            "representation_kind".to_string(),
+                            "setup_fingerprint".to_string(),
+                        ]);
         if symbol_embeddings_needs_migration {
             migrate_sqlite_symbol_embeddings_table(&conn)?;
         }
 
-        let symbol_embeddings_current_needs_migration = sqlite_table_has_column(
-            &conn,
-            "symbol_embeddings_current",
-            "artefact_id",
-        )? && (!sqlite_table_has_column(&conn, "symbol_embeddings_current", "setup_fingerprint")?
-            || sqlite_table_primary_key_columns(&conn, "symbol_embeddings_current")?
-                != vec![
-                    "artefact_id".to_string(),
-                    "representation_kind".to_string(),
-                    "setup_fingerprint".to_string(),
-                ]);
+        let symbol_embeddings_current_needs_migration =
+            sqlite_table_has_column(&conn, "symbol_embeddings_current", "artefact_id")?
+                && (!sqlite_table_has_column(
+                    &conn,
+                    "symbol_embeddings_current",
+                    "setup_fingerprint",
+                )? || sqlite_table_primary_key_columns(&conn, "symbol_embeddings_current")?
+                    != vec![
+                        "artefact_id".to_string(),
+                        "representation_kind".to_string(),
+                        "setup_fingerprint".to_string(),
+                    ]);
         if symbol_embeddings_current_needs_migration {
             migrate_sqlite_current_symbol_embeddings_table(&conn)?;
         }
 
-        let active_state_needs_migration = sqlite_table_has_column(
-            &conn,
-            "semantic_clone_embedding_setup_state",
-            "repo_id",
-        )? && (!sqlite_table_has_column(
-            &conn,
-            "semantic_clone_embedding_setup_state",
-            "setup_fingerprint",
-        )? || sqlite_table_primary_key_columns(&conn, "semantic_clone_embedding_setup_state")?
-            != vec!["repo_id".to_string(), "representation_kind".to_string()]);
+        let active_state_needs_migration =
+            sqlite_table_has_column(&conn, "semantic_clone_embedding_setup_state", "repo_id")?
+                && (!sqlite_table_has_column(
+                    &conn,
+                    "semantic_clone_embedding_setup_state",
+                    "setup_fingerprint",
+                )? || sqlite_table_primary_key_columns(
+                    &conn,
+                    "semantic_clone_embedding_setup_state",
+                )? != vec!["repo_id".to_string(), "representation_kind".to_string()]);
         if active_state_needs_migration {
             migrate_sqlite_active_embedding_setup_table(&conn)?;
         }
@@ -369,7 +368,8 @@ async fn upgrade_sqlite_semantic_embeddings_schema(sqlite_path: &Path) -> Result
 }
 
 fn migrate_sqlite_symbol_embeddings_table(conn: &rusqlite::Connection) -> Result<()> {
-    let has_representation = sqlite_table_has_column(conn, "symbol_embeddings", "representation_kind")?;
+    let has_representation =
+        sqlite_table_has_column(conn, "symbol_embeddings", "representation_kind")?;
     conn.execute(
         "ALTER TABLE symbol_embeddings RENAME TO symbol_embeddings_legacy",
         [],

--- a/bitloops/src/capability_packs/semantic_clones/stage_embeddings/schema.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_embeddings/schema.rs
@@ -8,25 +8,34 @@ pub(crate) fn semantic_embeddings_postgres_schema_sql() -> &'static str {
     r#"
 CREATE EXTENSION IF NOT EXISTS vector;
 
+CREATE TABLE IF NOT EXISTS semantic_embedding_setups (
+    setup_fingerprint TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    dimension INTEGER NOT NULL CHECK (dimension > 0),
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
 CREATE TABLE IF NOT EXISTS symbol_embeddings (
     artefact_id TEXT NOT NULL,
     repo_id TEXT NOT NULL,
     blob_sha TEXT NOT NULL,
-    representation_kind TEXT NOT NULL DEFAULT 'baseline',
+    representation_kind TEXT NOT NULL DEFAULT 'code',
+    setup_fingerprint TEXT NOT NULL,
     provider TEXT NOT NULL,
     model TEXT NOT NULL,
     dimension INTEGER NOT NULL CHECK (dimension > 0),
     embedding_input_hash TEXT NOT NULL,
     embedding vector NOT NULL,
     generated_at TIMESTAMPTZ DEFAULT now(),
-    PRIMARY KEY (artefact_id, representation_kind)
+    PRIMARY KEY (artefact_id, representation_kind, setup_fingerprint)
 );
 
 CREATE INDEX IF NOT EXISTS symbol_embeddings_repo_artefact_idx
-ON symbol_embeddings (repo_id, artefact_id, representation_kind);
+ON symbol_embeddings (repo_id, artefact_id, representation_kind, setup_fingerprint);
 
 CREATE INDEX IF NOT EXISTS symbol_embeddings_repo_model_idx
-ON symbol_embeddings (repo_id, representation_kind, provider, model, dimension, blob_sha);
+ON symbol_embeddings (repo_id, representation_kind, setup_fingerprint, blob_sha);
 
 CREATE TABLE IF NOT EXISTS symbol_embeddings_current (
     artefact_id TEXT NOT NULL,
@@ -34,54 +43,66 @@ CREATE TABLE IF NOT EXISTS symbol_embeddings_current (
     path TEXT NOT NULL,
     content_id TEXT NOT NULL,
     symbol_id TEXT,
-    representation_kind TEXT NOT NULL DEFAULT 'baseline',
+    representation_kind TEXT NOT NULL DEFAULT 'code',
+    setup_fingerprint TEXT NOT NULL,
     provider TEXT NOT NULL,
     model TEXT NOT NULL,
     dimension INTEGER NOT NULL CHECK (dimension > 0),
     embedding_input_hash TEXT NOT NULL,
     embedding vector NOT NULL,
     generated_at TIMESTAMPTZ DEFAULT now(),
-    PRIMARY KEY (artefact_id, representation_kind)
+    PRIMARY KEY (artefact_id, representation_kind, setup_fingerprint)
 );
 
 CREATE INDEX IF NOT EXISTS symbol_embeddings_current_repo_path_idx
 ON symbol_embeddings_current (repo_id, path);
 
 CREATE UNIQUE INDEX IF NOT EXISTS symbol_embeddings_current_repo_artefact_idx
-ON symbol_embeddings_current (repo_id, artefact_id, representation_kind);
+ON symbol_embeddings_current (repo_id, artefact_id, representation_kind, setup_fingerprint);
+
 CREATE TABLE IF NOT EXISTS semantic_clone_embedding_setup_state (
-    repo_id TEXT PRIMARY KEY,
-    representation_kind TEXT NOT NULL DEFAULT 'baseline',
+    repo_id TEXT NOT NULL,
+    representation_kind TEXT NOT NULL DEFAULT 'code',
     provider TEXT NOT NULL,
     model TEXT NOT NULL,
     dimension INTEGER NOT NULL CHECK (dimension > 0),
     setup_fingerprint TEXT NOT NULL,
-    updated_at TIMESTAMPTZ DEFAULT now()
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (repo_id, representation_kind)
 );
 "#
 }
 
 pub(crate) fn semantic_embeddings_sqlite_schema_sql() -> &'static str {
     r#"
+CREATE TABLE IF NOT EXISTS semantic_embedding_setups (
+    setup_fingerprint TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    dimension INTEGER NOT NULL CHECK (dimension > 0),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE IF NOT EXISTS symbol_embeddings (
     artefact_id TEXT NOT NULL,
     repo_id TEXT NOT NULL,
     blob_sha TEXT NOT NULL,
-    representation_kind TEXT NOT NULL DEFAULT 'baseline',
+    representation_kind TEXT NOT NULL DEFAULT 'code',
+    setup_fingerprint TEXT NOT NULL,
     provider TEXT NOT NULL,
     model TEXT NOT NULL,
     dimension INTEGER NOT NULL CHECK (dimension > 0),
     embedding_input_hash TEXT NOT NULL,
     embedding TEXT NOT NULL,
     generated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (artefact_id, representation_kind)
+    PRIMARY KEY (artefact_id, representation_kind, setup_fingerprint)
 );
 
 CREATE INDEX IF NOT EXISTS symbol_embeddings_repo_artefact_idx
-ON symbol_embeddings (repo_id, artefact_id, representation_kind);
+ON symbol_embeddings (repo_id, artefact_id, representation_kind, setup_fingerprint);
 
 CREATE INDEX IF NOT EXISTS symbol_embeddings_repo_model_idx
-ON symbol_embeddings (repo_id, representation_kind, provider, model, dimension, blob_sha);
+ON symbol_embeddings (repo_id, representation_kind, setup_fingerprint, blob_sha);
 
 CREATE TABLE IF NOT EXISTS symbol_embeddings_current (
     artefact_id TEXT NOT NULL,
@@ -89,53 +110,110 @@ CREATE TABLE IF NOT EXISTS symbol_embeddings_current (
     path TEXT NOT NULL,
     content_id TEXT NOT NULL,
     symbol_id TEXT,
-    representation_kind TEXT NOT NULL DEFAULT 'baseline',
+    representation_kind TEXT NOT NULL DEFAULT 'code',
+    setup_fingerprint TEXT NOT NULL,
     provider TEXT NOT NULL,
     model TEXT NOT NULL,
     dimension INTEGER NOT NULL CHECK (dimension > 0),
     embedding_input_hash TEXT NOT NULL,
     embedding TEXT NOT NULL,
     generated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (artefact_id, representation_kind)
+    PRIMARY KEY (artefact_id, representation_kind, setup_fingerprint)
 );
 
 CREATE INDEX IF NOT EXISTS symbol_embeddings_current_repo_path_idx
 ON symbol_embeddings_current (repo_id, path);
 
 CREATE UNIQUE INDEX IF NOT EXISTS symbol_embeddings_current_repo_artefact_idx
-ON symbol_embeddings_current (repo_id, artefact_id, representation_kind);
+ON symbol_embeddings_current (repo_id, artefact_id, representation_kind, setup_fingerprint);
+
 CREATE TABLE IF NOT EXISTS semantic_clone_embedding_setup_state (
-    repo_id TEXT PRIMARY KEY,
-    representation_kind TEXT NOT NULL DEFAULT 'baseline',
+    repo_id TEXT NOT NULL,
+    representation_kind TEXT NOT NULL DEFAULT 'code',
     provider TEXT NOT NULL,
     model TEXT NOT NULL,
     dimension INTEGER NOT NULL CHECK (dimension > 0),
     setup_fingerprint TEXT NOT NULL,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, representation_kind)
 );
 "#
 }
 
 fn semantic_embeddings_postgres_upgrade_sql() -> &'static str {
     r#"
+CREATE TABLE IF NOT EXISTS semantic_embedding_setups (
+    setup_fingerprint TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    dimension INTEGER NOT NULL CHECK (dimension > 0),
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
 ALTER TABLE symbol_embeddings
-    ADD COLUMN IF NOT EXISTS representation_kind TEXT NOT NULL DEFAULT 'baseline';
+    ADD COLUMN IF NOT EXISTS representation_kind TEXT NOT NULL DEFAULT 'code';
+ALTER TABLE symbol_embeddings
+    ADD COLUMN IF NOT EXISTS setup_fingerprint TEXT;
 ALTER TABLE symbol_embeddings_current
-    ADD COLUMN IF NOT EXISTS representation_kind TEXT NOT NULL DEFAULT 'baseline';
+    ADD COLUMN IF NOT EXISTS representation_kind TEXT NOT NULL DEFAULT 'code';
+ALTER TABLE symbol_embeddings_current
+    ADD COLUMN IF NOT EXISTS setup_fingerprint TEXT;
 ALTER TABLE semantic_clone_embedding_setup_state
-    ADD COLUMN IF NOT EXISTS representation_kind TEXT NOT NULL DEFAULT 'baseline';
+    ADD COLUMN IF NOT EXISTS representation_kind TEXT NOT NULL DEFAULT 'code';
+ALTER TABLE semantic_clone_embedding_setup_state
+    ADD COLUMN IF NOT EXISTS setup_fingerprint TEXT;
+
+UPDATE symbol_embeddings
+SET setup_fingerprint = 'provider=' || provider || '|model=' || model || '|dimension=' || dimension::text
+WHERE setup_fingerprint IS NULL OR btrim(setup_fingerprint) = '';
+
+UPDATE symbol_embeddings_current
+SET setup_fingerprint = 'provider=' || provider || '|model=' || model || '|dimension=' || dimension::text
+WHERE setup_fingerprint IS NULL OR btrim(setup_fingerprint) = '';
+
+UPDATE semantic_clone_embedding_setup_state
+SET setup_fingerprint = 'provider=' || provider || '|model=' || model || '|dimension=' || dimension::text
+WHERE setup_fingerprint IS NULL OR btrim(setup_fingerprint) = '';
+
+INSERT INTO semantic_embedding_setups (setup_fingerprint, provider, model, dimension)
+SELECT DISTINCT setup_fingerprint, provider, model, dimension
+FROM symbol_embeddings
+WHERE setup_fingerprint IS NOT NULL AND btrim(setup_fingerprint) <> ''
+ON CONFLICT (setup_fingerprint) DO UPDATE
+SET provider = EXCLUDED.provider, model = EXCLUDED.model, dimension = EXCLUDED.dimension;
+
+INSERT INTO semantic_embedding_setups (setup_fingerprint, provider, model, dimension)
+SELECT DISTINCT setup_fingerprint, provider, model, dimension
+FROM symbol_embeddings_current
+WHERE setup_fingerprint IS NOT NULL AND btrim(setup_fingerprint) <> ''
+ON CONFLICT (setup_fingerprint) DO UPDATE
+SET provider = EXCLUDED.provider, model = EXCLUDED.model, dimension = EXCLUDED.dimension;
+
+INSERT INTO semantic_embedding_setups (setup_fingerprint, provider, model, dimension)
+SELECT DISTINCT setup_fingerprint, provider, model, dimension
+FROM semantic_clone_embedding_setup_state
+WHERE setup_fingerprint IS NOT NULL AND btrim(setup_fingerprint) <> ''
+ON CONFLICT (setup_fingerprint) DO UPDATE
+SET provider = EXCLUDED.provider, model = EXCLUDED.model, dimension = EXCLUDED.dimension;
+
+ALTER TABLE symbol_embeddings
+    ALTER COLUMN setup_fingerprint SET NOT NULL;
+ALTER TABLE symbol_embeddings_current
+    ALTER COLUMN setup_fingerprint SET NOT NULL;
+ALTER TABLE semantic_clone_embedding_setup_state
+    ALTER COLUMN setup_fingerprint SET NOT NULL;
 
 DROP INDEX IF EXISTS symbol_embeddings_repo_artefact_idx;
 CREATE INDEX IF NOT EXISTS symbol_embeddings_repo_artefact_idx
-ON symbol_embeddings (repo_id, artefact_id, representation_kind);
+ON symbol_embeddings (repo_id, artefact_id, representation_kind, setup_fingerprint);
 
 DROP INDEX IF EXISTS symbol_embeddings_repo_model_idx;
 CREATE INDEX IF NOT EXISTS symbol_embeddings_repo_model_idx
-ON symbol_embeddings (repo_id, representation_kind, provider, model, dimension, blob_sha);
+ON symbol_embeddings (repo_id, representation_kind, setup_fingerprint, blob_sha);
 
 DROP INDEX IF EXISTS symbol_embeddings_current_repo_artefact_idx;
 CREATE UNIQUE INDEX IF NOT EXISTS symbol_embeddings_current_repo_artefact_idx
-ON symbol_embeddings_current (repo_id, artefact_id, representation_kind);
+ON symbol_embeddings_current (repo_id, artefact_id, representation_kind, setup_fingerprint);
 
 DO $$
 BEGIN
@@ -154,7 +232,7 @@ END $$;
 DO $$
 BEGIN
     ALTER TABLE symbol_embeddings
-        ADD CONSTRAINT symbol_embeddings_pkey PRIMARY KEY (artefact_id, representation_kind);
+        ADD CONSTRAINT symbol_embeddings_pkey PRIMARY KEY (artefact_id, representation_kind, setup_fingerprint);
 EXCEPTION WHEN duplicate_table THEN
     NULL;
 WHEN duplicate_object THEN
@@ -178,7 +256,31 @@ END $$;
 DO $$
 BEGIN
     ALTER TABLE symbol_embeddings_current
-        ADD CONSTRAINT symbol_embeddings_current_pkey PRIMARY KEY (artefact_id, representation_kind);
+        ADD CONSTRAINT symbol_embeddings_current_pkey PRIMARY KEY (artefact_id, representation_kind, setup_fingerprint);
+EXCEPTION WHEN duplicate_table THEN
+    NULL;
+WHEN duplicate_object THEN
+    NULL;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'semantic_clone_embedding_setup_state'::regclass
+          AND conname = 'semantic_clone_embedding_setup_state_pkey'
+    ) THEN
+        ALTER TABLE semantic_clone_embedding_setup_state DROP CONSTRAINT semantic_clone_embedding_setup_state_pkey;
+    END IF;
+EXCEPTION WHEN undefined_table THEN
+    NULL;
+END $$;
+
+DO $$
+BEGIN
+    ALTER TABLE semantic_clone_embedding_setup_state
+        ADD CONSTRAINT semantic_clone_embedding_setup_state_pkey PRIMARY KEY (repo_id, representation_kind);
 EXCEPTION WHEN duplicate_table THEN
     NULL;
 WHEN duplicate_object THEN
@@ -213,113 +315,236 @@ async fn upgrade_sqlite_semantic_embeddings_schema(sqlite_path: &Path) -> Result
         let conn = rusqlite::Connection::open(&db_path)
             .with_context(|| format!("opening SQLite database at {}", db_path.display()))?;
 
-        if sqlite_table_has_column(&conn, "symbol_embeddings", "artefact_id")?
-            && !sqlite_table_has_column(&conn, "symbol_embeddings", "representation_kind")?
-        {
-            conn.execute(
-                "ALTER TABLE symbol_embeddings RENAME TO symbol_embeddings_legacy",
-                [],
-            )
-            .context("renaming legacy symbol_embeddings table")?;
-            conn.execute_batch(semantic_embeddings_sqlite_schema_sql())
-                .context("creating upgraded semantic embedding tables")?;
-            conn.execute(
-                "INSERT INTO symbol_embeddings (
-                    artefact_id,
-                    repo_id,
-                    blob_sha,
-                    representation_kind,
-                    provider,
-                    model,
-                    dimension,
-                    embedding_input_hash,
-                    embedding,
-                    generated_at
-                )
-                SELECT
-                    artefact_id,
-                    repo_id,
-                    blob_sha,
-                    'baseline',
-                    provider,
-                    model,
-                    dimension,
-                    embedding_input_hash,
-                    embedding,
-                    generated_at
-                FROM symbol_embeddings_legacy",
-                [],
-            )
-            .context("copying legacy symbol_embeddings rows into upgraded table")?;
-            conn.execute("DROP TABLE symbol_embeddings_legacy", [])
-                .context("dropping legacy symbol_embeddings table")?;
+        let symbol_embeddings_needs_migration = sqlite_table_has_column(
+            &conn,
+            "symbol_embeddings",
+            "artefact_id",
+        )? && (!sqlite_table_has_column(&conn, "symbol_embeddings", "setup_fingerprint")?
+            || sqlite_table_primary_key_columns(&conn, "symbol_embeddings")?
+                != vec![
+                    "artefact_id".to_string(),
+                    "representation_kind".to_string(),
+                    "setup_fingerprint".to_string(),
+                ]);
+        if symbol_embeddings_needs_migration {
+            migrate_sqlite_symbol_embeddings_table(&conn)?;
         }
 
-        if sqlite_table_has_column(&conn, "symbol_embeddings_current", "artefact_id")?
-            && !sqlite_table_has_column(&conn, "symbol_embeddings_current", "representation_kind")?
-        {
-            conn.execute(
-                "ALTER TABLE symbol_embeddings_current RENAME TO symbol_embeddings_current_legacy",
-                [],
-            )
-            .context("renaming legacy symbol_embeddings_current table")?;
-            conn.execute_batch(semantic_embeddings_sqlite_schema_sql())
-                .context("creating upgraded current semantic embedding tables")?;
-            conn.execute(
-                "INSERT INTO symbol_embeddings_current (
-                    artefact_id,
-                    repo_id,
-                    path,
-                    content_id,
-                    symbol_id,
-                    representation_kind,
-                    provider,
-                    model,
-                    dimension,
-                    embedding_input_hash,
-                    embedding,
-                    generated_at
-                )
-                SELECT
-                    artefact_id,
-                    repo_id,
-                    path,
-                    content_id,
-                    symbol_id,
-                    'baseline',
-                    provider,
-                    model,
-                    dimension,
-                    embedding_input_hash,
-                    embedding,
-                    generated_at
-                FROM symbol_embeddings_current_legacy",
-                [],
-            )
-            .context("copying legacy symbol_embeddings_current rows into upgraded table")?;
-            conn.execute("DROP TABLE symbol_embeddings_current_legacy", [])
-                .context("dropping legacy symbol_embeddings_current table")?;
+        let symbol_embeddings_current_needs_migration = sqlite_table_has_column(
+            &conn,
+            "symbol_embeddings_current",
+            "artefact_id",
+        )? && (!sqlite_table_has_column(&conn, "symbol_embeddings_current", "setup_fingerprint")?
+            || sqlite_table_primary_key_columns(&conn, "symbol_embeddings_current")?
+                != vec![
+                    "artefact_id".to_string(),
+                    "representation_kind".to_string(),
+                    "setup_fingerprint".to_string(),
+                ]);
+        if symbol_embeddings_current_needs_migration {
+            migrate_sqlite_current_symbol_embeddings_table(&conn)?;
         }
 
-        if sqlite_table_has_column(&conn, "semantic_clone_embedding_setup_state", "repo_id")?
-            && !sqlite_table_has_column(
-                &conn,
-                "semantic_clone_embedding_setup_state",
-                "representation_kind",
-            )?
-        {
-            conn.execute(
-                "ALTER TABLE semantic_clone_embedding_setup_state
-                 ADD COLUMN representation_kind TEXT NOT NULL DEFAULT 'baseline'",
-                [],
-            )
-            .context("adding representation_kind to semantic_clone_embedding_setup_state")?;
+        let active_state_needs_migration = sqlite_table_has_column(
+            &conn,
+            "semantic_clone_embedding_setup_state",
+            "repo_id",
+        )? && (!sqlite_table_has_column(
+            &conn,
+            "semantic_clone_embedding_setup_state",
+            "setup_fingerprint",
+        )? || sqlite_table_primary_key_columns(&conn, "semantic_clone_embedding_setup_state")?
+            != vec!["repo_id".to_string(), "representation_kind".to_string()]);
+        if active_state_needs_migration {
+            migrate_sqlite_active_embedding_setup_table(&conn)?;
         }
 
+        conn.execute_batch(semantic_embeddings_sqlite_schema_sql())
+            .context("ensuring upgraded SQLite semantic embedding tables")?;
+        backfill_sqlite_embedding_setup_catalog(&conn)?;
         Ok(())
     })
     .await
     .context("joining SQLite semantic embedding upgrade task")?
+}
+
+fn migrate_sqlite_symbol_embeddings_table(conn: &rusqlite::Connection) -> Result<()> {
+    let has_representation = sqlite_table_has_column(conn, "symbol_embeddings", "representation_kind")?;
+    conn.execute(
+        "ALTER TABLE symbol_embeddings RENAME TO symbol_embeddings_legacy",
+        [],
+    )
+    .context("renaming legacy symbol_embeddings table")?;
+    conn.execute_batch(semantic_embeddings_sqlite_schema_sql())
+        .context("creating upgraded semantic embedding tables")?;
+    let representation_expr = if has_representation {
+        "COALESCE(representation_kind, 'baseline')"
+    } else {
+        "'baseline'"
+    };
+    conn.execute(
+        &format!(
+            "INSERT INTO symbol_embeddings (
+                artefact_id,
+                repo_id,
+                blob_sha,
+                representation_kind,
+                setup_fingerprint,
+                provider,
+                model,
+                dimension,
+                embedding_input_hash,
+                embedding,
+                generated_at
+            )
+            SELECT
+                artefact_id,
+                repo_id,
+                blob_sha,
+                {representation_expr},
+                'provider=' || provider || '|model=' || model || '|dimension=' || dimension,
+                provider,
+                model,
+                dimension,
+                embedding_input_hash,
+                embedding,
+                generated_at
+            FROM symbol_embeddings_legacy"
+        ),
+        [],
+    )
+    .context("copying symbol_embeddings rows into upgraded table")?;
+    conn.execute("DROP TABLE symbol_embeddings_legacy", [])
+        .context("dropping legacy symbol_embeddings table")?;
+    Ok(())
+}
+
+fn migrate_sqlite_current_symbol_embeddings_table(conn: &rusqlite::Connection) -> Result<()> {
+    let has_representation =
+        sqlite_table_has_column(conn, "symbol_embeddings_current", "representation_kind")?;
+    conn.execute(
+        "ALTER TABLE symbol_embeddings_current RENAME TO symbol_embeddings_current_legacy",
+        [],
+    )
+    .context("renaming legacy symbol_embeddings_current table")?;
+    conn.execute_batch(semantic_embeddings_sqlite_schema_sql())
+        .context("creating upgraded current semantic embedding tables")?;
+    let representation_expr = if has_representation {
+        "COALESCE(representation_kind, 'baseline')"
+    } else {
+        "'baseline'"
+    };
+    conn.execute(
+        &format!(
+            "INSERT INTO symbol_embeddings_current (
+                artefact_id,
+                repo_id,
+                path,
+                content_id,
+                symbol_id,
+                representation_kind,
+                setup_fingerprint,
+                provider,
+                model,
+                dimension,
+                embedding_input_hash,
+                embedding,
+                generated_at
+            )
+            SELECT
+                artefact_id,
+                repo_id,
+                path,
+                content_id,
+                symbol_id,
+                {representation_expr},
+                'provider=' || provider || '|model=' || model || '|dimension=' || dimension,
+                provider,
+                model,
+                dimension,
+                embedding_input_hash,
+                embedding,
+                generated_at
+            FROM symbol_embeddings_current_legacy"
+        ),
+        [],
+    )
+    .context("copying symbol_embeddings_current rows into upgraded table")?;
+    conn.execute("DROP TABLE symbol_embeddings_current_legacy", [])
+        .context("dropping legacy symbol_embeddings_current table")?;
+    Ok(())
+}
+
+fn migrate_sqlite_active_embedding_setup_table(conn: &rusqlite::Connection) -> Result<()> {
+    let has_representation = sqlite_table_has_column(
+        conn,
+        "semantic_clone_embedding_setup_state",
+        "representation_kind",
+    )?;
+    conn.execute(
+        "ALTER TABLE semantic_clone_embedding_setup_state RENAME TO semantic_clone_embedding_setup_state_legacy",
+        [],
+    )
+    .context("renaming legacy semantic_clone_embedding_setup_state table")?;
+    conn.execute_batch(semantic_embeddings_sqlite_schema_sql())
+        .context("creating upgraded semantic_clone_embedding_setup_state table")?;
+    let representation_expr = if has_representation {
+        "COALESCE(representation_kind, 'baseline')"
+    } else {
+        "'baseline'"
+    };
+    conn.execute(
+        &format!(
+            "INSERT INTO semantic_clone_embedding_setup_state (
+                repo_id,
+                representation_kind,
+                provider,
+                model,
+                dimension,
+                setup_fingerprint,
+                updated_at
+            )
+            SELECT
+                repo_id,
+                {representation_expr},
+                provider,
+                model,
+                dimension,
+                'provider=' || provider || '|model=' || model || '|dimension=' || dimension,
+                updated_at
+            FROM semantic_clone_embedding_setup_state_legacy"
+        ),
+        [],
+    )
+    .context("copying semantic_clone_embedding_setup_state rows into upgraded table")?;
+    conn.execute("DROP TABLE semantic_clone_embedding_setup_state_legacy", [])
+        .context("dropping legacy semantic_clone_embedding_setup_state table")?;
+    Ok(())
+}
+
+fn backfill_sqlite_embedding_setup_catalog(conn: &rusqlite::Connection) -> Result<()> {
+    for table in [
+        "symbol_embeddings",
+        "symbol_embeddings_current",
+        "semantic_clone_embedding_setup_state",
+    ] {
+        if !sqlite_table_has_column(conn, table, "setup_fingerprint")? {
+            continue;
+        }
+        let sql = format!(
+            "INSERT INTO semantic_embedding_setups (setup_fingerprint, provider, model, dimension)
+            SELECT DISTINCT setup_fingerprint, provider, model, dimension
+            FROM {table}
+            WHERE setup_fingerprint IS NOT NULL AND TRIM(setup_fingerprint) <> ''
+            ON CONFLICT(setup_fingerprint) DO UPDATE SET
+                provider = excluded.provider,
+                model = excluded.model,
+                dimension = excluded.dimension"
+        );
+        conn.execute(&sql, [])
+            .with_context(|| format!("backfilling semantic_embedding_setups from {table}"))?;
+    }
+    Ok(())
 }
 
 fn sqlite_table_has_column(
@@ -345,4 +570,47 @@ fn sqlite_table_has_column(
         }
     }
     Ok(false)
+}
+
+fn sqlite_table_primary_key_columns(
+    conn: &rusqlite::Connection,
+    table_name: &str,
+) -> Result<Vec<String>> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table_name})"))
+        .with_context(|| format!("preparing PRAGMA table_info({table_name})"))?;
+    let mut rows = stmt
+        .query([])
+        .with_context(|| format!("querying PRAGMA table_info({table_name})"))?;
+    let mut columns = Vec::<(i64, String)>::new();
+    while let Some(row) = rows
+        .next()
+        .with_context(|| format!("iterating PRAGMA table_info({table_name})"))?
+    {
+        let name: String = row
+            .get(1)
+            .with_context(|| format!("reading column name from PRAGMA table_info({table_name})"))?;
+        let pk_position: i64 = row
+            .get(5)
+            .with_context(|| format!("reading pk position from PRAGMA table_info({table_name})"))?;
+        if pk_position > 0 {
+            columns.push((pk_position, name));
+        }
+    }
+    columns.sort_by_key(|(position, _)| *position);
+    Ok(columns.into_iter().map(|(_, name)| name).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::capability_packs::semantic_clones::embeddings::EmbeddingSetup;
+
+    #[test]
+    fn embedding_setup_fingerprint_format_matches_schema_backfill() {
+        let setup = EmbeddingSetup::new("provider-x", "model-y", 42);
+        assert_eq!(
+            setup.setup_fingerprint,
+            "provider=provider-x|model=model-y|dimension=42"
+        );
+    }
 }

--- a/bitloops/src/capability_packs/semantic_clones/stage_embeddings_tests.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_embeddings_tests.rs
@@ -28,6 +28,10 @@ impl EmbeddingProvider for TestEmbeddingProvider {
     }
 }
 
+fn test_setup_fingerprint(provider: &str, model: &str, dimension: usize) -> String {
+    embeddings::EmbeddingSetup::new(provider, model, dimension).setup_fingerprint
+}
+
 async fn sqlite_relational_with_schema(sql: &str) -> RelationalStorage {
     let temp = tempdir().expect("temp dir");
     let db_path = temp.path().join("semantic-embeddings.sqlite");
@@ -78,7 +82,8 @@ fn semantic_embedding_postgres_persist_sql_contains_vector_literal() {
         artefact_id: "artefact-1".to_string(),
         repo_id: "repo-1".to_string(),
         blob_sha: "blob-1".to_string(),
-        representation_kind: embeddings::EmbeddingRepresentationKind::Baseline,
+        representation_kind: embeddings::EmbeddingRepresentationKind::Code,
+        setup_fingerprint: test_setup_fingerprint("voyage", "voyage-code-3", 3),
         provider: "voyage".to_string(),
         model: "voyage-code-3".to_string(),
         dimension: 3,
@@ -96,7 +101,12 @@ fn semantic_embedding_sqlite_persist_sql_contains_json_literal() {
         artefact_id: "artefact-1".to_string(),
         repo_id: "repo-1".to_string(),
         blob_sha: "blob-1".to_string(),
-        representation_kind: embeddings::EmbeddingRepresentationKind::Baseline,
+        representation_kind: embeddings::EmbeddingRepresentationKind::Code,
+        setup_fingerprint: test_setup_fingerprint(
+            "local",
+            "jinaai/jina-embeddings-v2-base-code",
+            3,
+        ),
         provider: "local".to_string(),
         model: "jinaai/jina-embeddings-v2-base-code".to_string(),
         dimension: 3,
@@ -146,11 +156,13 @@ fn semantic_embedding_index_state_sql_filters_by_artefact_id() {
     let sql = build_symbol_embedding_index_state_sql(
         "artefact-'1",
         "symbol_embeddings",
-        embeddings::EmbeddingRepresentationKind::Baseline,
+        embeddings::EmbeddingRepresentationKind::Code,
+        "provider=voyage|model=voyage-code-3|dimension=1024",
     );
     assert!(sql.contains("FROM symbol_embeddings"));
     assert!(sql.contains("WHERE artefact_id = 'artefact-''1'"));
-    assert!(sql.contains("representation_kind = 'baseline'"));
+    assert!(sql.contains("representation_kind = 'code'"));
+    assert!(sql.contains("setup_fingerprint = 'provider=voyage|model=voyage-code-3|dimension=1024'"));
 }
 
 #[test]
@@ -166,29 +178,24 @@ fn semantic_embedding_summary_lookup_sql_uses_all_ids() {
 
 #[tokio::test]
 async fn semantic_embedding_loads_index_state_from_relational_storage() {
-    let relational = sqlite_relational_with_schema(
-        "CREATE TABLE symbol_embeddings (
-            artefact_id TEXT NOT NULL,
-            repo_id TEXT NOT NULL,
-            representation_kind TEXT NOT NULL,
-            provider TEXT NOT NULL,
-            model TEXT NOT NULL,
-            dimension INTEGER NOT NULL,
-            embedding_input_hash TEXT NOT NULL,
-            PRIMARY KEY (artefact_id, representation_kind)
-        );
+    let setup_fingerprint = test_setup_fingerprint("voyage", "voyage-code-3", 1024);
+    let relational = sqlite_relational_with_schema(&format!(
+        "{schema}
         INSERT INTO symbol_embeddings (
-            artefact_id, repo_id, representation_kind, provider, model, dimension, embedding_input_hash
+            artefact_id, repo_id, blob_sha, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding
         ) VALUES (
-            'artefact-1', 'repo-1', 'baseline', 'voyage', 'voyage-code-3', 1024, 'hash-1'
+            'artefact-1', 'repo-1', 'blob-1', 'code', '{setup_fingerprint}', 'voyage', 'voyage-code-3', 1024, 'hash-1', '[0.1,0.2,0.3]'
         );",
-    )
+        schema = schema::semantic_embeddings_sqlite_schema_sql(),
+        setup_fingerprint = setup_fingerprint,
+    ))
     .await;
 
     let state = load_symbol_embedding_index_state(
         &relational,
         "artefact-1",
-        embeddings::EmbeddingRepresentationKind::Baseline,
+        embeddings::EmbeddingRepresentationKind::Code,
+        &setup_fingerprint,
     )
     .await
     .expect("load embedding state");
@@ -197,7 +204,7 @@ async fn semantic_embedding_loads_index_state_from_relational_storage() {
 }
 
 #[tokio::test]
-async fn current_embedding_upsert_reuses_matching_rows_and_keeps_enriched_variant() {
+async fn current_embedding_upsert_reuses_matching_rows_and_keeps_summary_variant() {
     let relational = sqlite_relational_with_schema(&format!(
         "{}\nCREATE TABLE symbol_semantics_current (
             artefact_id TEXT PRIMARY KEY,
@@ -270,41 +277,41 @@ async fn current_embedding_upsert_reuses_matching_rows_and_keeps_enriched_varian
     ];
     let provider: Arc<dyn EmbeddingProvider> = Arc::new(TestEmbeddingProvider);
 
-    let baseline_first = upsert_current_symbol_embedding_rows(
+    let code_first = upsert_current_symbol_embedding_rows(
         &relational,
         "src/a.ts",
         "blob-1",
         &inputs,
-        embeddings::EmbeddingRepresentationKind::Baseline,
+        embeddings::EmbeddingRepresentationKind::Code,
         Arc::clone(&provider),
     )
     .await
-    .expect("upsert baseline current embeddings");
-    let baseline_second = upsert_current_symbol_embedding_rows(
+    .expect("upsert code current embeddings");
+    let code_second = upsert_current_symbol_embedding_rows(
         &relational,
         "src/a.ts",
         "blob-1",
         &inputs,
-        embeddings::EmbeddingRepresentationKind::Baseline,
+        embeddings::EmbeddingRepresentationKind::Code,
         Arc::clone(&provider),
     )
     .await
-    .expect("reuse baseline current embeddings");
-    let enriched = upsert_current_symbol_embedding_rows(
+    .expect("reuse code current embeddings");
+    let summary = upsert_current_symbol_embedding_rows(
         &relational,
         "src/a.ts",
         "blob-1",
         &inputs,
-        embeddings::EmbeddingRepresentationKind::Enriched,
+        embeddings::EmbeddingRepresentationKind::Summary,
         provider,
     )
     .await
-    .expect("upsert enriched current embeddings");
+    .expect("upsert summary current embeddings");
 
-    assert_eq!(baseline_first.upserted, 2);
-    assert_eq!(baseline_second.skipped, 2);
-    assert_eq!(enriched.eligible, 1);
-    assert_eq!(enriched.upserted, 1);
+    assert_eq!(code_first.upserted, 2);
+    assert_eq!(code_second.skipped, 2);
+    assert_eq!(summary.eligible, 2);
+    assert_eq!(summary.upserted, 2);
 
     let rows = relational
         .query_rows(
@@ -330,9 +337,10 @@ async fn current_embedding_upsert_reuses_matching_rows_and_keeps_enriched_varian
     assert_eq!(
         rendered,
         vec![
-            ("artefact-1".to_string(), "baseline".to_string()),
-            ("artefact-1".to_string(), "enriched".to_string()),
-            ("artefact-2".to_string(), "baseline".to_string()),
+            ("artefact-1".to_string(), "code".to_string()),
+            ("artefact-1".to_string(), "summary".to_string()),
+            ("artefact-2".to_string(), "code".to_string()),
+            ("artefact-2".to_string(), "summary".to_string()),
         ]
     );
 }
@@ -364,7 +372,7 @@ async fn semantic_embedding_loads_summary_map_from_relational_storage() {
             "artefact-2".to_string(),
             "artefact-3".to_string(),
         ],
-        embeddings::EmbeddingRepresentationKind::Baseline,
+        embeddings::EmbeddingRepresentationKind::Code,
     )
     .await
     .expect("load summary map");
@@ -416,8 +424,8 @@ async fn semantic_embedding_sync_action_adopts_existing_single_setup() {
         .expect("insert current artefact");
     relational
         .exec(
-            "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, representation_kind, provider, model, dimension, embedding_input_hash, embedding)
-             VALUES ('artefact-1', 'repo-1', 'blob-1', 'baseline', 'local_fastembed', 'jinaai/jina-embeddings-v2-base-code', 3, 'hash-1', '[0.1,0.2,0.3]')",
+            "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding)
+             VALUES ('artefact-1', 'repo-1', 'blob-1', 'baseline', 'provider=local_fastembed|model=jinaai/jina-embeddings-v2-base-code|dimension=3', 'local_fastembed', 'jinaai/jina-embeddings-v2-base-code', 3, 'hash-1', '[0.1,0.2,0.3]')",
         )
         .await
         .expect("insert embedding row");
@@ -425,7 +433,7 @@ async fn semantic_embedding_sync_action_adopts_existing_single_setup() {
     let action = determine_repo_embedding_sync_action(
         &relational,
         "repo-1",
-        embeddings::EmbeddingRepresentationKind::Baseline,
+        embeddings::EmbeddingRepresentationKind::Code,
         &embeddings::EmbeddingSetup::new(
             "local_fastembed",
             "jinaai/jina-embeddings-v2-base-code",
@@ -445,7 +453,7 @@ async fn semantic_embedding_sync_action_refreshes_when_active_setup_changes() {
         &relational,
         "repo-1",
         &embeddings::ActiveEmbeddingRepresentationState::new(
-            embeddings::EmbeddingRepresentationKind::Baseline,
+            embeddings::EmbeddingRepresentationKind::Code,
             embeddings::EmbeddingSetup::new(
                 "local_fastembed",
                 "jinaai/jina-embeddings-v2-base-code",
@@ -459,7 +467,7 @@ async fn semantic_embedding_sync_action_refreshes_when_active_setup_changes() {
     let action = determine_repo_embedding_sync_action(
         &relational,
         "repo-1",
-        embeddings::EmbeddingRepresentationKind::Baseline,
+        embeddings::EmbeddingRepresentationKind::Code,
         &embeddings::EmbeddingSetup::new("voyage", "voyage-code-3", 1024),
     )
     .await

--- a/bitloops/src/capability_packs/semantic_clones/stage_embeddings_tests.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_embeddings_tests.rs
@@ -239,7 +239,9 @@ fn semantic_embedding_index_state_sql_filters_by_artefact_id() {
     assert!(sql.contains("FROM symbol_embeddings"));
     assert!(sql.contains("WHERE artefact_id = 'artefact-''1'"));
     assert!(sql.contains("representation_kind = 'code'"));
-    assert!(sql.contains("setup_fingerprint = 'provider=voyage|model=voyage-code-3|dimension=1024'"));
+    assert!(
+        sql.contains("setup_fingerprint = 'provider=voyage|model=voyage-code-3|dimension=1024'")
+    );
 }
 
 #[test]

--- a/bitloops/src/cli/embeddings.rs
+++ b/bitloops/src/cli/embeddings.rs
@@ -405,6 +405,7 @@ fn pull_runtime_client_config(
 mod tests {
     use super::*;
     use crate::cli::{Cli, Commands};
+    use crate::test_support::process_state::enter_process_state;
     use clap::Parser;
     use std::fs;
     use std::path::Path;
@@ -727,6 +728,15 @@ request_timeout_secs = 5
     #[test]
     fn inspect_embeddings_install_state_reports_not_configured() {
         let repo = TempDir::new().expect("tempdir");
+        let home = TempDir::new().expect("home dir");
+        let home_path = home.path().to_string_lossy().to_string();
+        let _guard = enter_process_state(
+            Some(repo.path()),
+            &[
+                ("HOME", Some(home_path.as_str())),
+                ("USERPROFILE", Some(home_path.as_str())),
+            ],
+        );
         crate::test_support::git_fixtures::init_test_repo(
             repo.path(),
             "main",

--- a/bitloops/src/cli/embeddings.rs
+++ b/bitloops/src/cli/embeddings.rs
@@ -161,6 +161,9 @@ pub(crate) fn inspect_embeddings_install_state(repo_root: &Path) -> EmbeddingsIn
     let Ok(config_path) = resolve_daemon_config_path_for_repo(repo_root) else {
         return EmbeddingsInstallState::NotConfigured;
     };
+    if !config_path.is_file() {
+        return EmbeddingsInstallState::NotConfigured;
+    }
     let Ok(capability) = embedding_capability_for_config_path(&config_path) else {
         return EmbeddingsInstallState::NotConfigured;
     };

--- a/bitloops/src/daemon/enrichment/execution.rs
+++ b/bitloops/src/daemon/enrichment/execution.rs
@@ -10,10 +10,11 @@ use crate::capability_packs::semantic_clones::extension_descriptor::{
 use crate::capability_packs::semantic_clones::features as semantic_features;
 use crate::capability_packs::semantic_clones::features::SemanticSummaryProviderConfig;
 use crate::capability_packs::semantic_clones::{
-    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup,
-    clear_repo_active_embedding_setup_for_representation,
-    determine_repo_embedding_sync_action, load_semantic_feature_inputs_for_artefacts,
-    load_semantic_summary_snapshot, persist_active_embedding_setup, persist_semantic_summary_row,
+    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup, clear_repo_symbol_embedding_rows,
+    clear_repo_symbol_embedding_rows_for_representation,
+    clear_repo_active_embedding_setup_for_representation, determine_repo_embedding_sync_action,
+    load_semantic_feature_inputs_for_artefacts, load_semantic_summary_snapshot,
+    persist_active_embedding_setup, persist_semantic_summary_row,
     refresh_current_repo_symbol_embeddings_and_clone_edges, upsert_symbol_embedding_rows,
 };
 use crate::config::{
@@ -526,6 +527,7 @@ fn clone_edges_rebuild_follow_up(job: &EnrichmentJob) -> FollowUpJob {
 }
 
 async fn clear_embedding_outputs(relational: &RelationalStorage, repo_id: &str) -> Result<()> {
+    clear_repo_symbol_embedding_rows(relational, repo_id).await?;
     clear_repo_active_embedding_setup(relational, repo_id).await?;
     crate::capability_packs::semantic_clones::pipeline::delete_repo_symbol_clone_edges(
         relational, repo_id,
@@ -538,6 +540,8 @@ async fn clear_embedding_representation(
     repo_id: &str,
     representation_kind: crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind,
 ) -> Result<()> {
+    clear_repo_symbol_embedding_rows_for_representation(relational, repo_id, representation_kind)
+        .await?;
     clear_repo_active_embedding_setup_for_representation(relational, repo_id, representation_kind)
         .await?;
     if representation_kind

--- a/bitloops/src/daemon/enrichment/execution.rs
+++ b/bitloops/src/daemon/enrichment/execution.rs
@@ -10,7 +10,8 @@ use crate::capability_packs::semantic_clones::extension_descriptor::{
 use crate::capability_packs::semantic_clones::features as semantic_features;
 use crate::capability_packs::semantic_clones::features::SemanticSummaryProviderConfig;
 use crate::capability_packs::semantic_clones::{
-    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup, clear_repo_symbol_embedding_rows,
+    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup,
+    clear_repo_active_embedding_setup_for_representation,
     determine_repo_embedding_sync_action, load_semantic_feature_inputs_for_artefacts,
     load_semantic_summary_snapshot, persist_active_embedding_setup, persist_semantic_summary_row,
     refresh_current_repo_symbol_embeddings_and_clone_edges, upsert_symbol_embedding_rows,
@@ -251,7 +252,13 @@ async fn execute_semantic_job(
             job,
             &artefact_ids,
             input_hashes,
-            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Enriched,
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
+        ));
+        outcome.follow_ups.push(symbol_embeddings_follow_up(
+            job,
+            &artefact_ids,
+            input_hashes,
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Summary,
         ));
     }
     outcome
@@ -288,7 +295,13 @@ async fn execute_embedding_job(
         Err(err) => {
             let error = format!("{err:#}");
             evict_cached_embedding_provider(&provider_config, &job.repo_root);
-            return match clear_embedding_outputs(relational, &job.repo_id).await {
+            return match clear_embedding_representation(
+                relational,
+                &job.repo_id,
+                representation_kind,
+            )
+            .await
+            {
                 Ok(()) => JobExecutionOutcome {
                     error: Some(error),
                     follow_ups: Vec::new(),
@@ -298,7 +311,9 @@ async fn execute_embedding_job(
         }
     };
     let Some(provider) = provider else {
-        return match clear_embedding_outputs(relational, &job.repo_id).await {
+        return match clear_embedding_representation(relational, &job.repo_id, representation_kind)
+            .await
+        {
             Ok(()) => JobExecutionOutcome::ok(),
             Err(err) => JobExecutionOutcome::failed(err),
         };
@@ -323,9 +338,6 @@ async fn execute_embedding_job(
     };
 
     if sync_action == RepoEmbeddingSyncAction::RefreshCurrentRepo {
-        if let Err(err) = clear_embedding_outputs(relational, &job.repo_id).await {
-            return JobExecutionOutcome::failed(err);
-        }
         return match refresh_current_repo_symbol_embeddings_and_clone_edges(
             relational,
             &job.repo_root,
@@ -362,6 +374,14 @@ async fn execute_embedding_job(
         Err(err) => return JobExecutionOutcome::failed(err),
     };
     if current_inputs.is_empty() {
+        if sync_action == RepoEmbeddingSyncAction::AdoptExisting
+            && representation_kind
+                == crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code
+        {
+            let mut outcome = JobExecutionOutcome::ok();
+            outcome.follow_ups.push(clone_edges_rebuild_follow_up(job));
+            return outcome;
+        }
         return JobExecutionOutcome::ok();
     }
 
@@ -377,7 +397,13 @@ async fn execute_embedding_job(
         Err(err) => {
             evict_cached_embedding_provider(&provider_config, &job.repo_root);
             let error = format!("{err:#}");
-            return match clear_embedding_outputs(relational, &job.repo_id).await {
+            return match clear_embedding_representation(
+                relational,
+                &job.repo_id,
+                representation_kind,
+            )
+            .await
+            {
                 Ok(()) => JobExecutionOutcome {
                     error: Some(error),
                     follow_ups: Vec::new(),
@@ -404,7 +430,11 @@ async fn execute_embedding_job(
     }
 
     let mut outcome = JobExecutionOutcome::ok();
-    outcome.follow_ups.push(clone_edges_rebuild_follow_up(job));
+    if representation_kind
+        == crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code
+    {
+        outcome.follow_ups.push(clone_edges_rebuild_follow_up(job));
+    }
     outcome
 }
 
@@ -460,12 +490,29 @@ fn clone_edges_rebuild_follow_up(job: &EnrichmentJob) -> FollowUpJob {
 }
 
 async fn clear_embedding_outputs(relational: &RelationalStorage, repo_id: &str) -> Result<()> {
-    clear_repo_symbol_embedding_rows(relational, repo_id).await?;
     clear_repo_active_embedding_setup(relational, repo_id).await?;
     crate::capability_packs::semantic_clones::pipeline::delete_repo_symbol_clone_edges(
         relational, repo_id,
     )
     .await
+}
+
+async fn clear_embedding_representation(
+    relational: &RelationalStorage,
+    repo_id: &str,
+    representation_kind: crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind,
+) -> Result<()> {
+    clear_repo_active_embedding_setup_for_representation(relational, repo_id, representation_kind)
+        .await?;
+    if representation_kind
+        == crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code
+    {
+        crate::capability_packs::semantic_clones::pipeline::delete_repo_symbol_clone_edges(
+            relational, repo_id,
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 fn embeddings_enabled(config_root: &std::path::Path) -> bool {

--- a/bitloops/src/daemon/enrichment/execution.rs
+++ b/bitloops/src/daemon/enrichment/execution.rs
@@ -10,9 +10,9 @@ use crate::capability_packs::semantic_clones::extension_descriptor::{
 use crate::capability_packs::semantic_clones::features as semantic_features;
 use crate::capability_packs::semantic_clones::features::SemanticSummaryProviderConfig;
 use crate::capability_packs::semantic_clones::{
-    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup, clear_repo_symbol_embedding_rows,
-    clear_repo_symbol_embedding_rows_for_representation,
-    clear_repo_active_embedding_setup_for_representation, determine_repo_embedding_sync_action,
+    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup,
+    clear_repo_active_embedding_setup_for_representation, clear_repo_symbol_embedding_rows,
+    clear_repo_symbol_embedding_rows_for_representation, determine_repo_embedding_sync_action,
     load_semantic_feature_inputs_for_artefacts, load_semantic_summary_snapshot,
     persist_active_embedding_setup, persist_semantic_summary_row,
     refresh_current_repo_symbol_embeddings_and_clone_edges, upsert_symbol_embedding_rows,

--- a/bitloops/src/daemon/enrichment/execution_tests.rs
+++ b/bitloops/src/daemon/enrichment/execution_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::capability_packs::semantic_clones::clear_repo_symbol_embedding_rows;
 use crate::capability_packs::semantic_clones::features::NoopSemanticSummaryProvider;
 use crate::capability_packs::semantic_clones::upsert_semantic_feature_rows;
 use crate::config::BITLOOPS_CONFIG_RELATIVE_PATH;
@@ -533,7 +534,7 @@ fn build_embedding_job(
             artefact_ids,
             input_hashes,
             representation_kind:
-                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
         },
     }
 }

--- a/bitloops/src/daemon/enrichment_tests.rs
+++ b/bitloops/src/daemon/enrichment_tests.rs
@@ -107,7 +107,7 @@ fn sample_embedding_job(
             artefact_ids: vec![format!("artefact-{batch_key}")],
             input_hashes: BTreeMap::from([(format!("artefact-{batch_key}"), "hash".to_string())]),
             batch_key: batch_key.to_string(),
-            representation_kind: EmbeddingRepresentationKind::Baseline,
+            representation_kind: EmbeddingRepresentationKind::Code,
         },
     }
 }
@@ -256,7 +256,7 @@ async fn enqueue_symbol_embeddings_splits_large_batches_into_smaller_jobs() {
             sample_target(repo_id),
             inputs,
             input_hashes,
-            EmbeddingRepresentationKind::Baseline,
+            EmbeddingRepresentationKind::Code,
         )
         .await
         .expect("enqueue embedding jobs");

--- a/bitloops/src/host/devql.rs
+++ b/bitloops/src/host/devql.rs
@@ -13,9 +13,8 @@ use crate::capability_packs::semantic_clones::extension_descriptor as semantic_c
 use crate::capability_packs::semantic_clones::features as semantic;
 use crate::capability_packs::semantic_clones::{
     SEMANTIC_CLONES_CAPABILITY_ID, SEMANTIC_CLONES_CLONE_EDGES_REBUILD_INGESTER_ID,
-    clear_repo_symbol_embedding_rows, load_pre_stage_artefacts_for_blob,
-    load_pre_stage_dependencies_for_blob, upsert_semantic_feature_rows,
-    upsert_symbol_embedding_rows,
+    load_pre_stage_artefacts_for_blob, load_pre_stage_dependencies_for_blob,
+    upsert_semantic_feature_rows, upsert_symbol_embedding_rows,
 };
 use crate::config::{
     EventsBackendConfig, RelationalBackendConfig, StoreBackendConfig,

--- a/bitloops/src/host/devql/commands_ingest.rs
+++ b/bitloops/src/host/devql/commands_ingest.rs
@@ -81,12 +81,8 @@ async fn execute_ingest_inner(
             .context("resolving knowledge capability ingester owner")?;
     let capability = resolve_embedding_capability_config_for_repo(&cfg.daemon_config_root);
     let semantic_clones = capability.semantic_clones.clone();
-    let preferred_representation_kind = if semantic_clones.summary_mode == SemanticSummaryMode::Auto
-    {
-        crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Enriched
-    } else {
-        crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline
-    };
+    let preferred_representation_kind =
+        crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code;
     let summary_provider: Arc<dyn semantic::SemanticSummaryProvider> = if enrichment.is_some()
         || semantic_clones.summary_mode == SemanticSummaryMode::Off
     {
@@ -380,31 +376,37 @@ async fn execute_ingest_inner(
                                     enqueue_target.clone(),
                                     semantic_feature_inputs.clone(),
                                     input_hashes.clone(),
-                                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+                                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
+                                )
+                                .await?;
+                            enrichment
+                                .enqueue_symbol_embeddings(
+                                    enqueue_target,
+                                    semantic_feature_inputs.clone(),
+                                    input_hashes.clone(),
+                                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Summary,
                                 )
                                 .await?;
                         }
                     } else if let Some(embedding_provider) = embedding_provider.as_ref() {
-                        let baseline_stats = upsert_symbol_embedding_rows(
+                        let code_stats = upsert_symbol_embedding_rows(
                             &relational,
                             &semantic_feature_inputs,
-                            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+                            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
                             Arc::clone(embedding_provider),
                         )
                         .await?;
-                        counters.symbol_embedding_rows_upserted += baseline_stats.upserted;
-                        counters.symbol_embedding_rows_skipped += baseline_stats.skipped;
-                        if semantic_clones.summary_mode == SemanticSummaryMode::Auto {
-                            let enriched_stats = upsert_symbol_embedding_rows(
-                                &relational,
-                                &semantic_feature_inputs,
-                                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Enriched,
-                                Arc::clone(embedding_provider),
-                            )
-                            .await?;
-                            counters.symbol_embedding_rows_upserted += enriched_stats.upserted;
-                            counters.symbol_embedding_rows_skipped += enriched_stats.skipped;
-                        }
+                        counters.symbol_embedding_rows_upserted += code_stats.upserted;
+                        counters.symbol_embedding_rows_skipped += code_stats.skipped;
+                        let summary_stats = upsert_symbol_embedding_rows(
+                            &relational,
+                            &semantic_feature_inputs,
+                            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Summary,
+                            Arc::clone(embedding_provider),
+                        )
+                        .await?;
+                        counters.symbol_embedding_rows_upserted += summary_stats.upserted;
+                        counters.symbol_embedding_rows_skipped += summary_stats.skipped;
                     }
                     counters.artefacts_upserted += 1;
                     counters.semantic_feature_rows_upserted += semantic_feature_stats.upserted;
@@ -515,7 +517,11 @@ async fn execute_ingest_inner(
     if let Some(enrichment) = enrichment.as_ref()
         && embedding_outputs_enabled
         && counters.artefacts_upserted == 0
-        && load_active_embedding_setup(&relational, &cfg.repo.repo_id)
+        && load_active_embedding_setup(
+            &relational,
+            &cfg.repo.repo_id,
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
+        )
             .await?
             .is_none()
     {
@@ -549,19 +555,17 @@ async fn execute_ingest_inner(
                     enqueue_target.clone(),
                     bootstrap_inputs.clone(),
                     bootstrap_input_hashes.clone(),
-                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
                 )
                 .await?;
-            if semantic_clones.summary_mode == SemanticSummaryMode::Auto {
-                enrichment
-                    .enqueue_symbol_embeddings(
-                        enqueue_target,
-                        bootstrap_inputs,
-                        bootstrap_input_hashes,
-                        crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Enriched,
-                    )
-                    .await?;
-            }
+            enrichment
+                .enqueue_symbol_embeddings(
+                    enqueue_target,
+                    bootstrap_inputs,
+                    bootstrap_input_hashes,
+                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Summary,
+                )
+                .await?;
         }
     }
 
@@ -574,7 +578,6 @@ async fn execute_ingest_inner(
     if let (None, Some(embedding_provider)) = (enrichment.as_ref(), embedding_provider.as_ref()) {
         match direct_embedding_sync_action.unwrap_or(RepoEmbeddingSyncAction::Incremental) {
             RepoEmbeddingSyncAction::RefreshCurrentRepo => {
-                clear_repo_symbol_embedding_rows(&relational, &cfg.repo.repo_id).await?;
                 clear_repo_active_embedding_setup(&relational, &cfg.repo.repo_id).await?;
                 crate::capability_packs::semantic_clones::pipeline::delete_repo_symbol_clone_edges(
                     &relational,
@@ -587,32 +590,30 @@ async fn execute_ingest_inner(
                     &cfg.repo.repo_id,
                 )
                 .await?;
-                let baseline_stats = upsert_symbol_embedding_rows(
+                let code_stats = upsert_symbol_embedding_rows(
                     &relational,
                     &current_inputs,
-                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
                     Arc::clone(embedding_provider),
                 )
                 .await?;
-                counters.symbol_embedding_rows_upserted += baseline_stats.upserted;
-                counters.symbol_embedding_rows_skipped += baseline_stats.skipped;
-                if semantic_clones.summary_mode == SemanticSummaryMode::Auto {
-                    let enriched_stats = upsert_symbol_embedding_rows(
-                        &relational,
-                        &current_inputs,
-                        crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Enriched,
-                        Arc::clone(embedding_provider),
-                    )
-                    .await?;
-                    counters.symbol_embedding_rows_upserted += enriched_stats.upserted;
-                    counters.symbol_embedding_rows_skipped += enriched_stats.skipped;
-                }
+                counters.symbol_embedding_rows_upserted += code_stats.upserted;
+                counters.symbol_embedding_rows_skipped += code_stats.skipped;
+                let summary_stats = upsert_symbol_embedding_rows(
+                    &relational,
+                    &current_inputs,
+                    crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Summary,
+                    Arc::clone(embedding_provider),
+                )
+                .await?;
+                counters.symbol_embedding_rows_upserted += summary_stats.upserted;
+                counters.symbol_embedding_rows_skipped += summary_stats.skipped;
             }
             RepoEmbeddingSyncAction::Incremental | RepoEmbeddingSyncAction::AdoptExisting => {}
         }
 
         if let Some(setup) = resolved_embedding_setup.as_ref() {
-            if let Some(active_state) = select_active_embedding_state_for_repo(
+            if let Some(active_state) = select_active_code_embedding_state_for_repo(
                 &relational,
                 &cfg.repo.repo_id,
                 setup,
@@ -633,7 +634,6 @@ async fn execute_ingest_inner(
             }
         }
     } else if !embedding_outputs_enabled || (enrichment.is_none() && embedding_provider.is_none()) {
-        clear_repo_symbol_embedding_rows(&relational, &cfg.repo.repo_id).await?;
         clear_repo_active_embedding_setup(&relational, &cfg.repo.repo_id).await?;
         crate::capability_packs::semantic_clones::pipeline::delete_repo_symbol_clone_edges(
             &relational,
@@ -672,7 +672,7 @@ async fn execute_ingest_inner(
     }
 }
 
-async fn select_active_embedding_state_for_repo(
+async fn select_active_code_embedding_state_for_repo(
     relational: &RelationalStorage,
     repo_id: &str,
     setup: &embeddings::EmbeddingSetup,
@@ -681,25 +681,13 @@ async fn select_active_embedding_state_for_repo(
         crate::capability_packs::semantic_clones::embeddings::ActiveEmbeddingRepresentationState,
     >,
 > {
-    let states = load_current_repo_embedding_states(relational, repo_id, None).await?;
-    let mut baseline = None;
-    let mut enriched = None;
-
-    for state in states {
-        if state.setup != *setup {
-            continue;
-        }
-        match state.representation_kind {
-            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline => {
-                baseline = Some(state);
-            }
-            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Enriched => {
-                enriched = Some(state);
-            }
-        }
-    }
-
-    Ok(enriched.or(baseline))
+    let states = load_current_repo_embedding_states(
+        relational,
+        repo_id,
+        Some(crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code),
+    )
+    .await?;
+    Ok(states.into_iter().find(|state| state.setup == *setup))
 }
 
 async fn rebuild_active_clone_edges(

--- a/bitloops/src/host/devql/commands_ingest.rs
+++ b/bitloops/src/host/devql/commands_ingest.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::capability_packs::semantic_clones::{
-    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup,
+    RepoEmbeddingSyncAction, clear_repo_active_embedding_setup, clear_repo_symbol_embedding_rows,
     determine_repo_embedding_sync_action, load_active_embedding_setup,
     load_current_repo_embedding_states, load_semantic_feature_inputs_for_current_repo,
     persist_active_embedding_setup,
@@ -578,6 +578,7 @@ async fn execute_ingest_inner(
     if let (None, Some(embedding_provider)) = (enrichment.as_ref(), embedding_provider.as_ref()) {
         match direct_embedding_sync_action.unwrap_or(RepoEmbeddingSyncAction::Incremental) {
             RepoEmbeddingSyncAction::RefreshCurrentRepo => {
+                clear_repo_symbol_embedding_rows(&relational, &cfg.repo.repo_id).await?;
                 clear_repo_active_embedding_setup(&relational, &cfg.repo.repo_id).await?;
                 crate::capability_packs::semantic_clones::pipeline::delete_repo_symbol_clone_edges(
                     &relational,
@@ -642,6 +643,7 @@ async fn execute_ingest_inner(
             }
         }
     } else if !embedding_outputs_enabled || (enrichment.is_none() && embedding_provider.is_none()) {
+        clear_repo_symbol_embedding_rows(&relational, &cfg.repo.repo_id).await?;
         clear_repo_active_embedding_setup(&relational, &cfg.repo.repo_id).await?;
         crate::capability_packs::semantic_clones::pipeline::delete_repo_symbol_clone_edges(
             &relational,
@@ -692,7 +694,9 @@ async fn select_active_code_embedding_state_for_repo(
     let states = load_current_repo_embedding_states(
         relational,
         repo_id,
-        Some(crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code),
+        Some(
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
+        ),
     )
     .await?;
     Ok(states.into_iter().find(|state| state.setup == *setup))

--- a/bitloops/src/host/devql/sync/semantic_projector.rs
+++ b/bitloops/src/host/devql/sync/semantic_projector.rs
@@ -75,7 +75,7 @@ pub(crate) async fn project_path(
             &desired.path,
             &desired.effective_content_id,
             &inputs,
-            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
             Arc::clone(&embedding_provider),
         )
         .await?;
@@ -84,7 +84,7 @@ pub(crate) async fn project_path(
             &desired.path,
             &desired.effective_content_id,
             &inputs,
-            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Enriched,
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Summary,
             embedding_provider,
         )
         .await?;

--- a/bitloops/src/host/devql/tests/cucumber_steps/core.rs
+++ b/bitloops/src/host/devql/tests/cucumber_steps/core.rs
@@ -287,26 +287,31 @@ fn build_fixture_embedding_provider(
     summary_by_artefact_id: &HashMap<String, String>,
     embeddings_by_artefact_id: &HashMap<String, Vec<f32>>,
 ) -> Result<Arc<dyn EmbeddingProvider>> {
-    let embedding_inputs = semantic_embeddings::build_symbol_embedding_inputs(
-        inputs,
+    let mut embeddings_by_document = HashMap::new();
+    for representation_kind in [
         semantic_embeddings::EmbeddingRepresentationKind::Code,
-        summary_by_artefact_id,
-    );
-    let mut embeddings_by_document = HashMap::with_capacity(embedding_inputs.len());
-    for input in embedding_inputs {
-        let embedding = embeddings_by_artefact_id
-            .get(&input.artefact_id)
-            .cloned()
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "fixture embedding not configured for artefact `{}`",
-                    input.artefact_id
-                )
-            })?;
-        embeddings_by_document.insert(
-            semantic_embeddings::build_symbol_embedding_text(&input),
-            embedding,
+        semantic_embeddings::EmbeddingRepresentationKind::Summary,
+    ] {
+        let embedding_inputs = semantic_embeddings::build_symbol_embedding_inputs(
+            inputs,
+            representation_kind,
+            summary_by_artefact_id,
         );
+        for input in embedding_inputs {
+            let embedding = embeddings_by_artefact_id
+                .get(&input.artefact_id)
+                .cloned()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "fixture embedding not configured for artefact `{}`",
+                        input.artefact_id
+                    )
+                })?;
+            embeddings_by_document.insert(
+                semantic_embeddings::build_symbol_embedding_text(&input),
+                embedding,
+            );
+        }
     }
     Ok(Arc::new(FixtureEmbeddingProvider {
         embeddings_by_document,
@@ -2518,15 +2523,14 @@ fn when_semantic_clone_incremental_indexing_runs_across_two_snapshots(
             &initial_embeddings_by_artefact_id,
         )
         .expect("build snapshot one fixture embedding provider");
-        let initial_stage2_stats =
-            upsert_symbol_embedding_rows(
-                &relational,
-                &initial_inputs,
-                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
-                initial_embedding_provider,
-            )
-            .await
-            .expect("run stage 2 for incremental snapshot one");
+        let initial_stage2_stats = upsert_symbol_embedding_rows(
+            &relational,
+            &initial_inputs,
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
+            initial_embedding_provider,
+        )
+        .await
+        .expect("run stage 2 for incremental snapshot one");
         assert_eq!(
             initial_stage2_stats.upserted,
             snapshot_one.len(),
@@ -2580,15 +2584,14 @@ fn when_semantic_clone_incremental_indexing_runs_across_two_snapshots(
             &updated_embeddings_by_artefact_id,
         )
         .expect("build snapshot two fixture embedding provider");
-        let stage2_stats =
-            upsert_symbol_embedding_rows(
-                &relational,
-                &updated_inputs,
-                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
-                updated_embedding_provider,
-            )
-            .await
-            .expect("run stage 2 for incremental snapshot two");
+        let stage2_stats = upsert_symbol_embedding_rows(
+            &relational,
+            &updated_inputs,
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
+            updated_embedding_provider,
+        )
+        .await
+        .expect("run stage 2 for incremental snapshot two");
         rebuild_symbol_clone_edges(&relational, &repo_id)
             .await
             .expect("rebuild clone edges for snapshot two");

--- a/bitloops/src/host/devql/tests/cucumber_steps/core.rs
+++ b/bitloops/src/host/devql/tests/cucumber_steps/core.rs
@@ -251,7 +251,7 @@ async fn load_persisted_summary_map(
         .join(", ");
     let rows = relational
         .query_rows(&format!(
-            "SELECT artefact_id, template_summary, docstring_summary \
+            "SELECT artefact_id, template_summary, docstring_summary, llm_summary, summary, source_model \
              FROM symbol_semantics \
              WHERE artefact_id IN ({ids_sql})"
         ))
@@ -274,10 +274,29 @@ async fn load_persisted_summary_map(
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty());
-        summaries.insert(
-            artefact_id.to_string(),
-            semantic::synthesize_deterministic_summary(template_summary, docstring_summary),
-        );
+        let canonical_summary = row
+            .get("summary")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let llm_summary = row
+            .get("llm_summary")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let has_llm_enrichment = llm_summary.is_some()
+            || row
+                .get("source_model")
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty());
+        let summary = if has_llm_enrichment {
+            canonical_summary.map(str::to_string).unwrap_or_else(|| {
+                semantic::synthesize_deterministic_summary(template_summary, docstring_summary)
+            })
+        } else {
+            semantic::synthesize_deterministic_summary(template_summary, docstring_summary)
+        };
+        summaries.insert(artefact_id.to_string(), summary);
     }
     Ok(summaries)
 }

--- a/bitloops/src/host/devql/tests/cucumber_steps/core.rs
+++ b/bitloops/src/host/devql/tests/cucumber_steps/core.rs
@@ -289,7 +289,7 @@ fn build_fixture_embedding_provider(
 ) -> Result<Arc<dyn EmbeddingProvider>> {
     let embedding_inputs = semantic_embeddings::build_symbol_embedding_inputs(
         inputs,
-        semantic_embeddings::EmbeddingRepresentationKind::Baseline,
+        semantic_embeddings::EmbeddingRepresentationKind::Code,
         summary_by_artefact_id,
     );
     let mut embeddings_by_document = HashMap::with_capacity(embedding_inputs.len());
@@ -1226,7 +1226,7 @@ async fn build_prepared_real_clone_fixture_db(
     upsert_symbol_embedding_rows(
         &relational,
         &all_semantic_inputs,
-        crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+        crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
         embedding_provider,
     )
     .await
@@ -2522,7 +2522,7 @@ fn when_semantic_clone_incremental_indexing_runs_across_two_snapshots(
             upsert_symbol_embedding_rows(
                 &relational,
                 &initial_inputs,
-                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
                 initial_embedding_provider,
             )
             .await
@@ -2584,7 +2584,7 @@ fn when_semantic_clone_incremental_indexing_runs_across_two_snapshots(
             upsert_symbol_embedding_rows(
                 &relational,
                 &updated_inputs,
-                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Baseline,
+                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
                 updated_embedding_provider,
             )
             .await

--- a/bitloops/src/host/devql/tests/devql_tests/clones.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/clones.rs
@@ -365,14 +365,20 @@ async fn execute_relational_pipeline_reads_clones_from_sqlite_relational_store()
     .expect("insert target features");
 
     conn.execute(
-        "INSERT INTO symbol_embeddings_current (artefact_id, repo_id, path, content_id, symbol_id, provider, model, dimension, embedding_input_hash, embedding)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        "INSERT INTO symbol_embeddings_current (artefact_id, repo_id, path, content_id, symbol_id, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'code', ?6, ?7, ?8, ?9, ?10, ?11)",
         rusqlite::params![
             "artefact::invoice_pdf",
             repo_id,
             "src/pdf.ts",
             "blob-1",
             "sym::invoice_pdf",
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingSetup::new(
+                "local",
+                "jinaai/jina-embeddings-v2-base-code",
+                3,
+            )
+            .setup_fingerprint,
             "local",
             "jinaai/jina-embeddings-v2-base-code",
             3,
@@ -382,14 +388,20 @@ async fn execute_relational_pipeline_reads_clones_from_sqlite_relational_store()
     )
     .expect("insert source embedding");
     conn.execute(
-        "INSERT INTO symbol_embeddings_current (artefact_id, repo_id, path, content_id, symbol_id, provider, model, dimension, embedding_input_hash, embedding)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        "INSERT INTO symbol_embeddings_current (artefact_id, repo_id, path, content_id, symbol_id, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'code', ?6, ?7, ?8, ?9, ?10, ?11)",
         rusqlite::params![
             "artefact::invoice_doc",
             repo_id,
             "src/render.ts",
             "blob-2",
             "sym::invoice_doc",
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingSetup::new(
+                "local",
+                "jinaai/jina-embeddings-v2-base-code",
+                3,
+            )
+            .setup_fingerprint,
             "local",
             "jinaai/jina-embeddings-v2-base-code",
             3,
@@ -594,6 +606,13 @@ fn insert_clone_candidate_fixture(
     dimension: i64,
     embedding: &str,
 ) {
+    let setup_fingerprint =
+        crate::capability_packs::semantic_clones::embeddings::EmbeddingSetup::new(
+            provider,
+            model,
+            dimension as usize,
+        )
+        .setup_fingerprint;
     conn.execute(
         "INSERT INTO artefacts (artefact_id, symbol_id, repo_id, blob_sha, path, language, canonical_kind, language_kind, symbol_fqn, parent_artefact_id, start_line, end_line, start_byte, end_byte, signature, modifiers, content_hash)
          VALUES (?1, ?2, ?3, ?4, ?5, 'typescript', 'function', 'function_declaration', ?6, NULL, 1, 12, 0, 120, ?7, '[]', ?8)",
@@ -657,12 +676,13 @@ fn insert_clone_candidate_fixture(
     .expect("insert features");
 
     conn.execute(
-        "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, provider, model, dimension, embedding_input_hash, embedding)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        "INSERT INTO symbol_embeddings (artefact_id, repo_id, blob_sha, representation_kind, setup_fingerprint, provider, model, dimension, embedding_input_hash, embedding)
+         VALUES (?1, ?2, ?3, 'code', ?4, ?5, ?6, ?7, ?8, ?9)",
         rusqlite::params![
             artefact_id,
             repo_id,
             format!("blob-{symbol_id}"),
+            setup_fingerprint,
             provider,
             model,
             dimension,

--- a/bitloops/src/host/devql/tests/devql_tests/semantic.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/semantic.rs
@@ -398,6 +398,7 @@ duckdb_path = ".bitloops/stores/events.duckdb"
 struct CurrentEmbeddingRow {
     symbol_fqn: String,
     path: String,
+    representation_kind: String,
     provider: String,
     model: String,
     dimension: i64,
@@ -408,21 +409,22 @@ fn load_current_embedding_rows(sqlite_path: &Path, repo_id: &str) -> Vec<Current
     let conn = rusqlite::Connection::open(sqlite_path).expect("open sqlite db");
     let mut stmt = conn
         .prepare(
-            "SELECT a.symbol_fqn, a.path, e.provider, e.model, e.dimension, e.embedding_input_hash
+            "SELECT a.symbol_fqn, a.path, e.representation_kind, e.provider, e.model, e.dimension, e.embedding_input_hash
              FROM artefacts_current a
              JOIN symbol_embeddings e ON e.artefact_id = a.artefact_id
              WHERE a.repo_id = ?1
-             ORDER BY a.path, a.start_line, a.symbol_fqn",
+             ORDER BY a.path, a.start_line, a.symbol_fqn, e.representation_kind",
         )
         .expect("prepare current embeddings query");
     stmt.query_map([repo_id], |row| {
         Ok(CurrentEmbeddingRow {
             symbol_fqn: row.get(0)?,
             path: row.get(1)?,
-            provider: row.get(2)?,
-            model: row.get(3)?,
-            dimension: row.get(4)?,
-            embedding_input_hash: row.get(5)?,
+            representation_kind: row.get(2)?,
+            provider: row.get(3)?,
+            model: row.get(4)?,
+            dimension: row.get(5)?,
+            embedding_input_hash: row.get(6)?,
         })
     })
     .expect("query current embeddings")
@@ -474,8 +476,16 @@ fn load_clone_edge_count(sqlite_path: &Path, repo_id: &str) -> i64 {
 
 fn hash_by_symbol(rows: &[CurrentEmbeddingRow]) -> BTreeMap<String, String> {
     rows.iter()
+        .filter(|row| is_code_embedding_row(row))
         .map(|row| (row.symbol_fqn.clone(), row.embedding_input_hash.clone()))
         .collect()
+}
+
+fn is_code_embedding_row(row: &CurrentEmbeddingRow) -> bool {
+    matches!(
+        row.representation_kind.as_str(),
+        "code" | "baseline" | "enriched"
+    )
 }
 
 async fn run_direct_ingest_with_env(
@@ -692,14 +702,14 @@ async fn direct_ingest_does_not_refresh_on_profile_rename_with_same_runtime_desc
     );
 
     let mut unchanged_symbol_count = 0usize;
-    for row in &second_rows {
+    for row in second_rows.iter().filter(|row| is_code_embedding_row(row)) {
         let first_hash = first_hashes
             .get(&row.symbol_fqn)
             .expect("symbol present after profile rename");
         assert_eq!(&row.embedding_input_hash, first_hash);
         unchanged_symbol_count += 1;
     }
-    assert_eq!(unchanged_symbol_count, second_rows.len());
+    assert_eq!(unchanged_symbol_count, first_hashes.len());
     assert_eq!(
         second_hashes
             .get("src/invoice.ts")

--- a/bitloops/src/host/devql/tests/sync_tests/execute_sync_modes.rs
+++ b/bitloops/src/host/devql/tests/sync_tests/execute_sync_modes.rs
@@ -651,7 +651,7 @@ async fn sync_populates_current_semantic_and_embedding_tables() {
         .expect("count symbol_features_current rows");
     let embedding_rows: i64 = db
         .query_row(
-            "SELECT COUNT(*) FROM symbol_embeddings_current WHERE repo_id = ?1 AND representation_kind = 'baseline'",
+            "SELECT COUNT(*) FROM symbol_embeddings_current WHERE repo_id = ?1 AND representation_kind = 'code'",
             [cfg.repo.repo_id.as_str()],
             |row| row.get(0),
         )
@@ -668,6 +668,6 @@ async fn sync_populates_current_semantic_and_embedding_tables() {
     );
     assert!(
         embedding_rows > 0,
-        "current baseline embeddings should be populated"
+        "current code embeddings should be populated"
     );
 }


### PR DESCRIPTION
## Summary

This PR adds dual embedding representations for semantic-clone ingestion by storing both:

- `code` embeddings, built from code-centric symbol content
- `summary` embeddings, built from the persisted semantic summary of the symbol

The goal is to preserve implementation-level similarity while also capturing higher-level behavioral intent, so we can support richer retrieval and clone-analysis workflows without losing the current code-based clone pipeline.

## Why

A single summary-only embedding path is too lossy for clone analysis.

- `code` embeddings are better at capturing implementation and structural similarity
- `summary` embeddings are better at capturing intent and behavior similarity

This PR introduces both representations into the pipeline so we can persist and reason about both views of the same symbol.

## What Changed

### Dual embedding representations

- Added explicit embedding representation kinds: `code` and `summary`
- Built embedding input/text generation around the selected representation
- Kept embedding hashing/setup tracking representation-aware

### Storage and schema updates

- Added `representation_kind` to embedding storage
- Updated embedding primary keys and indexes to be representation-aware
- Updated active embedding setup state to track the active setup per representation
- Added migration/backfill support for legacy embedding rows

### Ingestion and sync

- DevQL sync now projects both `code` and `summary` embeddings
- Direct ingest and daemon enrichment flows now manage representation-aware embedding refresh/adopt/incremental behavior
- Bootstrap/enrichment queue paths enqueue both embedding representations
- Refresh/cleanup logic clears stale rows correctly when setup changes

### Clone pipeline behavior

- Clone rebuilds continue to use the active `code` embedding setup
- Summary embeddings are persisted and kept current, but are not yet used as a second scoring/search channel in clone ranking

### Test and fixture updates

- Updated semantic-clone fixtures and test helpers to support dual embedding rows
- Fixed direct-ingest tests for representation-aware hashing/setup behavior
- Updated sync/clone assertions to use `code` instead of legacy `baseline` naming where appropriate

## Current Scope

This PR lays the foundation for multi-view retrieval, but it does **not** yet implement joint clone scoring across both embedding spaces.

Current behavior is:

- persist `code` embeddings
- persist `summary` embeddings
- use `code` embeddings as the active source for clone rebuild/query behavior

That means this change is primarily an indexing/storage/pipeline foundation for future:
- high-code / low-summary comparisons
- low-code / high-summary comparisons
- combined clone / utility-extraction ranking

## Testing

- `cargo dev-fmt`
- `cargo dev-fmt-check`
- `cargo dev-clippy`
- `cargo dev-test-fast`
- `cargo dev-loop`

Focused verification also covered:
- representation-aware direct ingest behavior
- semantic clone cucumber/BDD scenarios
- embedding install-state and fixture/provider regressions


## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

