### PR TITLE
Fix ci release binary path and test failures

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,12 +27,12 @@ dev-coverage-compare = "run --quiet --package xtask -- coverage compare --lines 
 dev-coverage-html = "llvm-cov --manifest-path bitloops/Cargo.toml --workspace --all-targets --features slow-tests --no-default-features --html --output-dir bitloops/target/llvm-cov-html"
 
 # QAT aliases from workspace root.
-qat = "test --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance -- --exact qat --ignored"
-qat-smoke = "test --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance qat_smoke -- --ignored --exact"
-qat-devql-capabilities = "test --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance qat_devql_capabilities -- --ignored --exact"
-qat-devql-sync = "test --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance qat_devql_sync -- --ignored --exact"
-qat-onboarding = "test --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance qat_onboarding -- --ignored --exact"
-qat-devql-ingest = "test --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance qat_devql_ingest -- --ignored --exact"
+qat = "nextest run --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance --run-ignored only -- qat --exact"
+qat-smoke = "nextest run --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance --run-ignored only -- qat_smoke --exact"
+qat-devql-capabilities = "nextest run --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_capabilities --exact"
+qat-devql-sync = "nextest run --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_sync --exact"
+qat-onboarding = "nextest run --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance --run-ignored only -- qat_onboarding --exact"
+qat-devql-ingest = "nextest run --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_ingest --exact"
 
 # Explicit bundled-DuckDB aliases for release/offline/exotic targets.
 dev-check-bundled = "check --manifest-path bitloops/Cargo.toml --features duckdb-bundled"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,30 @@
+[profile.default]
+fail-fast = false
+test-threads = 8
+
+[[profile.default.overrides]]
+filter = 'binary(=production_seed) or binary(=graphql_smoke) or binary(=graphql) or binary(=performance) or binary(=testlens_gherkin) or binary(=testlens_sqlite_acceptance) or binary(=agent_cli_smoke) or binary(=claude_git_hooks_integration) or binary(=checkpoint_rewind_smoke) or binary(=copilot_integration) or binary(=cursor_e2e_scenarios) or binary(=dashboard_bundle_lifecycle_e2e) or binary(=e2e_scenario_groups)'
+test-group = 'env-mutating'
+
+[[profile.default.overrides]]
+filter = 'binary(=qat_acceptance)'
+test-group = 'qat'
+
+[profile.ci]
+fail-fast = false
+test-threads = 6
+
+[profile.ci.junit]
+path = "junit.xml"
+
+[[profile.ci.overrides]]
+filter = 'binary(=production_seed) or binary(=graphql_smoke) or binary(=graphql) or binary(=performance) or binary(=testlens_gherkin) or binary(=testlens_sqlite_acceptance) or binary(=agent_cli_smoke) or binary(=claude_git_hooks_integration) or binary(=checkpoint_rewind_smoke) or binary(=copilot_integration) or binary(=cursor_e2e_scenarios) or binary(=dashboard_bundle_lifecycle_e2e) or binary(=e2e_scenario_groups)'
+test-group = 'env-mutating'
+
+[[profile.ci.overrides]]
+filter = 'binary(=qat_acceptance)'
+test-group = 'qat'
+
+[test-groups]
+env-mutating = { max-threads = 1 }
+qat = { max-threads = 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Compile test targets
-        run: cargo test --manifest-path bitloops/Cargo.toml --no-default-features
+        run: cargo test -p bitloops --no-default-features
 
   test-full:
     name: Full test suite
@@ -124,31 +124,31 @@ jobs:
         if: ${{ contains(matrix.target, 'unknown-linux-musl') }}
         env:
           DUCKDB_DOWNLOAD_LIB: '0'
-        run: cross build --release --manifest-path bitloops/Cargo.toml --target ${{ matrix.target }} --features duckdb-bundled
+        run: cross build --release -p bitloops --target ${{ matrix.target }} --features duckdb-bundled
 
       - name: Build (non-musl targets)
         if: ${{ !contains(matrix.target, 'unknown-linux-musl') }}
-        run: cargo build --release --manifest-path bitloops/Cargo.toml --target ${{ matrix.target }}
+        run: cargo build --release -p bitloops --target ${{ matrix.target }}
 
       - name: Smoke test (Unix)
         if: runner.os != 'Windows' && matrix.target != 'aarch64-unknown-linux-musl'
-        run: ./bitloops/target/${{ matrix.target }}/release/bitloops --version
+        run: ./target/${{ matrix.target }}/release/bitloops --version
 
       - name: Smoke test (Linux arm64 via qemu)
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: qemu-aarch64 ./bitloops/target/${{ matrix.target }}/release/bitloops --version
+        run: qemu-aarch64 ./target/${{ matrix.target }}/release/bitloops --version
 
       - name: Smoke test (Windows)
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
         run: |
-          & "bitloops/target/${{ matrix.target }}/release/bitloops.exe" --version
+          & "target/${{ matrix.target }}/release/bitloops.exe" --version
 
       - name: Validate Windows arm64 build output
         if: matrix.target == 'aarch64-pc-windows-msvc'
         shell: pwsh
         run: |
-          $path = "bitloops/target/${{ matrix.target }}/release/bitloops.exe"
+          $path = "target/${{ matrix.target }}/release/bitloops.exe"
           if (-not (Test-Path $path)) {
             throw "Missing expected binary: $path"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -51,9 +52,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - name: Compile test targets
-        run: cargo test -p bitloops --no-default-features
+        run: cargo nextest run -p bitloops --no-default-features --profile ci --no-run
 
   test-full:
     name: Full test suite
@@ -64,6 +66,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -25,7 +25,6 @@ permissions:
 
 env:
   DUCKDB_DOWNLOAD_LIB: '1'
-  BITLOOPS_TEST_THREADS: '6'
 
 jobs:
   rust-file-size:
@@ -74,6 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
@@ -89,6 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
@@ -104,6 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target

--- a/.github/workflows/develop-coverage-baseline.yml
+++ b/.github/workflows/develop-coverage-baseline.yml
@@ -21,6 +21,8 @@ jobs:
   publish-coverage-baseline:
     name: Publish coverage baseline metadata
     runs-on: self-hosted
+    env:
+      BITLOOPS_ACTIONS_VARIABLES_TOKEN: ${{ secrets.BITLOOPS_ACTIONS_VARIABLES_TOKEN }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -53,7 +55,7 @@ jobs:
           echo "lines=$lines" >> "$GITHUB_OUTPUT"
           echo "functions=$functions" >> "$GITHUB_OUTPUT"
       - name: Validate variables write token
-        if: ${{ secrets.BITLOOPS_ACTIONS_VARIABLES_TOKEN == '' }}
+        if: ${{ env.BITLOOPS_ACTIONS_VARIABLES_TOKEN == '' }}
         run: |
           echo "::error::Missing secret BITLOOPS_ACTIONS_VARIABLES_TOKEN. Configure a fine-grained PAT or GitHub App installation token with repository Variables: write access."
           exit 1
@@ -63,7 +65,7 @@ jobs:
           LINES: ${{ steps.metrics.outputs.lines }}
           FUNCTIONS: ${{ steps.metrics.outputs.functions }}
         with:
-          github-token: ${{ secrets.BITLOOPS_ACTIONS_VARIABLES_TOKEN }}
+          github-token: ${{ env.BITLOOPS_ACTIONS_VARIABLES_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/develop-qat.yml
+++ b/.github/workflows/develop-qat.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- **Testing Migrated to nextest**: moved from cargo test to cargo nextest for faster and more targeted testing
 - **Breaking — semantic inference configuration is now slot-based**: replaced legacy `[semantic]`, `[embeddings]`, and `semantic_clones.{summary_profile, embedding_profile}` configuration with unified `[inference]` runtimes/profiles plus `[semantic_clones.inference]` slot bindings. Production runtime selection now belongs entirely to the host layer.
 - **Semantic-clone enrichment now runs through the capability host**: DevQL ingest, current-state sync projection, semantic-clone health checks, and daemon enrichment now resolve slot-scoped host inference/config surfaces and execute semantic summary refresh, symbol embedding refresh, and clone-edge rebuild via `DevqlCapabilityHost` ingesters instead of constructing semantic-clone providers directly in host and daemon runtime paths.
 - **Inference and embeddings documentation refreshed**: updated the changelog-adjacent docs, configuration reference, CLI reference, DevQL guidance, storage guidance, quick-start material, and `RUN.md` examples so they describe the unified `[inference]` configuration model, `semantic_clones.inference` slot bindings, and the standalone `bitloops-embeddings` IPC runtime.

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,15 @@
 
 Run commands from the repository root.
 
+Install `cargo-nextest` before using the test lanes. On macOS, prefer:
+
+```bash
+brew install cargo-nextest
+```
+
+For other platforms, follow the official installation guide:
+[https://nexte.st/docs/installation/](https://nexte.st/docs/installation/)
+
 ## Default commands (Cargo aliases)
 
 | Goal                                             | Command                      |
@@ -29,12 +38,12 @@ Run commands from the repository root.
 
 `cargo dev-loop` runs: `fmt` (write fixes) -> `clippy` -> fast tests -> file-size check.
 `cargo dev-test-fast` is the default local feedback loop.
-The checked-in default fast-lane concurrency is `8` test threads.
-CI is pinned to `BITLOOPS_TEST_THREADS=6`.
+`cargo-nextest` is the default runner behind `dev-test-*`, `test-*`, and `qat*`.
+The checked-in local `nextest` default is `8` test threads.
+CI uses the `ci` `nextest` profile, pinned to `6` test threads.
 `cargo dev-test-merge` runs the fast lane plus a curated set of slow smoke suites and is the blocking gate for pull requests into `develop`.
 `cargo dev-test-slow` runs all slow targets only.
 `cargo dev-test-full` runs fast + slow and is used for post-merge verification on `develop` and pull requests into `main`.
-`dev-test-*` aliases run with terse test output (`.` style) by default.
 On macOS, `dev-test-*` and `dev-install` automatically sign produced binaries to reduce repeated policy validation overhead (`syspolicyd`).
 `cargo qat` runs onboarding and DevQL sync in parallel, then smoke, then the DevQL capabilities suite.
 `cargo qat-devql-capabilities` is the focused DevQL capabilities alias.
@@ -42,7 +51,7 @@ On macOS, `dev-test-*` and `dev-install` automatically sign produced binaries to
 
 ### Fast-lane thread tuning
 
-- Override the local default with `BITLOOPS_TEST_THREADS=<n> cargo dev-test-fast`.
+- Override the local fast-lane default with `BITLOOPS_TEST_THREADS=<n> cargo dev-test-fast`.
 - For a persistent per-machine override, export `BITLOOPS_TEST_THREADS` from your shell profile, for example `~/.zshrc`.
 - Recommended starting points:
   - Apple Silicon laptops with more headroom: try `8` to `10`
@@ -123,6 +132,8 @@ The `postgres-tests` Cargo feature is **not** enabled by `slow-tests`, `dev-test
 ```bash
 cargo test -p bitloops --lib --no-default-features --features postgres-tests
 ```
+
+If the repo gains doctests in future, keep running those through `cargo test --doc`; `cargo-nextest` does not support doctests.
 
 ## Checklist before opening a PR
 

--- a/bitloops/.cargo/config.toml
+++ b/bitloops/.cargo/config.toml
@@ -33,18 +33,17 @@ dev-check-bundled = "check --features duckdb-bundled"
 dev-build-bundled = "build --features duckdb-bundled"
 
 # Back-compat aliases (kept while docs and local usage migrate to `dev-*`).
-test-all = "test --no-fail-fast --no-default-features"
-test-core = "test --lib --no-fail-fast --no-default-features"
-test-cli = "test --bin bitloops --no-fail-fast --no-default-features"
-test-integration = "test --tests --no-fail-fast --no-default-features"
+test-all = "nextest run --no-fail-fast --no-default-features"
+test-core = "nextest run --lib --no-fail-fast --no-default-features"
+test-cli = "nextest run --bin bitloops --no-fail-fast --no-default-features"
+test-integration = "nextest run --tests --no-fail-fast --no-default-features"
 test-coverage = "llvm-cov --workspace --all-targets --features slow-tests --no-default-features --html --output-dir target/llvm-cov-html"
 test-coverage-lcov = "llvm-cov --workspace --all-targets --features slow-tests --no-default-features --lcov --output-path target/llvm-cov.info"
 
 # QAT aliases
-qat = "test --features qat-tests --test qat_acceptance -- --exact qat --ignored"
-qat-smoke = "test --features qat-tests --test qat_acceptance qat_smoke -- --ignored --exact"
-qat-devql-sync = "test --features qat-tests --test qat_acceptance qat_devql_sync -- --ignored --exact"
-qat-onboarding = "test --features qat-tests --test qat_acceptance qat_onboarding -- --ignored --exact"
-qat-devql-capabilities = "test --features qat-tests --test qat_acceptance qat_devql_capabilities -- --ignored --exact"
-qat-devql-ingest = "test --features qat-tests --test qat_acceptance qat_devql_ingest -- --ignored --exact"
-
+qat = "nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat --exact"
+qat-smoke = "nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_smoke --exact"
+qat-devql-sync = "nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_sync --exact"
+qat-onboarding = "nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_onboarding --exact"
+qat-devql-capabilities = "nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_capabilities --exact"
+qat-devql-ingest = "nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_ingest --exact"

--- a/bitloops/qat/README.md
+++ b/bitloops/qat/README.md
@@ -2,13 +2,13 @@
 
 This document explains how to run Bitloops QAT (Cucumber) journeys and how to inspect artifacts.
 
-QAT runs as a standard Cargo integration test. The production binary no longer exposes a
+QAT runs as a standard Rust integration test target, executed via `cargo-nextest`. The production binary no longer exposes a
 `qat` subcommand, and the repo aliases enable the dedicated `qat-tests` feature automatically.
 
 ## Where to run from
 
 All commands below assume you are at the repository root.
-The explicit `cargo test` forms also work from the `bitloops/` crate directory when you keep the `--manifest-path bitloops/Cargo.toml` flag.
+The explicit `cargo nextest run` forms also work from the `bitloops/` crate directory when you keep the `--manifest-path bitloops/Cargo.toml` flag.
 
 ## Implemented test suites
 
@@ -41,7 +41,7 @@ cargo qat-smoke
 Or equivalently:
 
 ```bash
-cargo test --features qat-tests --test qat_acceptance qat_smoke -- --ignored
+cargo nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_smoke --exact
 ```
 
 **Scenarios:**
@@ -66,7 +66,7 @@ cargo qat-onboarding
 Or equivalently:
 
 ```bash
-cargo test --features qat-tests --test qat_acceptance qat_onboarding -- --ignored
+cargo nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_onboarding --exact
 ```
 
 **Scenarios:**
@@ -100,7 +100,7 @@ cargo qat-devql-sync
 Or equivalently:
 
 ```bash
-cargo test --features qat-tests --test qat_acceptance qat_devql_sync -- --ignored
+cargo nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_sync --exact
 ```
 
 **Scenarios:**
@@ -123,7 +123,7 @@ cargo test --features qat-tests --test qat_acceptance qat_devql_sync -- --ignore
 | 14  | Init sync=true — incremental sync for new files    | `SyncInitSyncTrueIncremental`   |
 | 15  | Init sync=true — validation stays clean            | `SyncInitSyncTrueValidateClean` |
 
-### 4. DevQL capabilities (`cargo qat-devql`, 18 scenarios)
+### 4. DevQL capabilities (`cargo qat-devql-capabilities`, 18 scenarios)
 
 Exercises the strict offline DevQL capability surface: agent queryability,
 checkpoint and chat-history retrieval, artefact-scoped dependency blast radius,
@@ -131,13 +131,13 @@ artefact-scoped TestHarness proof-map queries, deterministic semantic clones,
 knowledge rejection handling, and one final integrated cross-capability smoke.
 
 ```bash
-cargo qat-devql
+cargo qat-devql-capabilities
 ```
 
 Or equivalently:
 
 ```bash
-cargo test --features qat-tests --test qat_acceptance qat_devql -- --ignored
+cargo nextest run --features qat-tests --test qat_acceptance --run-ignored only -- qat_devql_capabilities --exact
 ```
 
 **Scenarios:**

--- a/bitloops/qat/features/devql/agent_enablement_queryable.feature
+++ b/bitloops/qat/features/devql/agent_enablement_queryable.feature
@@ -32,5 +32,4 @@ Feature: Agent enablement produces a queryable repository
     And I make a first change using Claude Code to bitloops
     And I committed today in bitloops
     And I run DevQL init in bitloops
-    And I run DevQL ingest in bitloops
     Then DevQL chatHistory query returns results in bitloops

--- a/bitloops/qat/features/devql/cross_capability_smoke.feature
+++ b/bitloops/qat/features/devql/cross_capability_smoke.feature
@@ -30,4 +30,4 @@ Feature: Cross-capability deterministic smoke
     And DevQL artefacts query returns results in bitloops
     And DevQL deps query for "UserService.createUser" with direction "in" and asOf latest commit returns at least 1 result in bitloops
     And TestHarness query for "UserService.createUser" at current workspace state with view "summary" returns results in bitloops
-    And DevQL clones query for "UserService.createUser" returns at least 1 result in bitloops
+    And DevQL clones query for "renderInvoice" returns at least 1 result in bitloops

--- a/bitloops/qat/features/devql/test_harness_proof_map.feature
+++ b/bitloops/qat/features/devql/test_harness_proof_map.feature
@@ -18,24 +18,24 @@ Feature: TestHarness proof-map for pre-change safety assessment
 
   @devql @testharness
   Scenario: Test summary returns counts for `UserService.createUser`
-    Then TestHarness query for "UserService.createUser" at current workspace state with view "summary" returns results in bitloops
+    Then TestHarness query for "UserService.createUser" at latest commit with view "summary" returns results in bitloops
     And TestHarness summary shows non-zero test count in bitloops
 
   @devql @testharness
   Scenario: Tests query returns individual covering tests for `UserService.createUser`
-    Then TestHarness query for "UserService.createUser" at current workspace state with view "tests" returns results in bitloops
+    Then TestHarness query for "UserService.createUser" at latest commit with view "tests" returns results in bitloops
     And TestHarness tests include at least 1 test with a classification in bitloops
 
   @devql @testharness
   Scenario: Coverage query returns line coverage data for `UserService.createUser`
-    Then TestHarness query for "UserService.createUser" at current workspace state with view "coverage" returns results in bitloops
+    Then TestHarness query for "UserService.createUser" at latest commit with view "coverage" returns results in bitloops
     And TestHarness coverage shows line coverage percentage in bitloops
 
   @devql @testharness
   Scenario: Untested artefact is clearly identified for `UntestableSingleton.getInstance`
-    Then TestHarness query for "UntestableSingleton.getInstance" at current workspace state with view "summary" returns empty or zero-count in bitloops
+    Then TestHarness query for "UntestableSingleton.getInstance" at latest commit with view "summary" returns empty or zero-count in bitloops
 
   @devql @testharness
   Scenario: Failing test is distinguishable from passing test
     Given I run TestHarness ingest-results with a failing test for latest commit in bitloops
-    Then TestHarness query for "UserService.createUser" at current workspace state with view "tests" includes a failing test in bitloops
+    Then TestHarness query for "UserService.createUser" at latest commit with view "tests" includes a failing test in bitloops

--- a/bitloops/scripts/qa/semantic_clones_ann_ab.sh
+++ b/bitloops/scripts/qa/semantic_clones_ann_ab.sh
@@ -171,7 +171,7 @@ calc_stats() {
 speedup_percent() {
   local baseline_ms="$1"
   local improved_ms="$2"
-  awk -v baseline="$baseline_ms" -v improved="$improved_ms" '
+  LC_ALL=C awk -v baseline="$baseline_ms" -v improved="$improved_ms" '
     BEGIN {
       if (baseline <= 0) {
         printf "0.00"

--- a/bitloops/src/adapters/agents/codex/hooks_tests.rs
+++ b/bitloops/src/adapters/agents/codex/hooks_tests.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::test_support::process_state::with_env_var;
 use serde_json::Value;
 
 use super::*;
@@ -82,136 +83,151 @@ fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
+fn with_managed_hook_env_cleared<T>(f: impl FnOnce() -> T) -> T {
+    with_env_var(crate::config::ENV_DAEMON_CONFIG_PATH_OVERRIDE, None, f)
+}
+
 #[test]
 fn install_hooks_fresh_and_idempotent() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    let installed = install_hooks_at(dir.path(), false, false).expect("install");
-    assert_eq!(installed, 5);
-    assert!(are_hooks_installed_at(dir.path()));
-    assert!(config_file(dir.path()).exists());
+        let installed = install_hooks_at(dir.path(), false, false).expect("install");
+        assert_eq!(installed, 5);
+        assert!(are_hooks_installed_at(dir.path()));
+        assert!(config_file(dir.path()).exists());
 
-    let second = install_hooks_at(dir.path(), false, false).expect("install second");
-    assert_eq!(second, 0);
+        let second = install_hooks_at(dir.path(), false, false).expect("install second");
+        assert_eq!(second, 0);
 
-    let output = read_hooks_json(dir.path());
-    let session_commands = commands_for_hook(&output, "SessionStart");
-    let user_prompt_commands = commands_for_hook(&output, "UserPromptSubmit");
-    let pre_tool_commands = commands_for_hook(&output, "PreToolUse");
-    let post_tool_commands = commands_for_hook(&output, "PostToolUse");
-    let stop_commands = commands_for_hook(&output, "Stop");
+        let output = read_hooks_json(dir.path());
+        let session_commands = commands_for_hook(&output, "SessionStart");
+        let user_prompt_commands = commands_for_hook(&output, "UserPromptSubmit");
+        let pre_tool_commands = commands_for_hook(&output, "PreToolUse");
+        let post_tool_commands = commands_for_hook(&output, "PostToolUse");
+        let stop_commands = commands_for_hook(&output, "Stop");
 
-    assert_eq!(
-        session_commands,
-        vec!["bitloops hooks codex session-start".to_string()]
-    );
-    assert_eq!(
-        user_prompt_commands,
-        vec!["bitloops hooks codex user-prompt-submit".to_string()]
-    );
-    assert_eq!(
-        pre_tool_commands,
-        vec!["bitloops hooks codex pre-tool-use".to_string()]
-    );
-    assert_eq!(
-        post_tool_commands,
-        vec!["bitloops hooks codex post-tool-use".to_string()]
-    );
-    assert_eq!(stop_commands, vec!["bitloops hooks codex stop".to_string()]);
+        assert_eq!(
+            session_commands,
+            vec!["bitloops hooks codex session-start".to_string()]
+        );
+        assert_eq!(
+            user_prompt_commands,
+            vec!["bitloops hooks codex user-prompt-submit".to_string()]
+        );
+        assert_eq!(
+            pre_tool_commands,
+            vec!["bitloops hooks codex pre-tool-use".to_string()]
+        );
+        assert_eq!(
+            post_tool_commands,
+            vec!["bitloops hooks codex post-tool-use".to_string()]
+        );
+        assert_eq!(stop_commands, vec!["bitloops hooks codex stop".to_string()]);
 
-    let start_hook = output
-        .get("hooks")
-        .and_then(|hooks| hooks.get("SessionStart"))
-        .and_then(Value::as_array)
-        .and_then(|entries| entries.first())
-        .and_then(|entry| entry.get("hooks"))
-        .and_then(Value::as_array)
-        .and_then(|entries| entries.first())
-        .expect("SessionStart hook command");
+        let start_hook = output
+            .get("hooks")
+            .and_then(|hooks| hooks.get("SessionStart"))
+            .and_then(Value::as_array)
+            .and_then(|entries| entries.first())
+            .and_then(|entry| entry.get("hooks"))
+            .and_then(Value::as_array)
+            .and_then(|entries| entries.first())
+            .expect("SessionStart hook command");
 
-    assert_eq!(
-        start_hook.get("type").and_then(Value::as_str),
-        Some("command")
-    );
-    assert_eq!(
-        start_hook.get("statusMessage").and_then(Value::as_str),
-        Some("Initializing session...")
-    );
-    assert_eq!(start_hook.get("timeout").and_then(Value::as_i64), Some(10));
+        assert_eq!(
+            start_hook.get("type").and_then(Value::as_str),
+            Some("command")
+        );
+        assert_eq!(
+            start_hook.get("statusMessage").and_then(Value::as_str),
+            Some("Initializing session...")
+        );
+        assert_eq!(start_hook.get("timeout").and_then(Value::as_i64), Some(10));
+    });
 }
 
 #[test]
 fn installed_hooks_require_repo_local_codex_feature_config() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    install_hooks_at(dir.path(), false, false).expect("install");
-    fs::remove_file(config_file(dir.path())).expect("remove config");
+        install_hooks_at(dir.path(), false, false).expect("install");
+        fs::remove_file(config_file(dir.path())).expect("remove config");
 
-    assert!(
-        !are_hooks_installed_at(dir.path()),
-        "hooks should not be considered installed without .codex/config.toml enabling codex_hooks"
-    );
+        assert!(
+            !are_hooks_installed_at(dir.path()),
+            "hooks should not be considered installed without .codex/config.toml enabling codex_hooks"
+        );
+    });
 }
 
 #[test]
 fn installed_hooks_require_enabled_repo_local_codex_feature_config() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    install_hooks_at(dir.path(), false, false).expect("install");
-    fs::write(config_file(dir.path()), "[features]\ncodex_hooks = false\n")
-        .expect("disable codex hooks");
+        install_hooks_at(dir.path(), false, false).expect("install");
+        fs::write(config_file(dir.path()), "[features]\ncodex_hooks = false\n")
+            .expect("disable codex hooks");
 
-    assert!(
-        !are_hooks_installed_at(dir.path()),
-        "hooks should not be considered installed when codex_hooks is disabled"
-    );
+        assert!(
+            !are_hooks_installed_at(dir.path()),
+            "hooks should not be considered installed when codex_hooks is disabled"
+        );
+    });
 }
 
 #[test]
 fn install_hooks_local_dev_writes_cargo_run_commands() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    let installed = install_hooks_at(dir.path(), true, false).expect("install local-dev");
-    assert_eq!(installed, 5);
+        let installed = install_hooks_at(dir.path(), true, false).expect("install local-dev");
+        assert_eq!(installed, 5);
 
-    let output = read_hooks(dir.path());
-    assert!(output.contains("cargo run -- hooks codex session-start"));
-    assert!(output.contains("cargo run -- hooks codex user-prompt-submit"));
-    assert!(output.contains("cargo run -- hooks codex pre-tool-use"));
-    assert!(output.contains("cargo run -- hooks codex post-tool-use"));
-    assert!(output.contains("cargo run -- hooks codex stop"));
-    assert!(!output.contains("bitloops hooks codex session-start"));
+        let output = read_hooks(dir.path());
+        assert!(output.contains("cargo run -- hooks codex session-start"));
+        assert!(output.contains("cargo run -- hooks codex user-prompt-submit"));
+        assert!(output.contains("cargo run -- hooks codex pre-tool-use"));
+        assert!(output.contains("cargo run -- hooks codex post-tool-use"));
+        assert!(output.contains("cargo run -- hooks codex stop"));
+        assert!(!output.contains("bitloops hooks codex session-start"));
+    });
 }
 
 #[test]
 fn install_hooks_force_reinstalls_managed_hooks() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    install_hooks_at(dir.path(), false, false).expect("initial install");
+        install_hooks_at(dir.path(), false, false).expect("initial install");
 
-    let installed = install_hooks_at(dir.path(), false, true).expect("force install");
-    assert_eq!(installed, 5);
+        let installed = install_hooks_at(dir.path(), false, true).expect("force install");
+        assert_eq!(installed, 5);
 
-    let output = read_hooks(dir.path());
-    let count = output.matches("bitloops hooks codex stop").count();
-    assert_eq!(count, 1, "force should keep one managed stop hook");
+        let output = read_hooks(dir.path());
+        let count = output.matches("bitloops hooks codex stop").count();
+        assert_eq!(count, 1, "force should keep one managed stop hook");
+    });
 }
 
 #[test]
 fn install_hooks_preserves_unknown_fields() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    let codex_dir = dir.path().join(".codex");
-    fs::create_dir_all(&codex_dir).expect("create .codex");
-    fs::write(
-        codex_dir.join("hooks.json"),
-        r#"
+        let codex_dir = dir.path().join(".codex");
+        fs::create_dir_all(&codex_dir).expect("create .codex");
+        fs::write(
+            codex_dir.join("hooks.json"),
+            r#"
 {
   "profile": "strict",
   "hooks": {
@@ -228,27 +244,29 @@ fn install_hooks_preserves_unknown_fields() {
   }
 }
 "#,
-    )
-    .expect("seed config");
+        )
+        .expect("seed config");
 
-    install_hooks_at(dir.path(), false, false).expect("install");
+        install_hooks_at(dir.path(), false, false).expect("install");
 
-    let output = read_hooks(dir.path());
-    assert!(output.contains("\"profile\": \"strict\""));
-    assert!(output.contains("echo future"));
-    assert!(config_file(dir.path()).exists());
+        let output = read_hooks(dir.path());
+        assert!(output.contains("\"profile\": \"strict\""));
+        assert!(output.contains("echo future"));
+        assert!(config_file(dir.path()).exists());
+    });
 }
 
 #[test]
 fn uninstall_preserves_non_bitloops_hooks() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    let codex_dir = dir.path().join(".codex");
-    fs::create_dir_all(&codex_dir).expect("create .codex");
-    fs::write(
-        codex_dir.join("hooks.json"),
-        r#"
+        let codex_dir = dir.path().join(".codex");
+        fs::create_dir_all(&codex_dir).expect("create .codex");
+        fs::write(
+            codex_dir.join("hooks.json"),
+            r#"
 {
   "hooks": {
     "SessionStart": [
@@ -310,29 +328,31 @@ fn uninstall_preserves_non_bitloops_hooks() {
   }
 }
 "#,
-    )
-    .expect("seed config");
+        )
+        .expect("seed config");
 
-    uninstall_hooks_at(dir.path()).expect("uninstall");
-    let output = read_hooks(dir.path());
-    assert!(output.contains("echo custom"));
-    assert!(!output.contains("bitloops hooks codex session-start"));
-    assert!(!output.contains("bitloops hooks codex user-prompt-submit"));
-    assert!(!output.contains("bitloops hooks codex pre-tool-use"));
-    assert!(!output.contains("bitloops hooks codex post-tool-use"));
-    assert!(!output.contains("bitloops hooks codex stop"));
+        uninstall_hooks_at(dir.path()).expect("uninstall");
+        let output = read_hooks(dir.path());
+        assert!(output.contains("echo custom"));
+        assert!(!output.contains("bitloops hooks codex session-start"));
+        assert!(!output.contains("bitloops hooks codex user-prompt-submit"));
+        assert!(!output.contains("bitloops hooks codex pre-tool-use"));
+        assert!(!output.contains("bitloops hooks codex post-tool-use"));
+        assert!(!output.contains("bitloops hooks codex stop"));
+    });
 }
 
 #[test]
 fn install_hooks_migrates_local_dev_commands_without_force() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    let codex_dir = dir.path().join(".codex");
-    fs::create_dir_all(&codex_dir).expect("create .codex");
-    fs::write(
-        codex_dir.join("hooks.json"),
-        r#"
+        let codex_dir = dir.path().join(".codex");
+        fs::create_dir_all(&codex_dir).expect("create .codex");
+        fs::write(
+            codex_dir.join("hooks.json"),
+            r#"
 {
   "hooks": {
     "SessionStart": [
@@ -390,61 +410,67 @@ fn install_hooks_migrates_local_dev_commands_without_force() {
   }
 }
 "#,
-    )
-    .expect("seed config");
+        )
+        .expect("seed config");
 
-    let installed = install_hooks_at(dir.path(), false, false).expect("install");
-    assert_eq!(installed, 5);
+        let installed = install_hooks_at(dir.path(), false, false).expect("install");
+        assert_eq!(installed, 5);
 
-    let output = read_hooks(dir.path());
-    assert!(!output.contains("cargo run -- hooks codex session-start"));
-    assert!(!output.contains("cargo run -- hooks codex user-prompt-submit"));
-    assert!(!output.contains("cargo run -- hooks codex pre-tool-use"));
-    assert!(!output.contains("cargo run -- hooks codex post-tool-use"));
-    assert!(!output.contains("cargo run -- hooks codex stop"));
-    assert!(output.contains("bitloops hooks codex session-start"));
-    assert!(output.contains("bitloops hooks codex user-prompt-submit"));
-    assert!(output.contains("bitloops hooks codex pre-tool-use"));
-    assert!(output.contains("bitloops hooks codex post-tool-use"));
-    assert!(output.contains("bitloops hooks codex stop"));
+        let output = read_hooks(dir.path());
+        assert!(!output.contains("cargo run -- hooks codex session-start"));
+        assert!(!output.contains("cargo run -- hooks codex user-prompt-submit"));
+        assert!(!output.contains("cargo run -- hooks codex pre-tool-use"));
+        assert!(!output.contains("cargo run -- hooks codex post-tool-use"));
+        assert!(!output.contains("cargo run -- hooks codex stop"));
+        assert!(output.contains("bitloops hooks codex session-start"));
+        assert!(output.contains("bitloops hooks codex user-prompt-submit"));
+        assert!(output.contains("bitloops hooks codex pre-tool-use"));
+        assert!(output.contains("bitloops hooks codex post-tool-use"));
+        assert!(output.contains("bitloops hooks codex stop"));
+    });
 }
 
 #[test]
 fn uninstall_hooks_without_config_is_noop() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    uninstall_hooks_at(dir.path()).expect("uninstall noop");
+        uninstall_hooks_at(dir.path()).expect("uninstall noop");
+    });
 }
 
 #[test]
 fn install_hooks_sets_bash_matcher_for_tool_hooks() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    install_hooks_at(dir.path(), false, false).expect("install");
+        install_hooks_at(dir.path(), false, false).expect("install");
 
-    let output = read_hooks_json(dir.path());
-    assert_eq!(
-        matchers_for_hook(&output, "PreToolUse"),
-        vec!["Bash".to_string()]
-    );
-    assert_eq!(
-        matchers_for_hook(&output, "PostToolUse"),
-        vec!["Bash".to_string()]
-    );
+        let output = read_hooks_json(dir.path());
+        assert_eq!(
+            matchers_for_hook(&output, "PreToolUse"),
+            vec!["Bash".to_string()]
+        );
+        assert_eq!(
+            matchers_for_hook(&output, "PostToolUse"),
+            vec!["Bash".to_string()]
+        );
+    });
 }
 
 #[test]
 fn are_hooks_installed_requires_all_five_managed_hooks() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    init_repo(dir.path());
+    with_managed_hook_env_cleared(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
 
-    let codex_dir = dir.path().join(".codex");
-    fs::create_dir_all(&codex_dir).expect("create .codex");
-    fs::write(
-        codex_dir.join("hooks.json"),
-        r#"
+        let codex_dir = dir.path().join(".codex");
+        fs::create_dir_all(&codex_dir).expect("create .codex");
+        fs::write(
+            codex_dir.join("hooks.json"),
+            r#"
 {
   "hooks": {
     "SessionStart": [
@@ -502,52 +528,55 @@ fn are_hooks_installed_requires_all_five_managed_hooks() {
   }
 }
 "#,
-    )
-    .expect("seed config");
+        )
+        .expect("seed config");
 
-    assert!(
-        !are_hooks_installed_at(dir.path()),
-        "missing stop hook should be treated as incomplete install"
-    );
+        assert!(
+            !are_hooks_installed_at(dir.path()),
+            "missing stop hook should be treated as incomplete install"
+        );
+    });
 }
 
 #[test]
 fn legacy_bitloops_hooks_codex_usage_is_allowlisted() {
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let src_root = manifest_dir.join("src");
-    let mut files = Vec::new();
-    collect_rs_files(&src_root, &mut files);
+    with_managed_hook_env_cleared(|| {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let src_root = manifest_dir.join("src");
+        let mut files = Vec::new();
+        collect_rs_files(&src_root, &mut files);
 
-    let allowlist = [
-        "src/adapters/agents/codex/hooks.rs",
-        "src/adapters/agents/codex/hooks_tests.rs",
-        "src/cli/init.rs",
-        "src/cli/init/tests.rs",
-        "src/cli/root_test.rs",
-    ];
-    let mut violations = Vec::new();
+        let allowlist = [
+            "src/adapters/agents/codex/hooks.rs",
+            "src/adapters/agents/codex/hooks_tests.rs",
+            "src/cli/init.rs",
+            "src/cli/init/tests.rs",
+            "src/cli/root_test.rs",
+        ];
+        let mut violations = Vec::new();
 
-    for file in files {
-        let Ok(content) = fs::read_to_string(&file) else {
-            continue;
-        };
-        if !content.contains("bitloops hooks codex") {
-            continue;
+        for file in files {
+            let Ok(content) = fs::read_to_string(&file) else {
+                continue;
+            };
+            if !content.contains("bitloops hooks codex") {
+                continue;
+            }
+            let rel = file
+                .strip_prefix(manifest_dir)
+                .ok()
+                .and_then(|p| p.to_str())
+                .unwrap_or_default()
+                .replace('\\', "/");
+            if !allowlist.contains(&rel.as_str()) {
+                violations.push(rel);
+            }
         }
-        let rel = file
-            .strip_prefix(manifest_dir)
-            .ok()
-            .and_then(|p| p.to_str())
-            .unwrap_or_default()
-            .replace('\\', "/");
-        if !allowlist.contains(&rel.as_str()) {
-            violations.push(rel);
-        }
-    }
 
-    assert!(
-        violations.is_empty(),
-        "unexpected `bitloops hooks codex` usage outside allowlist: {:?}",
-        violations
-    );
+        assert!(
+            violations.is_empty(),
+            "unexpected `bitloops hooks codex` usage outside allowlist: {:?}",
+            violations
+        );
+    });
 }

--- a/bitloops/src/capability_packs/knowledge/migrations/initial.rs
+++ b/bitloops/src/capability_packs/knowledge/migrations/initial.rs
@@ -6,7 +6,6 @@ use crate::host::capability_host::{
 
 fn run_initial_knowledge_migration(ctx: &mut dyn KnowledgeMigrationContext) -> Result<()> {
     ctx.knowledge_relational().initialise_schema()?;
-    ctx.knowledge_documents().initialise_schema()?;
     Ok(())
 }
 

--- a/bitloops/src/graphql/mutation_root.rs
+++ b/bitloops/src/graphql/mutation_root.rs
@@ -2,6 +2,7 @@ use async_graphql::{Context, Error, ErrorExtensions, InputObject, Object, Result
 use chrono::Utc;
 use serde::Deserialize;
 use serde_json::json;
+use std::path::Path;
 
 use super::{
     DevqlGraphqlContext,
@@ -13,6 +14,14 @@ use super::{
 
 #[derive(Default)]
 pub struct MutationRoot;
+
+fn ensure_knowledge_document_schema(repo_root: &Path) -> anyhow::Result<()> {
+    let backends = crate::config::resolve_store_backend_config_for_repo(repo_root)?;
+    let documents = crate::capability_packs::knowledge::storage::DuckdbKnowledgeDocumentStore::new(
+        backends.events.resolve_duckdb_db_path_for_repo(repo_root),
+    );
+    documents.initialise_schema()
+}
 
 #[derive(Debug, Clone, InputObject)]
 pub struct AddKnowledgeInput {
@@ -553,6 +562,8 @@ impl MutationRoot {
             report.migration_plan
         };
         host.ensure_migrations_applied_sync()
+            .map_err(|err| operation_error("BACKEND_ERROR", "migration", "applyMigrations", err))?;
+        ensure_knowledge_document_schema(host.repo_root())
             .map_err(|err| operation_error("BACKEND_ERROR", "migration", "applyMigrations", err))?;
 
         let applied_at = DateTimeScalar::from_rfc3339(Utc::now().to_rfc3339())

--- a/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/strategy_trait.rs
+++ b/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/strategy_trait.rs
@@ -2,8 +2,71 @@ use super::*;
 use crate::host::interactions::db_store::SqliteInteractionSpool;
 use crate::host::interactions::interaction_repository::create_interaction_repository;
 use crate::host::interactions::store::{InteractionEventRepository, InteractionSpool};
+use crate::host::interactions::types::{
+    InteractionEvent, InteractionEventFilter, InteractionSession, InteractionTurn,
+};
 
 // ── Strategy trait impl ───────────────────────────────────────────────────────
+
+struct SpoolBackedInteractionRepository<'a> {
+    spool: &'a dyn InteractionSpool,
+}
+
+impl InteractionEventRepository for SpoolBackedInteractionRepository<'_> {
+    fn repo_id(&self) -> &str {
+        self.spool.repo_id()
+    }
+
+    fn upsert_session(&self, session: &InteractionSession) -> Result<()> {
+        self.spool.record_session(session)
+    }
+
+    fn upsert_turn(&self, turn: &InteractionTurn) -> Result<()> {
+        self.spool.record_turn(turn)
+    }
+
+    fn append_event(&self, event: &InteractionEvent) -> Result<()> {
+        self.spool.record_event(event)
+    }
+
+    fn assign_checkpoint_to_turns(
+        &self,
+        turn_ids: &[String],
+        checkpoint_id: &str,
+        assigned_at: &str,
+    ) -> Result<()> {
+        self.spool
+            .assign_checkpoint_to_turns(turn_ids, checkpoint_id, assigned_at)
+    }
+
+    fn list_sessions(&self, agent: Option<&str>, limit: usize) -> Result<Vec<InteractionSession>> {
+        self.spool.list_sessions(agent, limit)
+    }
+
+    fn load_session(&self, session_id: &str) -> Result<Option<InteractionSession>> {
+        self.spool.load_session(session_id)
+    }
+
+    fn list_turns_for_session(
+        &self,
+        session_id: &str,
+        limit: usize,
+    ) -> Result<Vec<InteractionTurn>> {
+        self.spool.list_turns_for_session(session_id, limit)
+    }
+
+    fn list_uncheckpointed_turns(&self) -> Result<Vec<InteractionTurn>> {
+        self.spool.list_uncheckpointed_turns()
+    }
+
+    fn list_events(
+        &self,
+        filter: &InteractionEventFilter,
+        limit: usize,
+    ) -> Result<Vec<InteractionEvent>> {
+        self.spool.list_events(filter, limit)
+    }
+}
 
 impl Strategy for ManualCommitStrategy {
     fn name(&self) -> &str {
@@ -362,44 +425,46 @@ impl Strategy for ManualCommitStrategy {
             .as_ref()
             .map(|spool| spool as &dyn InteractionSpool);
         let spool_pending_work = interaction_spool_ref.is_some_and(spool_has_pending_work);
-        let interaction_repository = match resolve_interaction_repository_for_post_commit(
-            &self.repo_root,
-        ) {
-            Ok(repository) => repository,
-            Err(err) => {
-                let context = format_post_commit_derivation_context(
-                    &head,
-                    None,
-                    None,
-                    &[],
-                    Some(spool_pending_work),
-                );
-                if spool_pending_work {
-                    eprintln!(
-                        "[bitloops] Warning: failed to resolve interaction event repository for post_commit ({context}): {err:#}"
+        let (interaction_repository, derivation_spool) =
+            match resolve_interaction_repository_for_post_commit(&self.repo_root) {
+                Ok(repository) => (repository, interaction_spool_ref),
+                Err(err) => {
+                    let context = format_post_commit_derivation_context(
+                        &head,
+                        None,
+                        None,
+                        &[],
+                        Some(spool_pending_work),
                     );
-                    return Err(err).context(format!(
-                        "resolving interaction event repository ({context})"
-                    ));
+                    if spool_pending_work && let Some(spool) = interaction_spool_ref {
+                        eprintln!(
+                            "[bitloops] Warning: failed to resolve interaction event repository for post_commit ({context}): {err:#}\n[bitloops] Warning: falling back to the local interaction spool for post_commit derivation"
+                        );
+                        (
+                            Box::new(SpoolBackedInteractionRepository { spool })
+                                as Box<dyn InteractionEventRepository>,
+                            None,
+                        )
+                    } else {
+                        eprintln!(
+                            "[bitloops] Warning: failed to resolve interaction event repository for post_commit ({context}): {err:#}"
+                        );
+                        update_active_session_base_commits(
+                            self.backend.as_ref(),
+                            &head,
+                            &std::collections::HashSet::new(),
+                        );
+                        return Ok(());
+                    }
                 }
-                eprintln!(
-                    "[bitloops] Warning: failed to resolve interaction event repository for post_commit ({context}): {err:#}"
-                );
-                update_active_session_base_commits(
-                    self.backend.as_ref(),
-                    &head,
-                    &std::collections::HashSet::new(),
-                );
-                return Ok(());
-            }
-        };
+            };
 
         if let Some(checkpoint_id) = self.derive_post_commit_from_interaction_sources(
             &head,
             &committed_files_set,
             is_rebase_in_progress,
-            &interaction_repository,
-            interaction_spool_ref,
+            interaction_repository.as_ref(),
+            derivation_spool,
         )? {
             insert_commit_checkpoint_mapping(&self.repo_root, &head, &checkpoint_id)?;
             if let Err(err) = run_devql_post_commit_checkpoint_projection_refresh(
@@ -647,13 +712,14 @@ impl ManualCommitStrategy {
 
 fn resolve_interaction_repository_for_post_commit(
     repo_root: &Path,
-) -> Result<impl InteractionEventRepository + use<>> {
+) -> Result<Box<dyn InteractionEventRepository>> {
     let backends = crate::config::resolve_store_backend_config_for_repo(repo_root)
         .context("resolving store backend config for interaction event repository")?;
     let repo_id = crate::host::devql::resolve_repo_identity(repo_root)
         .context("resolving repo identity for interaction event repository")?
         .repo_id;
     create_interaction_repository(&backends.events, repo_root, repo_id)
+        .map(|repository| Box::new(repository) as Box<dyn InteractionEventRepository>)
 }
 
 fn spool_has_pending_work(spool: &dyn InteractionSpool) -> bool {

--- a/bitloops/src/host/checkpoints/strategy/manual_commit_tests/post_commit/mapping.rs
+++ b/bitloops/src/host/checkpoints/strategy/manual_commit_tests/post_commit/mapping.rs
@@ -1,5 +1,24 @@
 use super::*;
 use crate::host::checkpoints::session::state::PendingCheckpointState;
+use crate::host::interactions::store::InteractionSpool;
+
+fn rewrite_post_commit_events_path(repo_root: &Path, replacement: &Path) {
+    let config_path = repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH);
+    let content = fs::read_to_string(&config_path).expect("read post-commit test config");
+    let updated = content
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("duckdb_path =") {
+                format!("duckdb_path = {:?}", replacement.to_string_lossy())
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    fs::write(&config_path, updated).expect("rewrite post-commit events path");
+}
 
 #[test]
 pub(crate) fn post_commit_creates_checkpoint_mapping_and_checkpoint() {
@@ -58,6 +77,56 @@ pub(crate) fn post_commit_creates_checkpoint_mapping_and_checkpoint() {
     assert!(
         result.is_err(),
         "post_commit should no longer materialize metadata branch commits"
+    );
+}
+
+#[test]
+pub(crate) fn post_commit_falls_back_to_local_spool_when_interaction_repository_is_unavailable() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(&dir);
+    init_devql_schema(dir.path());
+    seed_interaction_turn(
+        dir.path(),
+        "pc-fallback",
+        "pc-fallback-turn",
+        &["src/change.rs"],
+    );
+
+    let blocked_parent = dir.path().join("blocked-events-parent");
+    fs::write(&blocked_parent, "not a directory").unwrap();
+    rewrite_post_commit_events_path(dir.path(), &blocked_parent.join("events.duckdb"));
+
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(
+        dir.path().join("src/change.rs"),
+        "pub fn change() -> usize { 1 }\n",
+    )
+    .unwrap();
+    git_command()
+        .args(["add", "."])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    git_command()
+        .args(["commit", "-m", "fix: spool fallback"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let head_sha = run_git(dir.path(), &["rev-parse", "HEAD"]).unwrap();
+
+    let strategy = ManualCommitStrategy::new(dir.path());
+    strategy.post_commit().unwrap();
+
+    let checkpoint_id = query_commit_checkpoint_id(dir.path(), &head_sha)
+        .expect("checkpoint mapping should exist after spool fallback post_commit");
+    let turns = open_test_spool(dir.path())
+        .list_turns_for_session("pc-fallback", 10)
+        .expect("list turns after spool fallback derivation");
+    assert_eq!(turns.len(), 1);
+    assert_eq!(
+        turns[0].checkpoint_id.as_deref(),
+        Some(checkpoint_id.as_str()),
+        "local spool should record the assigned checkpoint id when canonical interaction storage is unavailable"
     );
 }
 

--- a/bitloops/src/host/devql/commands_ingest.rs
+++ b/bitloops/src/host/devql/commands_ingest.rs
@@ -180,7 +180,7 @@ async fn execute_ingest_inner(
     );
 
     let checkpoint_mappings = read_commit_checkpoint_mappings(&cfg.repo_root).unwrap_or_default();
-    let mut existing_event_ids = fetch_existing_checkpoint_event_ids(cfg, &backends.events).await?;
+    let mut existing_event_ids: Option<std::collections::HashSet<String>> = None;
 
     for commit_sha in commits {
         let checkpoint_id = checkpoint_mappings.get(&commit_sha).cloned();
@@ -437,6 +437,16 @@ async fn execute_ingest_inner(
                         checkpoint_id,
                     )?
                     .ok_or_else(|| anyhow!("checkpoint mapping exists but metadata is missing for `{checkpoint_id}`"))?;
+                    let existing_event_ids = match existing_event_ids.as_mut() {
+                        Some(ids) => ids,
+                        None => {
+                            existing_event_ids =
+                                Some(fetch_existing_checkpoint_event_ids(cfg, &backends.events).await?);
+                            existing_event_ids
+                                .as_mut()
+                                .expect("checkpoint event ids must be initialised")
+                        }
+                    };
                     let event_id = deterministic_uuid(&format!(
                         "{}|{}|{}|checkpoint_committed",
                         cfg.repo.repo_id, checkpoint.checkpoint_id, checkpoint.session_id

--- a/bitloops/src/host/devql/ingestion/artefact_identity.rs
+++ b/bitloops/src/host/devql/ingestion/artefact_identity.rs
@@ -79,14 +79,6 @@ pub(crate) fn revision_artefact_id(repo_id: &str, blob_sha: &str, symbol_id: &st
     ))
 }
 
-pub(super) fn historical_symbol_artefact_id(
-    repo_id: &str,
-    symbol_id: &str,
-    content_hash: &str,
-) -> String {
-    deterministic_uuid(&format!("{repo_id}|{symbol_id}|{content_hash}"))
-}
-
 #[cfg(test)]
 pub(super) fn extract_js_ts_functions(content: &str) -> Result<Vec<FunctionArtefact>> {
     let function_decl = Regex::new(

--- a/bitloops/src/host/devql/ingestion/artefact_persistence_symbols.rs
+++ b/bitloops/src/host/devql/ingestion/artefact_persistence_symbols.rs
@@ -30,7 +30,7 @@ pub(super) fn symbol_content_hash(item: &LanguageArtefact, content: &str) -> Str
 pub(super) fn build_symbol_records(
     cfg: &DevqlConfig,
     path: &str,
-    _blob_sha: &str,
+    blob_sha: &str,
     file_artefact: &FileArtefactRow,
     items: &[LanguageArtefact],
     content: &str,
@@ -49,8 +49,7 @@ pub(super) fn build_symbol_records(
             .map(String::as_str);
         let symbol_id = structural_symbol_id_for_artefact(item, semantic_parent_symbol_id);
         let content_hash = symbol_content_hash(item, content);
-        let artefact_id =
-            historical_symbol_artefact_id(&cfg.repo.repo_id, &symbol_id, &content_hash);
+        let artefact_id = revision_artefact_id(&cfg.repo.repo_id, blob_sha, &symbol_id);
         let parent_symbol_id = item
             .parent_symbol_fqn
             .as_ref()
@@ -200,6 +199,50 @@ mod tests {
         assert!(
             sql.contains("ON CONFLICT (artefact_id) DO UPDATE"),
             "historical builder should upsert on artefact_id"
+        );
+    }
+
+    #[test]
+    fn build_symbol_records_aligns_symbol_artefact_ids_with_revision_identity() {
+        let cfg = sample_cfg();
+        let file_artefact = FileArtefactRow {
+            artefact_id: revision_artefact_id("repo-id", "blob-sha", &file_symbol_id("src/lib.rs")),
+            symbol_id: file_symbol_id("src/lib.rs"),
+            language: "rust".to_string(),
+            end_line: 2,
+            end_byte: 32,
+        };
+        let item = LanguageArtefact {
+            canonical_kind: Some("function".to_string()),
+            language_kind: crate::host::language_adapter::LanguageKind::rust(
+                crate::host::language_adapter::RustKind::FunctionItem,
+            ),
+            name: "name".to_string(),
+            symbol_fqn: "src/lib.rs::name".to_string(),
+            parent_symbol_fqn: None,
+            start_line: 1,
+            end_line: 2,
+            start_byte: 0,
+            end_byte: 16,
+            signature: "fn name()".to_string(),
+            modifiers: vec!["pub".to_string()],
+            docstring: Some("docs".to_string()),
+        };
+
+        let records = build_symbol_records(
+            &cfg,
+            "src/lib.rs",
+            "blob-sha",
+            &file_artefact,
+            std::slice::from_ref(&item),
+            "pub fn name() {}\n",
+        );
+        let record = records.first().expect("expected symbol record");
+        let symbol_id = structural_symbol_id_for_artefact(&item, None);
+
+        assert_eq!(
+            record.artefact_id,
+            revision_artefact_id(&cfg.repo.repo_id, "blob-sha", &symbol_id)
         );
     }
 }

--- a/bitloops/src/host/devql/ingestion/schema/events_backends.rs
+++ b/bitloops/src/host/devql/ingestion/schema/events_backends.rs
@@ -220,6 +220,9 @@ ON interaction_events (repo_id, event_type, event_time);
     duckdb_exec_path_allow_create(&duckdb_path, interaction_sql)
         .await
         .context("creating DuckDB interaction_events table")?;
+    duckdb_exec_path_allow_create(&duckdb_path, knowledge_schema_sql_duckdb())
+        .await
+        .context("creating DuckDB knowledge_document_versions table")?;
     Ok(())
 }
 
@@ -304,5 +307,33 @@ mod tests {
         assert!(rows.contains(&"interaction_events_repo_time_idx".to_string()));
         assert!(rows.contains(&"interaction_events_session_idx".to_string()));
         assert!(rows.contains(&"interaction_events_type_idx".to_string()));
+    }
+
+    #[tokio::test]
+    async fn init_duckdb_schema_creates_knowledge_document_versions_table() {
+        let repo = TempDir::new().expect("temp dir");
+        let events_cfg = EventsBackendConfig {
+            duckdb_path: Some(".bitloops/stores/events.duckdb".into()),
+            clickhouse_url: None,
+            clickhouse_user: None,
+            clickhouse_password: None,
+            clickhouse_database: None,
+        };
+
+        init_duckdb_schema(repo.path(), &events_cfg)
+            .await
+            .expect("initialise duckdb schema");
+
+        let duckdb_path = events_cfg.resolve_duckdb_db_path_for_repo(repo.path());
+        let conn = duckdb::Connection::open(duckdb_path).expect("open duckdb");
+        let table_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'knowledge_document_versions'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count knowledge_document_versions table rows");
+
+        assert_eq!(table_exists, 1);
     }
 }

--- a/bitloops/src/host/devql/tests/devql_tests/commit_history.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/commit_history.rs
@@ -530,7 +530,7 @@ async fn execute_ingest_runs_checkpoint_companion_work_once_for_mapped_commits()
 }
 
 #[tokio::test]
-async fn execute_ingest_dedupes_historical_symbol_rows_by_content_hash_without_breaking_commit_queries()
+async fn execute_ingest_reuses_stable_symbol_ids_across_blob_only_changes_without_breaking_commit_queries()
  {
     let repo = seed_git_repo();
     write_local_devql_config(repo.path());
@@ -573,9 +573,21 @@ async fn execute_ingest_dedupes_historical_symbol_rows_by_content_hash_without_b
             |row| row.get(0),
         )
         .expect("count stable historical artefacts");
+    let stable_symbol_id_count: i64 = sqlite
+        .query_row(
+            "SELECT COUNT(DISTINCT symbol_id) FROM artefacts
+             WHERE repo_id = ?1 AND symbol_fqn = 'src/lib.rs::stable' AND canonical_kind = 'function'",
+            rusqlite::params![cfg.repo.repo_id.as_str()],
+            |row| row.get(0),
+        )
+        .expect("count stable historical symbol ids");
     assert_eq!(
-        stable_row_count, 1,
-        "historical ingest should reuse the same symbol artefact row when the symbol content hash is unchanged"
+        stable_row_count, 2,
+        "historical ingest should persist one symbol artefact row per blob-scoped revision"
+    );
+    assert_eq!(
+        stable_symbol_id_count, 1,
+        "historical ingest should preserve the same structural symbol identity when only the blob changes"
     );
 
     let first_rows = execute_query_json_for_repo_root(

--- a/bitloops/src/host/devql/tests/devql_tests/commit_history.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/commit_history.rs
@@ -12,6 +12,24 @@ duckdb_path = ".bitloops/stores/events.duckdb"
     );
 }
 
+fn rewrite_local_events_path(repo_root: &Path, replacement: &Path) {
+    let config_path = repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH);
+    let content = fs::read_to_string(&config_path).expect("read local devql config");
+    let updated = content
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("duckdb_path =") {
+                format!("duckdb_path = {:?}", replacement.to_string_lossy())
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    fs::write(&config_path, updated).expect("rewrite local events path");
+}
+
 fn cfg_for_repo(repo_root: &Path) -> DevqlConfig {
     let repo = resolve_repo_identity(repo_root).expect("resolve repo identity");
     DevqlConfig::from_env(repo_root.to_path_buf(), repo).expect("build devql cfg from repo")
@@ -355,6 +373,55 @@ async fn execute_ingest_materialises_unmapped_commit_history_without_current_sta
     assert_eq!(
         checkpoint_event_rows, 0,
         "unmapped commits must not synthesize checkpoint events"
+    );
+}
+
+#[tokio::test]
+async fn execute_ingest_skips_events_backend_for_unmapped_commits_when_events_store_is_unavailable()
+{
+    let repo = seed_git_repo();
+    write_local_devql_config(repo.path());
+    std::fs::create_dir_all(repo.path().join("src")).expect("create src");
+    std::fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn greet(name: &str) -> String { format!(\"hi {name}\") }\n",
+    )
+    .expect("write lib.rs");
+    git_ok(repo.path(), &["add", "."]);
+    git_ok(repo.path(), &["commit", "-m", "add lib"]);
+
+    let cfg = cfg_for_repo(repo.path());
+    execute_init_schema(&cfg, "commit-history unmapped events-unavailable test")
+        .await
+        .expect("initialise local devql store for unmapped events-unavailable test");
+
+    let blocked_parent = repo.path().join("blocked-events-parent");
+    std::fs::write(&blocked_parent, "not a directory").expect("write blocking file");
+    rewrite_local_events_path(repo.path(), &blocked_parent.join("events.duckdb"));
+
+    let summary = execute_ingest_with_observer(&cfg, false, 500, None, None)
+        .await
+        .expect("execute ingest for unmapped commits without events backend");
+    assert!(
+        summary.success,
+        "ingest summary should report success when unmapped commits do not require the events backend"
+    );
+    assert_eq!(summary.commits_processed, 2);
+    assert_eq!(summary.checkpoint_companions_processed, 0);
+    assert_eq!(summary.events_inserted, 0);
+
+    let sqlite =
+        rusqlite::Connection::open(sqlite_path_for_repo(repo.path())).expect("open sqlite");
+    let file_state_count: i64 = sqlite
+        .query_row(
+            "SELECT COUNT(*) FROM file_state WHERE repo_id = ?1",
+            rusqlite::params![cfg.repo.repo_id.as_str()],
+            |row| row.get(0),
+        )
+        .expect("count historical file_state rows");
+    assert!(
+        file_state_count > 0,
+        "historical ingest should still persist file_state rows when no checkpoint companions are present"
     );
 }
 

--- a/bitloops/src/host/devql/tests/devql_tests/core_and_ingestion/record_building.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/core_and_ingestion/record_building.rs
@@ -88,7 +88,7 @@ fn build_symbol_records_chain_file_and_nested_parent_links() {
 }
 
 #[test]
-fn build_symbol_records_derive_content_hash_from_symbol_content_not_blob() {
+fn build_symbol_records_keep_content_hash_stable_while_revision_artefact_id_changes_per_blob() {
     let cfg = test_cfg();
     let path = "src/ui.ts";
     let file_a = test_file_row(&cfg, path, "blob-a", 10, 100);
@@ -113,7 +113,8 @@ fn build_symbol_records_derive_content_hash_from_symbol_content_not_blob() {
     let second = build_symbol_records(&cfg, path, "blob-b", &file_b, &items, content);
 
     assert_eq!(first[0].content_hash, second[0].content_hash);
-    assert_eq!(first[0].artefact_id, second[0].artefact_id);
+    assert_eq!(first[0].symbol_id, second[0].symbol_id);
+    assert_ne!(first[0].artefact_id, second[0].artefact_id);
 }
 
 #[test]

--- a/bitloops/tests/performance/semantic_clones_ann_ab.rs
+++ b/bitloops/tests/performance/semantic_clones_ann_ab.rs
@@ -368,6 +368,71 @@ exit 0
 
 #[cfg(unix)]
 #[test]
+fn ann_ab_script_emits_json_safe_speedup_percent_under_decimal_comma_locale() {
+    use std::fs;
+    use std::process::Command;
+
+    let locale_output = Command::new("locale")
+        .arg("-a")
+        .output()
+        .expect("list locales");
+    assert!(locale_output.status.success(), "locale -a should succeed");
+    let locales = String::from_utf8_lossy(&locale_output.stdout);
+    let locale = locales
+        .lines()
+        .find(|line| {
+            matches!(
+                *line,
+                "de_DE.UTF-8" | "fr_FR.UTF-8" | "it_IT.UTF-8" | "nl_NL.UTF-8" | "el_GR.UTF-8"
+            )
+        })
+        .map(str::to_string);
+
+    let Some(locale) = locale else {
+        return;
+    };
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let repo_dir = temp.path().join("repo");
+    fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+    let report_path = temp.path().join("ann-ab-locale.json");
+    let output = run_ann_ab_script(
+        &repo_dir,
+        &[
+            "--symbol-fqn",
+            "src/services/orders.ts::OrderService.create",
+            "--iterations",
+            "1",
+            "--warmup",
+            "0",
+            "--output",
+            report_path.to_str().expect("report path utf8"),
+        ],
+        &[("BITLOOPS_ANN_AB_MOCK", "1"), ("LC_ALL", locale.as_str())],
+    );
+
+    assert!(
+        output.status.success(),
+        "script failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let report_raw = fs::read_to_string(&report_path).expect("read report json");
+    let report: serde_json::Value = serde_json::from_str(&report_raw).expect("parse report json");
+    assert_eq!(
+        report["metrics"]["ingest_ms"]["speedup_percent_ann_on_vs_ann_off"].as_f64(),
+        Some(39.02)
+    );
+    assert_eq!(
+        report["metrics"]["query_ms"]["speedup_percent_ann_on_vs_ann_off"].as_f64(),
+        Some(48.13)
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn ann_ab_script_rejects_empty_query_results_when_nonempty_required() {
     use std::fs;
 
@@ -559,6 +624,20 @@ fn run_ann_ab_script(
         .arg("--repo")
         .arg(repo_dir)
         .args(args);
+    // Keep these integration tests hermetic even when the parent process exports
+    // script-specific overrides such as ORT_DYLIB_PATH or mock controls.
+    for key in [
+        "BITLOOPS_ANN_AB_BINARY",
+        "BITLOOPS_ANN_AB_MOCK",
+        "BITLOOPS_ANN_AB_MOCK_QUERY_ROWS",
+        "BITLOOPS_ANN_AB_MOCK_QUERY_NESTED_EMPTY",
+        "BITLOOPS_ANN_AB_MOCK_INVALID_QUERY_JSON",
+        "BITLOOPS_ANN_AB_MOCK_INGEST_ERROR",
+        "BITLOOPS_SEMANTIC_CLONES_DISABLE_ANN",
+        "ORT_DYLIB_PATH",
+    ] {
+        command.env_remove(key);
+    }
     for (key, value) in envs {
         command.env(key, value);
     }

--- a/bitloops/tests/qat_support/helpers/core.rs
+++ b/bitloops/tests/qat_support/helpers/core.rs
@@ -1567,20 +1567,24 @@ pub fn assert_bitloops_stores_exist_for_repo(world: &QatWorld, repo_name: &str) 
             repo_stores_dir.join("event").join("events.duckdb"),
         )
     } else {
-        let cfg = resolve_store_backend_config_for_repo(world.repo_dir())
-            .context("resolving store backend config for QAT store assertions")?;
-        let relational = resolve_sqlite_db_path_for_repo(
-            world.repo_dir(),
-            cfg.relational.sqlite_path.as_deref(),
-        )
-        .context("resolving relational store path for QAT store assertions")?;
-        let events =
-            resolve_duckdb_db_path_for_repo(world.repo_dir(), cfg.events.duckdb_path.as_deref());
-        let stores_dir = relational
-            .parent()
-            .map(|p| p.to_path_buf())
-            .unwrap_or_default();
-        (stores_dir, relational, events)
+        with_scenario_app_env(world, || {
+            let cfg = resolve_store_backend_config_for_repo(world.repo_dir())
+                .context("resolving store backend config for QAT store assertions")?;
+            let relational = resolve_sqlite_db_path_for_repo(
+                world.repo_dir(),
+                cfg.relational.sqlite_path.as_deref(),
+            )
+            .context("resolving relational store path for QAT store assertions")?;
+            let events = resolve_duckdb_db_path_for_repo(
+                world.repo_dir(),
+                cfg.events.duckdb_path.as_deref(),
+            );
+            let stores_dir = relational
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_default();
+            Ok::<_, anyhow::Error>((stores_dir, relational, events))
+        })?
     };
     ensure!(
         stores_dir.exists(),

--- a/bitloops/tests/qat_support/helpers/deps_and_testlens.rs
+++ b/bitloops/tests/qat_support/helpers/deps_and_testlens.rs
@@ -547,23 +547,31 @@ pub fn run_testlens_query(
     repo_name: &str,
     artefact: &str,
     view: &str,
+    state_scope: &str,
 ) -> Result<serde_json::Value> {
     ensure_bitloops_repo_name(repo_name)?;
     let symbol_fqn = resolve_symbol_fqn_alias(world, artefact)?;
-    let commit_scope = world
-        .captured_commit_shas
-        .last()
-        .cloned()
-        .ok_or_else(|| anyhow!("no latest commit SHA captured for TestHarness query"))?;
+    let temporal_prefix = match state_scope {
+        "current workspace state" => String::new(),
+        "latest commit" => {
+            let commit_scope = world
+                .captured_commit_shas
+                .last()
+                .cloned()
+                .ok_or_else(|| anyhow!("no latest commit SHA captured for TestHarness query"))?;
+            format!(r#"->asOf(commit:"{}")"#, escape_devql_string(&commit_scope))
+        }
+        _ => bail!("unsupported TestHarness state scope `{state_scope}`"),
+    };
     let query = match view {
         "summary" | "tests" => format!(
-            r#"repo("bitloops")->asOf(commit:"{}")->artefacts(symbol_fqn:"{}")->tests()->limit(200)"#,
-            escape_devql_string(&commit_scope),
+            r#"repo("bitloops"){}->artefacts(symbol_fqn:"{}")->tests()->limit(200)"#,
+            temporal_prefix,
             escape_devql_string(&symbol_fqn),
         ),
         "coverage" => format!(
-            r#"repo("bitloops")->asOf(commit:"{}")->artefacts(symbol_fqn:"{}")->coverage()->limit(200)"#,
-            escape_devql_string(&commit_scope),
+            r#"repo("bitloops"){}->artefacts(symbol_fqn:"{}")->coverage()->limit(200)"#,
+            temporal_prefix,
             escape_devql_string(&symbol_fqn),
         ),
         _ => bail!("unsupported TestHarness view `{view}`"),
@@ -708,6 +716,7 @@ fn run_testlens_query_eventually(
     repo_name: &str,
     artefact: &str,
     view: &str,
+    state_scope: &str,
     expected: &str,
     condition: impl Fn(&serde_json::Value) -> bool,
 ) -> Result<serde_json::Value> {
@@ -721,7 +730,7 @@ fn run_testlens_query_eventually(
 
     loop {
         attempts += 1;
-        let value = run_testlens_query(world, repo_name, artefact, view)?;
+        let value = run_testlens_query(world, repo_name, artefact, view, state_scope)?;
         if condition(&value) {
             return Ok(value);
         }
@@ -745,12 +754,14 @@ pub fn assert_testlens_query_returns_results(
     repo_name: &str,
     artefact: &str,
     view: &str,
+    state_scope: &str,
 ) -> Result<()> {
     let value = run_testlens_query_eventually(
         world,
         repo_name,
         artefact,
         view,
+        state_scope,
         "return results",
         |value| count_testlens_payload_rows(value) >= 1,
     )?;
@@ -811,12 +822,14 @@ pub fn assert_testlens_query_empty_or_zero(
     repo_name: &str,
     artefact: &str,
     view: &str,
+    state_scope: &str,
 ) -> Result<()> {
     let value = run_testlens_query_eventually(
         world,
         repo_name,
         artefact,
         view,
+        state_scope,
         "become empty or zero-count",
         testlens_payload_is_empty_or_zero,
     )?;
@@ -833,8 +846,9 @@ pub fn assert_testlens_includes_failing_test(
     repo_name: &str,
     artefact: &str,
     view: &str,
+    state_scope: &str,
 ) -> Result<()> {
-    let value = run_testlens_query(world, repo_name, artefact, view)?;
+    let value = run_testlens_query(world, repo_name, artefact, view, state_scope)?;
     let tests = value
         .get("covering_tests")
         .and_then(serde_json::Value::as_array)

--- a/bitloops/tests/qat_support/steps/mod.rs
+++ b/bitloops/tests/qat_support/steps/mod.rs
@@ -478,7 +478,7 @@ pub fn collection() -> Collection<QatWorld> {
         .then(
             None,
             regex(
-                r#"^(?:TestHarness|TestLens) query for \"([^\"]+)\" at (?:latest commit|current workspace state) with view \"([^\"]+)\" returns results in (\S+)$"#,
+                r#"^(?:TestHarness|TestLens) query for \"([^\"]+)\" at (latest commit|current workspace state) with view \"([^\"]+)\" returns results in (\S+)$"#,
             ),
             step_fn(then_testlens_query_returns_results),
         )
@@ -502,14 +502,14 @@ pub fn collection() -> Collection<QatWorld> {
         .then(
             None,
             regex(
-                r#"^(?:TestHarness|TestLens) query for \"([^\"]+)\" at (?:latest commit|current workspace state) with view \"([^\"]+)\" returns empty or zero-count in (\S+)$"#,
+                r#"^(?:TestHarness|TestLens) query for \"([^\"]+)\" at (latest commit|current workspace state) with view \"([^\"]+)\" returns empty or zero-count in (\S+)$"#,
             ),
             step_fn(then_testlens_query_empty_or_zero),
         )
         .then(
             None,
             regex(
-                r#"^(?:TestHarness|TestLens) query for \"([^\"]+)\" at (?:latest commit|current workspace state) with view \"([^\"]+)\" includes a failing test in (\S+)$"#,
+                r#"^(?:TestHarness|TestLens) query for \"([^\"]+)\" at (latest commit|current workspace state) with view \"([^\"]+)\" includes a failing test in (\S+)$"#,
             ),
             step_fn(then_testlens_includes_failing_test),
         )

--- a/bitloops/tests/qat_support/steps/then.rs
+++ b/bitloops/tests/qat_support/steps/then.rs
@@ -406,11 +406,18 @@ pub(super) fn then_testlens_query_returns_results(
 ) -> LocalBoxFuture<'_, ()> {
     Box::pin(async move {
         let artefact = ctx.matches[1].1.clone();
-        let view = ctx.matches[2].1.clone();
-        let repo_name = ctx.matches[3].1.clone();
+        let state_scope = ctx.matches[2].1.clone();
+        let view = ctx.matches[3].1.clone();
+        let repo_name = ctx.matches[4].1.clone();
         run_step(
             "TestHarness query returns results",
-            helpers::assert_testlens_query_returns_results(world, &repo_name, &artefact, &view),
+            helpers::assert_testlens_query_returns_results(
+                world,
+                &repo_name,
+                &artefact,
+                &view,
+                &state_scope,
+            ),
         );
     })
 }
@@ -457,11 +464,18 @@ pub(super) fn then_testlens_query_empty_or_zero(
 ) -> LocalBoxFuture<'_, ()> {
     Box::pin(async move {
         let artefact = ctx.matches[1].1.clone();
-        let view = ctx.matches[2].1.clone();
-        let repo_name = ctx.matches[3].1.clone();
+        let state_scope = ctx.matches[2].1.clone();
+        let view = ctx.matches[3].1.clone();
+        let repo_name = ctx.matches[4].1.clone();
         run_step(
             "TestHarness query returns empty or zero-count",
-            helpers::assert_testlens_query_empty_or_zero(world, &repo_name, &artefact, &view),
+            helpers::assert_testlens_query_empty_or_zero(
+                world,
+                &repo_name,
+                &artefact,
+                &view,
+                &state_scope,
+            ),
         );
     })
 }
@@ -472,11 +486,18 @@ pub(super) fn then_testlens_includes_failing_test(
 ) -> LocalBoxFuture<'_, ()> {
     Box::pin(async move {
         let artefact = ctx.matches[1].1.clone();
-        let view = ctx.matches[2].1.clone();
-        let repo_name = ctx.matches[3].1.clone();
+        let state_scope = ctx.matches[2].1.clone();
+        let view = ctx.matches[3].1.clone();
+        let repo_name = ctx.matches[4].1.clone();
         run_step(
             "TestHarness query includes a failing test",
-            helpers::assert_testlens_includes_failing_test(world, &repo_name, &artefact, &view),
+            helpers::assert_testlens_includes_failing_test(
+                world,
+                &repo_name,
+                &artefact,
+                &view,
+                &state_scope,
+            ),
         );
     })
 }

--- a/documentation/contributors/development-setup.md
+++ b/documentation/contributors/development-setup.md
@@ -72,6 +72,8 @@ cargo dev-test-full
 cargo dev-coverage
 ```
 
+These test lanes are executed via `cargo-nextest`.
+
 `duckdb-bundled` is now opt-in. Use `cargo dev-check-bundled`/`cargo dev-build-bundled` when you need bundled DuckDB (for example offline or unsupported targets).
 
 ## Test Coverage
@@ -82,7 +84,18 @@ We use `cargo-llvm-cov` for coverage. Install it:
 cargo install cargo-llvm-cov
 ```
 
+Install `cargo-nextest` as well. On macOS, prefer:
+
+```bash
+brew install cargo-nextest
+```
+
+For other platforms, use the official installation guide:
+[https://nexte.st/docs/installation/](https://nexte.st/docs/installation/)
+
 The project maintains a coverage baseline in `.coverage-baseline.jsonl` (under `bitloops/`). CI refreshes the baseline metadata on pushes to `develop`, and coverage stays separate from the blocking pull-request gates. To enforce the 5% tolerance locally before merging, use `bash scripts/check-dev.sh --full`.
+
+If the repo gains doctests in future, keep those on `cargo test --doc`; `cargo-nextest` does not support doctests.
 
 Shell helpers in `bitloops/scripts/` are kept for CI/back-compat purposes, but local workflows should use Cargo `dev-*` commands.
 

--- a/documentation/contributors/guides/language-adapter-contributing.md
+++ b/documentation/contributors/guides/language-adapter-contributing.md
@@ -99,8 +99,8 @@ Recommended targeted commands:
 
 ```bash
 cargo check -p bitloops
-cargo test -p bitloops --lib host::devql::mapping_tests -- --nocapture
-cargo test -p bitloops --lib extraction_<your_language> -- --nocapture
+cargo nextest run -p bitloops --lib --no-capture -- host::devql::mapping_tests --exact
+cargo nextest run -p bitloops --lib --no-capture -- extraction_<your_language> --exact
 ```
 
 ## 6) Where registration happens

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -27,7 +27,6 @@ const MERGE_SMOKE_TARGETS: &[&str] = &[
     "graphql_smoke",
 ];
 const DEFAULT_LCOV_PATH: &str = "bitloops/target/llvm-cov.info";
-const DEFAULT_FAST_TEST_THREADS: u64 = 8;
 
 fn main() {
     let mut args = env::args().skip(1);
@@ -131,15 +130,13 @@ fn run_test_lane(lane: &str) -> Result<(), String> {
     let workspace_root = workspace_root()?;
     let lane_commands = test_lane_command_groups(lane)?;
     let test_threads = test_threads_for_lane(lane)?;
+    let profile_args = nextest_profile_args();
 
     if should_sign() {
         let mut compiled_binaries = BTreeSet::new();
         for lane_args in &lane_commands {
-            let mut compile_args = lane_args.clone();
-            compile_args.push("--no-run".to_string());
-            compile_args.push("--message-format=json-render-diagnostics".to_string());
-
-            for binary in collect_test_binaries(&workspace_root, &compile_args)? {
+            let list_args = nextest_list_args(lane_args, &profile_args)?;
+            for binary in collect_test_binaries(&workspace_root, &list_args)? {
                 compiled_binaries.insert(binary);
             }
         }
@@ -150,13 +147,11 @@ fn run_test_lane(lane: &str) -> Result<(), String> {
 
     for lane_args in lane_commands {
         let mut run_args = lane_args;
-        run_args.push("--".to_string());
-        run_args.push("--format=terse".to_string());
+        run_args.extend(profile_args.clone());
         if let Some(test_threads) = test_threads {
             run_args.push(format!("--test-threads={test_threads}"));
         }
-        let mut command = vec!["cargo".to_string()];
-        command.extend(run_args.iter().cloned());
+        let command = prepend_cargo(&run_args);
         run_command_owned(
             &workspace_root,
             &format!("cargo {}", run_args.join(" ")),
@@ -267,15 +262,46 @@ fn llvm_cov_report_html_display_command(html_dir: &str) -> String {
     )
 }
 
-fn parse_test_binary_json_line(line: &str) -> Option<PathBuf> {
-    let json = serde_json::from_str::<Value>(line).ok()?;
-    let executable = json.get("executable")?.as_str()?;
-    let is_test_profile = json.get("profile")?.get("test")?.as_bool().unwrap_or(false);
-    if is_test_profile {
-        Some(PathBuf::from(executable))
-    } else {
-        None
+fn collect_nextest_binary_paths(value: &Value, out: &mut BTreeSet<PathBuf>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if matches!(key.as_str(), "binary-path" | "binary_path")
+                    && let Some(path) = child.as_str()
+                {
+                    out.insert(PathBuf::from(path));
+                }
+                collect_nextest_binary_paths(child, out);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                collect_nextest_binary_paths(child, out);
+            }
+        }
+        _ => {}
     }
+}
+
+fn parse_nextest_binary_paths(output: &str) -> Vec<PathBuf> {
+    let mut binaries = BTreeSet::new();
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    if let Ok(json) = serde_json::from_str::<Value>(trimmed) {
+        collect_nextest_binary_paths(&json, &mut binaries);
+        return binaries.into_iter().collect();
+    }
+
+    for line in trimmed.lines() {
+        if let Ok(json) = serde_json::from_str::<Value>(line) {
+            collect_nextest_binary_paths(&json, &mut binaries);
+        }
+    }
+
+    binaries.into_iter().collect()
 }
 
 fn otool_list_output_links_libduckdb(text: &str) -> bool {
@@ -512,10 +538,10 @@ fn print_coverage_comparison(
 
 fn base_test_lane_args() -> Vec<String> {
     vec![
-        "test".to_string(),
+        "nextest".to_string(),
+        "run".to_string(),
         "--manifest-path".to_string(),
         BITLOOPS_MANIFEST.to_string(),
-        "--no-fail-fast".to_string(),
         "--no-default-features".to_string(),
     ]
 }
@@ -579,7 +605,7 @@ fn test_threads_for_lane(lane: &str) -> Result<Option<u64>, String> {
         Ok(value) => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
-                return Ok(Some(DEFAULT_FAST_TEST_THREADS));
+                return Ok(None);
             }
 
             let parsed = trimmed
@@ -590,8 +616,37 @@ fn test_threads_for_lane(lane: &str) -> Result<Option<u64>, String> {
             }
             Ok(Some(parsed))
         }
-        Err(_) => Ok(Some(DEFAULT_FAST_TEST_THREADS)),
+        Err(_) => Ok(None),
     }
+}
+
+fn nextest_profile_args() -> Vec<String> {
+    if env::var("GITHUB_ACTIONS")
+        .map(|value| value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        vec!["--profile".to_string(), "ci".to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn nextest_list_args(run_args: &[String], profile_args: &[String]) -> Result<Vec<String>, String> {
+    let mut args = run_args.to_vec();
+    if args.get(0).map(String::as_str) != Some("nextest")
+        || args.get(1).map(String::as_str) != Some("run")
+    {
+        return Err("expected nextest run arguments for test lane".to_string());
+    }
+    args[1] = "list".to_string();
+    args.extend_from_slice(profile_args);
+    args.push("--list-type".to_string());
+    args.push("binaries-only".to_string());
+    args.push("--message-format".to_string());
+    args.push("json".to_string());
+    args.push("--cargo-message-format".to_string());
+    args.push("json-render-diagnostics".to_string());
+    Ok(args)
 }
 
 fn collect_test_binaries(cwd: &Path, args: &[String]) -> Result<Vec<PathBuf>, String> {
@@ -603,20 +658,15 @@ fn collect_test_binaries(cwd: &Path, args: &[String]) -> Result<Vec<PathBuf>, St
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .output()
-        .map_err(|err| format!("failed to start cargo test compile step: {err}"))?;
+        .map_err(|err| format!("failed to start cargo nextest list step: {err}"))?;
 
     if !output.status.success() {
-        return Err("command failed: cargo test compile step".to_string());
+        return Err("command failed: cargo nextest list step".to_string());
     }
 
-    let mut binaries = BTreeSet::new();
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        if let Some(path) = parse_test_binary_json_line(line) {
-            binaries.insert(path);
-        }
-    }
-
-    Ok(binaries.into_iter().collect())
+    Ok(parse_nextest_binary_paths(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
 }
 
 fn should_sign() -> bool {
@@ -982,6 +1032,7 @@ fn is_gitignored(file: &Path, git_toplevel: Option<&Path>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::env;
     use std::fs;
     use std::io::Write;
@@ -991,15 +1042,15 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        BITLOOPS_MANIFEST, DEFAULT_FAST_TEST_THREADS, DEFAULT_LCOV_PATH, MERGE_SMOKE_TARGETS,
-        SLOW_TEST_TARGETS, collect_rs_files, count_lines, env_u64, is_regression, is_test_file,
-        llvm_cov_lcov_cargo_args, llvm_cov_lcov_display_command, llvm_cov_report_html_cargo_args,
-        llvm_cov_report_html_display_command, otool_list_output_links_libduckdb,
-        otool_load_output_contains_rpath, parse_compare_options, parse_coverage_all_paths,
-        parse_f64_flag, parse_lcov_metrics, parse_lcov_path, parse_test_binary_json_line,
-        parse_u64_value, percentage, prepend_cargo, read_lcov_metrics, resolve_workspace_path,
-        run_file_size_check, test_lane_args, test_lane_command_groups, test_threads_for_lane,
-        unknown_coverage_subcommand_error, workspace_root,
+        BITLOOPS_MANIFEST, DEFAULT_LCOV_PATH, MERGE_SMOKE_TARGETS, SLOW_TEST_TARGETS,
+        collect_nextest_binary_paths, collect_rs_files, count_lines, env_u64, is_regression,
+        is_test_file, llvm_cov_lcov_cargo_args, llvm_cov_lcov_display_command,
+        llvm_cov_report_html_cargo_args, llvm_cov_report_html_display_command,
+        otool_list_output_links_libduckdb, otool_load_output_contains_rpath, parse_compare_options,
+        parse_coverage_all_paths, parse_f64_flag, parse_lcov_metrics, parse_lcov_path,
+        parse_nextest_binary_paths, parse_u64_value, percentage, prepend_cargo, read_lcov_metrics,
+        resolve_workspace_path, run_file_size_check, test_lane_args, test_lane_command_groups,
+        test_threads_for_lane, unknown_coverage_subcommand_error, workspace_root,
     };
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -1181,16 +1232,13 @@ mod tests {
     }
 
     #[test]
-    fn fast_lane_uses_eight_threads_by_default_and_allows_override() {
+    fn fast_lane_uses_profile_defaults_and_allows_override() {
         let _g = ENV_LOCK.lock().expect("env lock");
         unsafe {
             env::remove_var("BITLOOPS_TEST_THREADS");
         }
 
-        assert_eq!(
-            test_threads_for_lane("fast").unwrap(),
-            Some(DEFAULT_FAST_TEST_THREADS)
-        );
+        assert_eq!(test_threads_for_lane("fast").unwrap(), None);
         assert_eq!(test_threads_for_lane("smoke").unwrap(), None);
 
         unsafe {
@@ -1213,13 +1261,55 @@ mod tests {
     }
 
     #[test]
+    fn nextest_profile_args_use_ci_on_github_actions() {
+        let _g = ENV_LOCK.lock().expect("env lock");
+        unsafe {
+            env::remove_var("GITHUB_ACTIONS");
+        }
+        assert!(super::nextest_profile_args().is_empty());
+
+        unsafe {
+            env::set_var("GITHUB_ACTIONS", "true");
+        }
+        assert_eq!(
+            super::nextest_profile_args(),
+            vec!["--profile".to_string(), "ci".to_string()]
+        );
+
+        unsafe {
+            env::remove_var("GITHUB_ACTIONS");
+        }
+    }
+
+    #[test]
+    fn nextest_list_args_swap_run_for_list_and_append_machine_output() {
+        let args = vec![
+            "nextest".to_string(),
+            "run".to_string(),
+            "--manifest-path".to_string(),
+            BITLOOPS_MANIFEST.to_string(),
+            "--no-default-features".to_string(),
+            "--lib".to_string(),
+        ];
+        let out = super::nextest_list_args(&args, &["--profile".to_string(), "ci".to_string()])
+            .expect("list args");
+        assert_eq!(out[0], "nextest");
+        assert_eq!(out[1], "list");
+        assert!(out.contains(&"--profile".to_string()));
+        assert!(out.contains(&"ci".to_string()));
+        assert!(out.contains(&"--list-type".to_string()));
+        assert!(out.contains(&"binaries-only".to_string()));
+        assert!(out.contains(&"json-render-diagnostics".to_string()));
+    }
+
+    #[test]
     fn test_lane_args_builds_expected_fragments() {
         let base = || {
             vec![
-                "test".to_string(),
+                "nextest".to_string(),
+                "run".to_string(),
                 "--manifest-path".to_string(),
                 BITLOOPS_MANIFEST.to_string(),
-                "--no-fail-fast".to_string(),
                 "--no-default-features".to_string(),
             ]
         };
@@ -1434,18 +1524,42 @@ mod tests {
     }
 
     #[test]
-    fn parse_test_binary_json_line_filters_executable() {
-        let line = r#"{"executable":"/tmp/t","profile":{"test":true}}"#;
+    fn parse_nextest_binary_paths_extracts_binary_paths() {
+        let line =
+            r#"{"rust-suites":[{"binary-id":"bitloops::tests/graphql","binary-path":"/tmp/t"}]}"#;
         assert_eq!(
-            parse_test_binary_json_line(line),
-            Some(PathBuf::from("/tmp/t"))
+            parse_nextest_binary_paths(line),
+            vec![PathBuf::from("/tmp/t")]
         );
-        assert!(parse_test_binary_json_line(r#"{"profile":{"test":true}}"#).is_none());
         assert!(
-            parse_test_binary_json_line(r#"{"executable":"/x","profile":{"test":false}}"#)
-                .is_none()
+            parse_nextest_binary_paths(
+                r#"{"rust-suites":[{"binary_path":"/tmp/a"},{"binary-path":"/tmp/b"}]}"#
+            )
+            .contains(&PathBuf::from("/tmp/a"))
         );
-        assert!(parse_test_binary_json_line("not json").is_none());
+        assert_eq!(
+            parse_nextest_binary_paths("not json"),
+            Vec::<PathBuf>::new()
+        );
+    }
+
+    #[test]
+    fn collect_nextest_binary_paths_walks_nested_json() {
+        let json = serde_json::json!({
+            "outer": {
+                "binary-path": "/tmp/one",
+                "items": [
+                    {"binary_path": "/tmp/two"},
+                    {"ignored": true}
+                ]
+            }
+        });
+        let mut out = BTreeSet::new();
+        collect_nextest_binary_paths(&json, &mut out);
+        assert_eq!(
+            out.into_iter().collect::<Vec<_>>(),
+            vec![PathBuf::from("/tmp/one"), PathBuf::from("/tmp/two")]
+        );
     }
 
     #[test]


### PR DESCRIPTION
This pull request focuses on improving test isolation, locale handling, and build/test workflow consistency for the `bitloops` project. The most significant changes include enhancing test hermeticity, ensuring locale-robustness in scripts, and simplifying CI build commands.

**Test isolation and reliability improvements:**
* All tests in `bitloops/src/adapters/agents/codex/hooks_tests.rs` now use a helper (`with_managed_hook_env_cleared`) to ensure the environment variable `ENV_DAEMON_CONFIG_PATH_OVERRIDE` is cleared during each test, preventing interference from parent process environment settings. [[1]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R4) [[2]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R86-R92) [[3]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R148-R153) [[4]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R164-R169) [[5]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R181-R186) [[6]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R200-R205) [[7]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R217-R222) [[8]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R256-R261) [[9]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R342-R347) [[10]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R430-R445) [[11]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R460-R465) [[12]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R538-R543) [[13]](diffhunk://#diff-2ded7456baa44e7679e26300c9cb97498b56ce74d72fa88bc720c483c9255917R581)
* The integration test runner in `bitloops/tests/performance/semantic_clones_ann_ab.rs` now explicitly removes certain environment variables before running scripts, keeping tests hermetic and unaffected by parent process overrides.

**Locale handling and robustness:**
* The `speedup_percent` function in `bitloops/scripts/qa/semantic_clones_ann_ab.sh` now forces the `LC_ALL=C` locale for `awk`, ensuring decimal points are used in output regardless of the system locale.
* A new test verifies that the ANN AB script emits valid JSON with decimal points for speedup percentages even under locales that use decimal commas (e.g., `de_DE.UTF-8`).

**CI workflow and build/test command consistency:**
* The CI workflow in `.github/workflows/ci.yml` now consistently uses the `-p bitloops` flag instead of `--manifest-path bitloops/Cargo.toml` for `cargo` and `cross` commands, simplifying invocation and reducing path-related errors. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL56-R56) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL127-R151)
* Output paths for smoke tests in the CI workflow have been updated to match the new build output structure (`./target/...` instead of `./bitloops/target/...`).