### PR TITLE
Stage DuckDB runtimes and harden QAT daemon teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,17 @@ jobs:
         if: ${{ !contains(matrix.target, 'unknown-linux-musl') }}
         run: cargo build --release -p bitloops --target ${{ matrix.target }}
 
+      - name: Stage DuckDB runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $binDir = "target/${{ matrix.target }}/release"
+          $dll = Join-Path $binDir "deps/duckdb.dll"
+          if (-not (Test-Path $dll)) {
+            throw "Missing expected DuckDB runtime: $dll"
+          }
+          Copy-Item $dll (Join-Path $binDir "duckdb.dll") -Force
+
       - name: Smoke test (Unix)
         if: runner.os != 'Windows' && matrix.target != 'aarch64-unknown-linux-musl'
         run: ./target/${{ matrix.target }}/release/bitloops --version
@@ -151,7 +162,12 @@ jobs:
         if: matrix.target == 'aarch64-pc-windows-msvc'
         shell: pwsh
         run: |
-          $path = "target/${{ matrix.target }}/release/bitloops.exe"
-          if (-not (Test-Path $path)) {
-            throw "Missing expected binary: $path"
+          $binDir = "target/${{ matrix.target }}/release"
+          $exe = Join-Path $binDir "bitloops.exe"
+          $dll = Join-Path $binDir "duckdb.dll"
+          if (-not (Test-Path $exe)) {
+            throw "Missing expected binary: $exe"
+          }
+          if (-not (Test-Path $dll)) {
+            throw "Missing expected DuckDB runtime: $dll"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,28 @@ jobs:
         if: ${{ !contains(matrix.target, 'unknown-linux-musl') }}
         run: cargo build --release --target ${{ matrix.target }} -p bitloops
 
+      - name: Stage DuckDB runtime (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          bin_dir="target/${{ matrix.target }}/release"
+          dylib="$bin_dir/deps/libduckdb.dylib"
+          if [ ! -f "$dylib" ]; then
+            echo "Missing expected DuckDB runtime: $dylib" >&2
+            exit 1
+          fi
+          cp "$dylib" "$bin_dir/libduckdb.dylib"
+
+      - name: Stage DuckDB runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $binDir = "target/${{ matrix.target }}/release"
+          $dll = Join-Path $binDir "deps/duckdb.dll"
+          if (-not (Test-Path $dll)) {
+            throw "Missing expected DuckDB runtime: $dll"
+          }
+          Copy-Item $dll (Join-Path $binDir "duckdb.dll") -Force
+
       - name: Smoke test (Unix)
         if: runner.os != 'Windows' && matrix.target != 'aarch64-unknown-linux-musl'
         run: ./target/${{ matrix.target }}/release/bitloops --version
@@ -91,8 +113,11 @@ jobs:
         if: matrix.target == 'aarch64-pc-windows-msvc'
         shell: pwsh
         run: |
-          $path = "target/${{ matrix.target }}/release/bitloops.exe"
-          if (-not (Test-Path $path)) { throw "Missing expected binary: $path" }
+          $binDir = "target/${{ matrix.target }}/release"
+          $exe = Join-Path $binDir "bitloops.exe"
+          $dll = Join-Path $binDir "duckdb.dll"
+          if (-not (Test-Path $exe)) { throw "Missing expected binary: $exe" }
+          if (-not (Test-Path $dll)) { throw "Missing expected DuckDB runtime: $dll" }
 
       - name: Import Apple signing certificate
         if: runner.os == 'macOS'
@@ -126,12 +151,17 @@ jobs:
         run: |
           codesign --force --options runtime --timestamp \
             --sign "$APPLE_SIGNING_IDENTITY" \
+            "target/${{ matrix.target }}/release/libduckdb.dylib"
+          codesign --force --options runtime --timestamp \
+            --sign "$APPLE_SIGNING_IDENTITY" \
             "target/${{ matrix.target }}/release/bitloops"
 
       - name: Verify macOS signature
         if: runner.os == 'macOS'
         run: |
+          codesign --verify --verbose=4 "target/${{ matrix.target }}/release/libduckdb.dylib"
           codesign --verify --verbose=4 "target/${{ matrix.target }}/release/bitloops"
+          codesign --display --verbose=4 "target/${{ matrix.target }}/release/libduckdb.dylib"
           codesign --display --verbose=4 "target/${{ matrix.target }}/release/bitloops"
           spctl -a -t exec -vv "target/${{ matrix.target }}/release/bitloops" || true
 
@@ -148,6 +178,7 @@ jobs:
         run: |
           mkdir -p dist/package
           cp "target/${{ matrix.target }}/release/bitloops" dist/package/bitloops
+          cp "target/${{ matrix.target }}/release/libduckdb.dylib" dist/package/libduckdb.dylib
           ditto -c -k --keepParent dist/package "dist/bitloops-${{ matrix.target }}.zip"
 
       - name: Restore App Store Connect key
@@ -175,6 +206,7 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path dist/package -Force | Out-Null
           Copy-Item "target/${{ matrix.target }}/release/bitloops.exe" "dist/package/bitloops.exe" -Force
+          Copy-Item "target/${{ matrix.target }}/release/duckdb.dll" "dist/package/duckdb.dll" -Force
           Compress-Archive -Path dist/package/* -DestinationPath dist/bitloops-${{ matrix.target }}.zip
 
       - name: Upload build artifact

--- a/bitloops/build.rs
+++ b/bitloops/build.rs
@@ -79,6 +79,30 @@ fn emit_build_metadata() {
     println!("cargo:rustc-env=BITLOOPS_BUILD_DATE={build_date}");
 }
 
+fn target_os() -> Option<String> {
+    env::var("CARGO_CFG_TARGET_OS").ok()
+}
+
+fn emit_macos_runtime_rpaths() {
+    if target_os().as_deref() != Some("macos") {
+        return;
+    }
+
+    // `libduckdb-sys` can place the downloaded runtime in `target/<profile>/deps`,
+    // but its own linker args do not propagate to the final `bitloops` binary on
+    // macOS. Teach the executable to look in both the Cargo build layout and the
+    // installed layout (`cargo dev-install` stages the dylib next to the binary).
+    for rpath in ["@executable_path", "@executable_path/deps"] {
+        println!("cargo:rustc-link-arg-bin=bitloops=-rpath");
+        println!("cargo:rustc-link-arg-bin=bitloops={rpath}");
+    }
+
+    // Test executables live under `target/<profile>/deps`, alongside the copied
+    // DuckDB dylib, so the executable directory itself is sufficient there.
+    println!("cargo:rustc-link-arg-tests=-rpath");
+    println!("cargo:rustc-link-arg-tests=@executable_path");
+}
+
 fn main() {
     println!("cargo:rerun-if-changed={DASHBOARD_CONFIG_PATH}");
     println!("cargo:rerun-if-changed=build.rs");
@@ -90,6 +114,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BITLOOPS_BUILD_DATE");
 
     emit_build_metadata();
+    emit_macos_runtime_rpaths();
 
     let raw = fs::read_to_string(DASHBOARD_CONFIG_PATH).unwrap_or_else(|err| {
         panic!(

--- a/bitloops/scripts/qa/semantic_clones_ann_ab.sh
+++ b/bitloops/scripts/qa/semantic_clones_ann_ab.sh
@@ -212,6 +212,10 @@ resolve_binary_path() {
     echo "$binary"
     return 0
   fi
+  if [[ -n "${!MOCK_ENV:-}" && "${!MOCK_ENV}" != "0" ]]; then
+    echo "$binary"
+    return 0
+  fi
   command -v "$binary"
 }
 

--- a/bitloops/src/daemon/types.rs
+++ b/bitloops/src/daemon/types.rs
@@ -10,7 +10,7 @@ pub(super) const GLOBAL_SUPERVISOR_SERVICE_NAME: &str = "com.bitloops.daemon";
 pub(crate) const SUPERVISOR_RUNTIME_STATE_FILE_NAME: &str = "supervisor-runtime.json";
 pub(super) const SUPERVISOR_SERVICE_STATE_FILE_NAME: &str = "supervisor-service.json";
 pub(super) const READY_TIMEOUT: Duration = Duration::from_secs(20);
-pub(super) const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+pub(super) const STOP_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/bitloops/tests/qat_support/helpers/core.rs
+++ b/bitloops/tests/qat_support/helpers/core.rs
@@ -88,6 +88,14 @@ pub fn ensure_daemon_for_scenario(world: &mut QatWorld) -> Result<()> {
     );
 }
 
+fn error_chain_contains_not_found(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::NotFound)
+    })
+}
+
 pub fn stop_daemon_for_scenario(world: &mut QatWorld) -> Result<()> {
     if world.run_dir.is_none() || world.repo_dir.is_none() || world.terminal_log_path.is_none() {
         return Ok(());
@@ -117,6 +125,12 @@ pub fn stop_daemon_for_scenario(world: &mut QatWorld) -> Result<()> {
                 stop_error = Some(anyhow!(
                     "bitloops daemon stop returned non-zero\nstdout:\n{stdout}\nstderr:\n{stderr}"
                 ));
+            }
+            Err(err) if error_chain_contains_not_found(&err) => {
+                append_world_log(
+                    world,
+                    "Daemon stop skipped because the bitloops binary is no longer present.\n",
+                )?;
             }
             Err(err) => {
                 append_world_log(world, &format!("Daemon stop failed: {err:#}\n"))?;

--- a/bitloops/tests/qat_support/helpers/tests.rs
+++ b/bitloops/tests/qat_support/helpers/tests.rs
@@ -119,6 +119,28 @@ fn text_has_missing_production_artefacts_error_detects_relational_materializatio
 }
 
 #[test]
+fn error_chain_contains_not_found_detects_missing_binary_errors() {
+    let err = anyhow::Error::from(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "No such file or directory",
+    ))
+    .context("executing bitloops daemon stop");
+
+    assert!(error_chain_contains_not_found(&err));
+}
+
+#[test]
+fn error_chain_contains_not_found_ignores_other_io_errors() {
+    let err = anyhow::Error::from(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "Permission denied",
+    ))
+    .context("executing bitloops daemon stop");
+
+    assert!(!error_chain_contains_not_found(&err));
+}
+
+#[test]
 fn build_init_bitloops_args_defaults_to_sync_false_when_unspecified() {
     let args = build_init_bitloops_args("claude-code", false, None);
     assert_eq!(


### PR DESCRIPTION
## Summary

This pull request improves cross-platform packaging and testing of the DuckDB runtime, enhances macOS runtime handling, and increases robustness in test helpers. The changes ensure that the DuckDB dynamic library is correctly staged, signed, and packaged for both Windows and macOS targets, and improve error handling in test scenarios where binaries may be missing.

**Cross-platform DuckDB runtime staging and packaging:**

* Added steps in `.github/workflows/ci.yml` and `.github/workflows/release.yml` to stage the DuckDB dynamic library (`duckdb.dll` on Windows, `libduckdb.dylib` on macOS) alongside the main binary after build, ensuring it is present for packaging and testing. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR136-R146) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R76-R97)
* Updated packaging steps to include the DuckDB runtime in release archives for both Windows and macOS, and added checks to verify its presence before proceeding. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L94-R120) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R181) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R209) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL154-R172)

**macOS runtime and code signing improvements:**

* Modified the build script (`bitloops/build.rs`) to add appropriate runtime search paths (`rpath`) for the DuckDB dylib, improving out-of-the-box execution on macOS. [[1]](diffhunk://#diff-b5237ddd614c2c2960646a1224836921fab8cbc0f48af41db1d4586653f709e1R82-R105) [[2]](diffhunk://#diff-b5237ddd614c2c2960646a1224836921fab8cbc0f48af41db1d4586653f709e1R117)
* Updated release workflow to sign and verify the DuckDB dylib with Apple's codesign utility, ensuring compliance with macOS security requirements.

**Test robustness and error handling:**

* Enhanced the test helper in `bitloops/tests/qat_support/helpers/core.rs` to gracefully handle cases where the `bitloops` binary is missing during daemon stop, logging the event instead of failing the test. [[1]](diffhunk://#diff-c12927bcd5b668c03cb5c1183ad3ea0fd3cc379248af08ae4b8fea55e6756749R91-R98) [[2]](diffhunk://#diff-c12927bcd5b668c03cb5c1183ad3ea0fd3cc379248af08ae4b8fea55e6756749R129-R134)
* Added tests to verify correct detection of missing binary errors.

**Miscellaneous:**

* Increased the daemon stop timeout from 10 to 20 seconds to allow more time for clean shutdowns.
* Improved a QA script to support mock environments when resolving the binary path.