### PR TITLE
Fix tests

### DIFF
--- a/bitloops/src/cli/rewind.rs
+++ b/bitloops/src/cli/rewind.rs
@@ -302,6 +302,7 @@ fn perform_full_rewind(repo_root: &Path, point: &RewindPoint) -> Result<()> {
 
 #[derive(Debug, Clone)]
 struct TreeEntry {
+    #[cfg(unix)]
     mode: String,
     hash: String,
     path: String,
@@ -362,6 +363,7 @@ fn list_checkpoint_tree_entries(repo_root: &Path, commit_id: &str) -> Result<Vec
         }
 
         entries.push(TreeEntry {
+            #[cfg(unix)]
             mode: mode.to_string(),
             hash: hash.to_string(),
             path: path.to_string(),

--- a/bitloops/src/host/devql.rs
+++ b/bitloops/src/host/devql.rs
@@ -890,18 +890,21 @@ mod mapping_tests;
 mod core_contract_tests;
 
 #[cfg(test)]
+#[cfg_attr(not(feature = "slow-tests"), allow(dead_code))]
 #[path = "devql/tests/cucumber_world.rs"]
 mod cucumber_world;
 
 #[cfg(test)]
+#[cfg_attr(not(feature = "slow-tests"), allow(dead_code))]
 #[path = "devql/tests/cucumber_steps/mod.rs"]
 mod cucumber_steps;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "slow-tests"))]
 #[path = "devql/tests/cucumber_bdd.rs"]
 mod cucumber_bdd;
 
 #[cfg(test)]
+#[cfg_attr(not(feature = "slow-tests"), allow(dead_code))]
 #[path = "devql/tests/knowledge_support.rs"]
 mod knowledge_support;
 

--- a/bitloops/tests/qat_support/helpers/core.rs
+++ b/bitloops/tests/qat_support/helpers/core.rs
@@ -34,6 +34,65 @@ pub fn ensure_bitloops_repo_name(repo_name: &str) -> Result<()> {
     Ok(())
 }
 
+const QAT_EVENTUAL_TIMEOUT_ENV: &str = "BITLOOPS_QAT_EVENTUAL_TIMEOUT_SECS";
+const DEFAULT_QAT_EVENTUAL_TIMEOUT_SECS: u64 = 15;
+const QAT_EVENTUAL_POLL_INTERVAL_MILLIS: u64 = 250;
+
+fn qat_eventual_timeout() -> StdDuration {
+    parse_timeout_seconds(
+        std::env::var(QAT_EVENTUAL_TIMEOUT_ENV).ok().as_deref(),
+        DEFAULT_QAT_EVENTUAL_TIMEOUT_SECS,
+    )
+}
+
+fn qat_eventual_poll_interval() -> StdDuration {
+    StdDuration::from_millis(QAT_EVENTUAL_POLL_INTERVAL_MILLIS)
+}
+
+fn wait_for_qat_condition<T, Observe, Ready, Describe>(
+    timeout: StdDuration,
+    poll_interval: StdDuration,
+    expected: &str,
+    mut observe: Observe,
+    is_ready: Ready,
+    describe: Describe,
+) -> Result<T>
+where
+    Observe: FnMut() -> Result<T>,
+    Ready: Fn(&T) -> bool,
+    Describe: Fn(&T) -> String,
+{
+    let started = Instant::now();
+    let mut attempts = 0_usize;
+    let mut last_observation = String::from("none");
+
+    loop {
+        attempts += 1;
+        match observe() {
+            Ok(value) => {
+                let summary = describe(&value);
+                if is_ready(&value) {
+                    return Ok(value);
+                }
+                last_observation = format!("value: {summary}");
+            }
+            Err(err) => {
+                last_observation = format!("error: {err:#}");
+            }
+        }
+
+        if started.elapsed() >= timeout {
+            bail!(
+                "timed out after {}s waiting for {expected}; attempts={attempts}; last observation={}",
+                timeout.as_secs(),
+                last_observation
+            );
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+}
+
 pub fn ensure_daemon_for_scenario(world: &mut QatWorld) -> Result<()> {
     stop_daemon_for_scenario(world).ok();
 
@@ -1695,9 +1754,17 @@ pub fn assert_agent_session_exists_for_repo(
 
 pub fn assert_checkpoint_mapping_exists_for_repo(world: &QatWorld, repo_name: &str) -> Result<()> {
     ensure_bitloops_repo_name(repo_name)?;
-    let mappings =
-        with_scenario_app_env(world, || read_commit_checkpoint_mappings(world.repo_dir()))
-            .context("reading Bitloops checkpoint mappings")?;
+    let mappings = wait_for_qat_condition(
+        qat_eventual_timeout(),
+        qat_eventual_poll_interval(),
+        "Bitloops checkpoint mappings to be persisted",
+        || {
+            with_scenario_app_env(world, || read_commit_checkpoint_mappings(world.repo_dir()))
+                .context("reading Bitloops checkpoint mappings")
+        },
+        |mappings| !mappings.is_empty(),
+        |mappings| format!("mappings={}", mappings.len()),
+    )?;
     if mappings.is_empty() && claude_fallback_marker_exists(world) {
         append_world_log(
             world,
@@ -1724,9 +1791,17 @@ pub fn assert_checkpoint_mapping_count_at_least_for_repo(
     min_count: usize,
 ) -> Result<()> {
     ensure_bitloops_repo_name(repo_name)?;
-    let mappings =
-        with_scenario_app_env(world, || read_commit_checkpoint_mappings(world.repo_dir()))
-            .context("reading Bitloops checkpoint mappings")?;
+    let mappings = wait_for_qat_condition(
+        qat_eventual_timeout(),
+        qat_eventual_poll_interval(),
+        &format!("at least {min_count} Bitloops checkpoint mappings"),
+        || {
+            with_scenario_app_env(world, || read_commit_checkpoint_mappings(world.repo_dir()))
+                .context("reading Bitloops checkpoint mappings")
+        },
+        |mappings| mappings.len() >= min_count,
+        |mappings| format!("mappings={}", mappings.len()),
+    )?;
     if mappings.len() < min_count && claude_fallback_marker_exists(world) {
         append_world_log(
             world,
@@ -1801,7 +1876,14 @@ pub fn assert_devql_artefacts_query_returns_results(
     repo_name: &str,
 ) -> Result<()> {
     ensure_bitloops_repo_name(repo_name)?;
-    let count = count_artefacts_across_source_files(world)?;
+    let count = wait_for_qat_condition(
+        qat_eventual_timeout(),
+        qat_eventual_poll_interval(),
+        "DevQL artefacts query to return results",
+        || count_artefacts_across_source_files(world),
+        |count| *count >= 1,
+        |count| format!("artefacts={count}"),
+    )?;
     world.last_query_result_count = Some(count);
     ensure!(
         count >= 1,

--- a/bitloops/tests/qat_support/helpers/tests.rs
+++ b/bitloops/tests/qat_support/helpers/tests.rs
@@ -534,6 +534,44 @@ fn wait_for_semantic_clone_condition_times_out_with_last_observation() {
 }
 
 #[test]
+fn wait_for_qat_condition_retries_until_ready() {
+    let mut attempts = 0_usize;
+
+    let value = wait_for_qat_condition(
+        StdDuration::from_millis(25),
+        StdDuration::from_millis(1),
+        "checkpoint mappings to be persisted",
+        || {
+            attempts += 1;
+            Ok(attempts)
+        },
+        |attempt| *attempt >= 3,
+        |attempt| format!("attempt={attempt}"),
+    )
+    .expect("eventual wait should succeed");
+
+    assert_eq!(value, 3);
+    assert_eq!(attempts, 3);
+}
+
+#[test]
+fn wait_for_qat_condition_times_out_with_last_observation() {
+    let err = wait_for_qat_condition(
+        StdDuration::from_millis(5),
+        StdDuration::from_millis(1),
+        "DevQL artefacts query to return results",
+        || Ok(0_usize),
+        |count| *count > 0,
+        |count| format!("artefacts={count}"),
+    )
+    .expect_err("eventual wait should time out");
+
+    let message = format!("{err:#}");
+    assert!(message.contains("DevQL artefacts query to return results"));
+    assert!(message.contains("last observation=value: artefacts=0"));
+}
+
+#[test]
 fn clone_query_wait_condition_any_response_accepts_empty_rows() {
     let rows: Vec<serde_json::Value> = Vec::new();
 

--- a/third_party/libduckdb-sys/build.rs
+++ b/third_party/libduckdb-sys/build.rs
@@ -456,25 +456,35 @@ mod build_linked {
         fs::create_dir_all(&download_dir)?;
 
         let archive_path = download_dir.join(archive.archive_name);
-        let lib_marker = download_dir.join(archive.dynamic_lib);
+        let required_artifacts = archive.required_artifacts();
+        let missing_artifacts = required_artifacts
+            .iter()
+            .filter(|artifact| !download_dir.join(artifact).exists())
+            .copied()
+            .collect::<Vec<_>>();
 
-        if lib_marker.exists() {
+        if missing_artifacts.is_empty() {
             println!("cargo:warning=Reusing libduckdb from {}", download_dir.display());
         } else {
             let client = http_client()?;
             let url = archive.download_url(&version);
             ensure_libduckdb(&client, &url, &archive_path)?;
             extract_libduckdb(&archive_path, &download_dir)?;
-            if !lib_marker.exists() {
+            let still_missing = required_artifacts
+                .iter()
+                .filter(|artifact| !download_dir.join(artifact).exists())
+                .copied()
+                .collect::<Vec<_>>();
+            if !still_missing.is_empty() {
                 return Err(format!(
-                    "Downloaded archive did not contain expected library '{}'",
-                    archive.dynamic_lib
+                    "Downloaded archive did not contain expected artefacts: {}",
+                    still_missing.join(", ")
                 )
                 .into());
             }
         }
 
-        let deps_dir = copy_libduckdb(&download_dir, archive.dynamic_lib, out_dir)?;
+        let deps_dir = copy_libduckdb(&download_dir, &required_artifacts, out_dir)?;
         configure_link_search(&deps_dir);
 
         Ok(HeaderLocation::FromPath(download_dir.to_string_lossy().into_owned()))
@@ -525,20 +535,22 @@ mod build_linked {
     // the default Cargo rpath, just like when DUCKDB_LIB_DIR is set.
     fn copy_libduckdb(
         download_dir: &Path,
-        lib_filename: &str,
+        lib_filenames: &[&str],
         out_dir: &str,
     ) -> Result<PathBuf, Box<dyn std::error::Error>> {
         let Some(deps_dir) = profile_deps_dir(out_dir) else {
             return Err("Could not determine target/deps directory for runtime lib copy".into());
         };
         fs::create_dir_all(&deps_dir)?;
-        let source = download_dir.join(lib_filename);
-        let dest = deps_dir.join(lib_filename);
-        if dest.exists() {
-            fs::remove_file(&dest)?;
+        for lib_filename in lib_filenames {
+            let source = download_dir.join(lib_filename);
+            let dest = deps_dir.join(lib_filename);
+            if dest.exists() {
+                fs::remove_file(&dest)?;
+            }
+            fs::copy(&source, &dest)?;
+            println!("cargo:warning=Copied libduckdb to {}", dest.display());
         }
-        fs::copy(&source, &dest)?;
-        println!("cargo:warning=Copied libduckdb to {}", dest.display());
         Ok(deps_dir)
     }
 
@@ -590,6 +602,7 @@ mod build_linked {
     struct LibduckdbArchive {
         archive_name: &'static str,
         dynamic_lib: &'static str,
+        import_lib: Option<&'static str>,
     }
 
     impl LibduckdbArchive {
@@ -598,25 +611,38 @@ mod build_linked {
                 t if t.ends_with("apple-darwin") => Some(Self {
                     archive_name: "libduckdb-osx-universal.zip",
                     dynamic_lib: "libduckdb.dylib",
+                    import_lib: None,
                 }),
                 "x86_64-unknown-linux-gnu" => Some(Self {
                     archive_name: "libduckdb-linux-amd64.zip",
                     dynamic_lib: "libduckdb.so",
+                    import_lib: None,
                 }),
                 "aarch64-unknown-linux-gnu" => Some(Self {
                     archive_name: "libduckdb-linux-arm64.zip",
                     dynamic_lib: "libduckdb.so",
+                    import_lib: None,
                 }),
                 "x86_64-pc-windows-msvc" => Some(Self {
                     archive_name: "libduckdb-windows-amd64.zip",
                     dynamic_lib: "duckdb.dll",
+                    import_lib: Some("duckdb.lib"),
                 }),
                 "aarch64-pc-windows-msvc" => Some(Self {
                     archive_name: "libduckdb-windows-arm64.zip",
                     dynamic_lib: "duckdb.dll",
+                    import_lib: Some("duckdb.lib"),
                 }),
                 _ => None,
             }
+        }
+
+        fn required_artifacts(&self) -> Vec<&'static str> {
+            let mut artefacts = vec![self.dynamic_lib];
+            if let Some(import_lib) = self.import_lib {
+                artefacts.push(import_lib);
+            }
+            artefacts
         }
 
         fn download_url(&self, version: &str) -> String {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,7 @@ const SLOW_TEST_TARGETS: &[&str] = &[
     "testlens_gherkin",
     "testlens_sqlite_acceptance",
 ];
+const SLOW_LIB_TESTS: &[&str] = &["host::devql::cucumber_bdd::devql_bdd_features_pass"];
 const MERGE_SMOKE_TARGETS: &[&str] = &[
     "agent_cli_smoke",
     "checkpoint_rewind_smoke",
@@ -557,6 +558,17 @@ fn slow_test_lane_args(targets: &[&str]) -> Vec<String> {
     args
 }
 
+fn slow_lib_test_lane_args(test_name: &str) -> Vec<String> {
+    let mut args = base_test_lane_args();
+    args.push("--features".to_string());
+    args.push("slow-tests".to_string());
+    args.push("--lib".to_string());
+    args.push("--".to_string());
+    args.push(test_name.to_string());
+    args.push("--exact".to_string());
+    args
+}
+
 fn test_lane_args(lane: &str) -> Result<Vec<String>, String> {
     let mut args = base_test_lane_args();
 
@@ -592,6 +604,15 @@ fn test_lane_args(lane: &str) -> Result<Vec<String>, String> {
 fn test_lane_command_groups(lane: &str) -> Result<Vec<Vec<String>>, String> {
     match lane {
         "merge" => Ok(vec![test_lane_args("fast")?, test_lane_args("smoke")?]),
+        "slow" => {
+            let mut groups = vec![test_lane_args("slow")?];
+            groups.extend(
+                SLOW_LIB_TESTS
+                    .iter()
+                    .map(|test_name| slow_lib_test_lane_args(test_name)),
+            );
+            Ok(groups)
+        }
         _ => Ok(vec![test_lane_args(lane)?]),
     }
 }


### PR DESCRIPTION
## Summary

This pull request introduces several important improvements across the codebase, focusing on enhancing test reliability, improving platform compatibility, and refining the build process for third-party dependencies. The most significant changes include the introduction of a robust polling utility for tests, improvements to test configuration and gating, and enhancements to the handling of the DuckDB library in the build system.

**Test reliability and infrastructure improvements:**

* Introduced a generic `wait_for_qat_condition` utility in `bitloops/tests/qat_support/helpers/core.rs` to poll for test conditions with configurable timeout and polling intervals, improving the reliability of tests that depend on asynchronous or eventual consistency. This utility is now used in key assertions to ensure they only proceed when the system is ready. [[1]](diffhunk://#diff-c12927bcd5b668c03cb5c1183ad3ea0fd3cc379248af08ae4b8fea55e6756749R37-R95) [[2]](diffhunk://#diff-c12927bcd5b668c03cb5c1183ad3ea0fd3cc379248af08ae4b8fea55e6756749L1698-R1767) [[3]](diffhunk://#diff-c12927bcd5b668c03cb5c1183ad3ea0fd3cc379248af08ae4b8fea55e6756749L1727-R1804) [[4]](diffhunk://#diff-c12927bcd5b668c03cb5c1183ad3ea0fd3cc379248af08ae4b8fea55e6756749L1804-R1886)
* Added comprehensive tests for `wait_for_qat_condition` in `bitloops/tests/qat_support/helpers/tests.rs`, verifying both successful polling and timeout behavior.

**Test configuration and gating:**

* Improved conditional compilation and gating for slow tests in `bitloops/src/host/devql.rs`, ensuring that certain test modules are only included or marked as dead code depending on the `slow-tests` feature.
* Enhanced the test runner in `xtask/src/main.rs` by introducing `SLOW_LIB_TESTS` and supporting fine-grained execution of slow library tests, allowing for more efficient and targeted CI runs. [[1]](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35R23) [[2]](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35R561-R571) [[3]](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35R607-R615)

**Build system and cross-platform improvements:**

* Refined the DuckDB build process in `third_party/libduckdb-sys/build.rs` to check for all required artefacts (including import libraries on Windows), improving reliability and cross-platform support. The build now verifies the presence of all necessary files after extraction and copies them as needed. [[1]](diffhunk://#diff-e15b0e3926b0ec7f8c7399f85d08278afc2e346dc094b91b480eab5e7aa81190L459-R487) [[2]](diffhunk://#diff-e15b0e3926b0ec7f8c7399f85d08278afc2e346dc094b91b480eab5e7aa81190L528-R553) [[3]](diffhunk://#diff-e15b0e3926b0ec7f8c7399f85d08278afc2e346dc094b91b480eab5e7aa81190R605) [[4]](diffhunk://#diff-e15b0e3926b0ec7f8c7399f85d08278afc2e346dc094b91b480eab5e7aa81190R614-R647)

**Platform-specific code improvements:**

* Updated `TreeEntry` struct and related logic in `bitloops/src/cli/rewind.rs` to conditionally include the `mode` field only on Unix platforms, improving portability. [[1]](diffhunk://#diff-9c5c1afdd85b924e885a05681685659c4e311ac7ebcc43c5bbd5491af9d53a57R305) [[2]](diffhunk://#diff-9c5c1afdd85b924e885a05681685659c4e311ac7ebcc43c5bbd5491af9d53a57R366)

