### PR TITLE
CLI-1627 Bind each repo to its daemon config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,43 +375,44 @@ jobs:
           tar -xzf bitloops-aarch64-unknown-linux-musl.tar.gz -C arm64
           chmod +x arm64/bitloops
           qemu-aarch64 arm64/bitloops --version
-          - name: Generate Slack message
-          id: slack_msg
-          shell: bash
-          run: |
-            VERSION="${GITHUB_REF_NAME#v}"
 
-            PART1=(
-              "🚀 Bitloops CLI v${VERSION} just dropped"
-              "🚀 Bitloops CLI v${VERSION} is live"
-              "🚀 Bitloops CLI v${VERSION} just shipped"
-              "🚀 Bitloops CLI v${VERSION} is out in the wild"
-              "🚀 Bitloops CLI v${VERSION} just landed"
-              "🚀 Bitloops CLI v${VERSION} is now available"
-              "🚀 Bitloops CLI v${VERSION} deployed successfully"
-              "🚀 Bitloops CLI v${VERSION} rollout complete"
-              "🚀 Bitloops CLI v${VERSION} is officially out"
-              "🚀 Bitloops CLI v${VERSION} release complete"
-            )
+      - name: Generate Slack message
+        id: slack_msg
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
 
-            PART2=(
-              "— built through strong cross-team collaboration 👏"
-              "— another solid team delivery 💪"
-              "— delivered with great engineering effort ⚙️"
-              "— a result of coordinated team execution 🤝"
-              "— reflecting high-quality team craftsmanship 🛠️"
-              "— powered by focused team iteration 🔁"
-              "— showcasing strong ownership across the team 🧠"
-              "— driven by consistent team momentum 📈"
-              "— executed with precision across contributors 🎯"
-              "— backed by collective engineering excellence ✨"
-            )
+          PART1=(
+            "🚀 Bitloops CLI v${VERSION} just dropped"
+            "🚀 Bitloops CLI v${VERSION} is live"
+            "🚀 Bitloops CLI v${VERSION} just shipped"
+            "🚀 Bitloops CLI v${VERSION} is out in the wild"
+            "🚀 Bitloops CLI v${VERSION} just landed"
+            "🚀 Bitloops CLI v${VERSION} is now available"
+            "🚀 Bitloops CLI v${VERSION} deployed successfully"
+            "🚀 Bitloops CLI v${VERSION} rollout complete"
+            "🚀 Bitloops CLI v${VERSION} is officially out"
+            "🚀 Bitloops CLI v${VERSION} release complete"
+          )
 
-            P1_INDEX=$((RANDOM % ${#PART1[@]}))
-            P2_INDEX=$((RANDOM % ${#PART2[@]}))
-            MESSAGE="${PART1[$P1_INDEX]} ${PART2[$P2_INDEX]}"
+          PART2=(
+            "— built through strong cross-team collaboration 👏"
+            "— another solid team delivery 💪"
+            "— delivered with great engineering effort ⚙️"
+            "— a result of coordinated team execution 🤝"
+            "— reflecting high-quality team craftsmanship 🛠️"
+            "— powered by focused team iteration 🔁"
+            "— showcasing strong ownership across the team 🧠"
+            "— driven by consistent team momentum 📈"
+            "— executed with precision across contributors 🎯"
+            "— backed by collective engineering excellence ✨"
+          )
 
-            echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
+          P1_INDEX=$((RANDOM % ${#PART1[@]}))
+          P2_INDEX=$((RANDOM % ${#PART2[@]}))
+          MESSAGE="${PART1[$P1_INDEX]} ${PART2[$P2_INDEX]}"
+
+          echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
 
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Repo-bound daemon config binding for safe capture**: added a local-only `[daemon].config_path` binding in `.bitloops.local.toml`, wired `bitloops init` to store the running daemon's canonicalised config path as the repo binding, and added the `x-bitloops-daemon-binding` request header so repo-scoped daemon requests carry a stable binding identifier derived from that config path.
+
 ### Changed
 
+- **Repo-scoped daemon-backed writes now resolve config strictly from the repo binding**: interaction spool opening, repo runtime-store access, repo-scoped DevQL GraphQL/SDL/WebSocket requests, and other daemon-backed write paths now use `BITLOOPS_DAEMON_CONFIG_PATH_OVERRIDE` first and the repo's local daemon binding second. They no longer fall back to the nearest `config.toml` or the default global daemon config for capture, queue, spool, or turn-data writes.
+
 ### Fixed
+
+- **Cross-project daemon/config misrouting**: Bitloops now rejects repo-scoped daemon requests whose repo binding does not match the running daemon's config path, with a clear `bitloops init` rebind error. When repo binding information is missing or invalid, hook capture now warns and skips instead of guessing another config and risking writes into the wrong project's stores.
 
 ## [0.0.13] - 2026-04-10
 

--- a/bitloops/src/api.rs
+++ b/bitloops/src/api.rs
@@ -56,6 +56,7 @@ pub struct DashboardRuntimeOptions {
     pub shutdown_message: Option<String>,
     pub on_ready: Option<DashboardReadyHook>,
     pub on_shutdown: Option<DashboardShutdownHook>,
+    pub config_path: Option<PathBuf>,
     pub config_root: Option<PathBuf>,
     pub repo_registry_path: Option<PathBuf>,
 }
@@ -70,6 +71,7 @@ impl Default for DashboardRuntimeOptions {
             shutdown_message: Some("Dashboard server stopped.".to_string()),
             on_ready: None,
             on_shutdown: None,
+            config_path: None,
             config_root: None,
             repo_registry_path: None,
         }
@@ -176,6 +178,7 @@ pub(crate) struct DashboardBundleSourceOverrides {
 
 #[derive(Clone)]
 pub(crate) struct DashboardState {
+    pub(super) config_path: PathBuf,
     pub(super) config_root: PathBuf,
     pub(super) repo_root: PathBuf,
     pub(super) repo_registry_path: Option<PathBuf>,

--- a/bitloops/src/api/bundle.rs
+++ b/bitloops/src/api/bundle.rs
@@ -560,6 +560,7 @@ mod tests {
         overrides: crate::api::DashboardBundleSourceOverrides,
     ) -> DashboardState {
         DashboardState {
+            config_path: PathBuf::from("."),
             config_root: PathBuf::from("."),
             repo_root: PathBuf::from("."),
             repo_registry_path: None,

--- a/bitloops/src/api/dashboard_runtime.rs
+++ b/bitloops/src/api/dashboard_runtime.rs
@@ -221,6 +221,10 @@ pub(super) async fn run(
     }
 
     let state = DashboardState {
+        config_path: options
+            .config_path
+            .clone()
+            .unwrap_or_else(|| config_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH)),
         config_root: config_root.clone(),
         repo_root,
         repo_registry_path: options.repo_registry_path.clone(),

--- a/bitloops/src/api/tests/devql_mutations_and_health.rs
+++ b/bitloops/src/api/tests/devql_mutations_and_health.rs
@@ -981,6 +981,10 @@ async fn daemon_bootstrap_creates_devql_schema_tables() {
             shutdown_message: None,
             on_ready: None,
             on_shutdown: None,
+            config_path: Some(
+                repo.path()
+                    .join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH),
+            ),
             config_root: Some(repo.path().to_path_buf()),
             repo_registry_path: None,
         },

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -150,7 +150,7 @@ async fn devql_global_route_rejects_mismatched_daemon_binding_for_repo_scoped_re
         temp.path().to_path_buf(),
     ));
     let repo_root = temp.path().to_string_lossy().to_string();
-    let headers = vec![
+    let headers = [
         (
             crate::devql_transport::HEADER_SCOPE_REPO_ROOT,
             crate::devql_transport::encode_scope_header_value(&repo_root),

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -74,6 +74,12 @@ fn slim_scope_headers(repo_root: &Path) -> Vec<(String, String)> {
             crate::devql_transport::HEADER_SCOPE_CONFIG_FINGERPRINT.to_string(),
             fingerprint,
         ),
+        (
+            crate::devql_transport::HEADER_DAEMON_BINDING.to_string(),
+            crate::devql_transport::daemon_binding_identifier_for_config_path(
+                &repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH),
+            ),
+        ),
     ]
 }
 
@@ -97,6 +103,84 @@ async fn request_slim_query(
         Body::from(json!({ "query": query }).to_string()),
     )
     .await
+}
+
+#[tokio::test]
+async fn devql_slim_route_rejects_missing_daemon_binding_for_repo_scoped_requests() {
+    let temp = TempDir::new().expect("temp dir");
+    let app = build_dashboard_router(test_state(
+        temp.path().to_path_buf(),
+        ServeMode::HelloWorld,
+        temp.path().to_path_buf(),
+    ));
+
+    let slim_headers = slim_scope_headers(temp.path())
+        .into_iter()
+        .filter(|(name, _)| name != crate::devql_transport::HEADER_DAEMON_BINDING)
+        .collect::<Vec<_>>();
+    let slim_headers_ref = slim_headers
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+
+    let (_status, body) = request_json_with_method_content_type_and_headers(
+        app,
+        Method::POST,
+        "/devql",
+        "application/json",
+        &slim_headers_ref,
+        Body::from(json!({ "query": "{ health { relational { backend } } }" }).to_string()),
+    )
+    .await;
+
+    assert!(
+        body["errors"][0]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Run `bitloops init`")),
+        "unexpected response body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn devql_global_route_rejects_mismatched_daemon_binding_for_repo_scoped_requests() {
+    let temp = TempDir::new().expect("temp dir");
+    let app = build_dashboard_router(test_state(
+        temp.path().to_path_buf(),
+        ServeMode::HelloWorld,
+        temp.path().to_path_buf(),
+    ));
+    let repo_root = temp.path().to_string_lossy().to_string();
+    let headers = vec![
+        (
+            crate::devql_transport::HEADER_SCOPE_REPO_ROOT,
+            crate::devql_transport::encode_scope_header_value(&repo_root),
+        ),
+        (
+            crate::devql_transport::HEADER_DAEMON_BINDING,
+            "mismatched-binding".to_string(),
+        ),
+    ];
+    let headers_ref = headers
+        .iter()
+        .map(|(name, value)| (*name, value.as_str()))
+        .collect::<Vec<_>>();
+
+    let (_status, body) = request_json_with_method_content_type_and_headers(
+        app,
+        Method::POST,
+        "/devql/global",
+        "application/json",
+        &headers_ref,
+        Body::from(json!({ "query": "{ health { relational { backend } } }" }).to_string()),
+    )
+    .await;
+
+    assert!(
+        body["errors"][0]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Run `bitloops init`")),
+        "unexpected response body: {body}"
+    );
 }
 
 #[tokio::test]

--- a/bitloops/src/api/tests/support_dashboard.rs
+++ b/bitloops/src/api/tests/support_dashboard.rs
@@ -7,6 +7,7 @@ pub(super) fn test_state(
 ) -> DashboardState {
     let db = crate::api::DashboardDbPools::default();
     DashboardState {
+        config_path: repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH),
         config_root: repo_root.clone(),
         repo_registry_path: None,
         subscription_hub: crate::graphql::SubscriptionHub::new_arc(),

--- a/bitloops/src/api/tests/support_storage.rs
+++ b/bitloops/src/api/tests/support_storage.rs
@@ -83,7 +83,12 @@ fn write_daemon_test_config(repo_root: &Path, settings: serde_json::Value) {
     for (key, value) in settings.as_object().expect("top-level config object") {
         doc[key] = json_value_to_toml_item(value);
     }
-    fs::write(config_path, doc.to_string()).expect("write config");
+    fs::write(&config_path, doc.to_string()).expect("write config");
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
 }
 
 pub(super) fn write_envelope_config(repo_root: &Path, settings: serde_json::Value) {

--- a/bitloops/src/cli/devql/graphql/client.rs
+++ b/bitloops/src/cli/devql/graphql/client.rs
@@ -179,7 +179,7 @@ pub(crate) async fn watch_sync_task_via_graphql(
     let mut renderer = SyncProgressRenderer::new();
     renderer.render(&initial_task)?;
 
-    match watch_sync_task_via_subscription(task_id.as_str(), &mut renderer).await {
+    match watch_sync_task_via_subscription(scope, task_id.as_str(), &mut renderer).await {
         Ok(summary) => {
             renderer.finish()?;
             return Ok(summary);
@@ -244,6 +244,10 @@ async fn fetch_schema_sdl_via_daemon(
 
     let mut request = client.get(endpoint);
     if let Some(scope) = scope {
+        request = crate::devql_transport::attach_repo_daemon_binding_headers(
+            request,
+            scope.repo_root.as_path(),
+        )?;
         request = crate::devql_transport::attach_slim_cli_scope_headers(request, scope);
     }
 
@@ -298,12 +302,12 @@ fn daemon_start_policy(require_daemon: bool) -> DaemonStartPolicy {
 }
 
 async fn ensure_daemon_available_for_ingest(
-    _repo_root: &Path,
+    repo_root: &Path,
     policy: DaemonStartPolicy,
 ) -> Result<()> {
     #[cfg(test)]
     if matches!(policy, DaemonStartPolicy::AutoStart)
-        && let Some(result) = maybe_bootstrap_daemon_via_hook(_repo_root)
+        && let Some(result) = maybe_bootstrap_daemon_via_hook(repo_root)
     {
         return result;
     }
@@ -317,7 +321,8 @@ async fn ensure_daemon_available_for_ingest(
     }
 
     let report = daemon::status().await?;
-    let daemon_config = daemon::resolve_daemon_config(None)?;
+    let daemon_config_path = crate::config::resolve_bound_daemon_config_path_for_repo(repo_root)?;
+    let daemon_config = daemon::resolve_daemon_config(Some(daemon_config_path.as_path()))?;
     let config = DashboardServerConfig {
         host: None,
         port: crate::api::DEFAULT_DASHBOARD_PORT,

--- a/bitloops/src/cli/devql/graphql/subscription.rs
+++ b/bitloops/src/cli/devql/graphql/subscription.rs
@@ -14,9 +14,11 @@ use super::documents::SYNC_PROGRESS_SUBSCRIPTION;
 use super::progress::{SYNC_RENDER_TICK_INTERVAL, SyncProgressRenderer};
 use super::types::{SyncProgressSubscriptionData, SyncTaskGraphqlRecord};
 use crate::daemon;
+use crate::devql_transport::SlimCliRepoScope;
 use crate::host::devql::SyncSummary;
 
 pub(super) async fn watch_sync_task_via_subscription(
+    scope: &SlimCliRepoScope,
     task_id: &str,
     renderer: &mut SyncProgressRenderer,
 ) -> Result<Option<SyncSummary>> {
@@ -28,6 +30,24 @@ pub(super) async fn watch_sync_task_via_subscription(
     request.headers_mut().insert(
         "Sec-WebSocket-Protocol",
         HeaderValue::from_static("graphql-transport-ws"),
+    );
+    request.headers_mut().insert(
+        crate::devql_transport::HEADER_SCOPE_REPO_ROOT,
+        HeaderValue::from_str(&crate::devql_transport::encode_scope_header_value(
+            &scope.repo_root.to_string_lossy(),
+        ))
+        .context("encoding DevQL websocket repo root header")?,
+    );
+    request.headers_mut().insert(
+        crate::devql_transport::HEADER_DAEMON_BINDING,
+        HeaderValue::from_str(
+            &crate::devql_transport::daemon_binding_identifier_for_config_path(
+                &crate::config::resolve_bound_daemon_config_path_for_repo(
+                    scope.repo_root.as_path(),
+                )?,
+            ),
+        )
+        .context("encoding DevQL websocket daemon binding header")?,
     );
 
     let (mut websocket, _) = connect_devql_websocket(request, &endpoint)

--- a/bitloops/src/cli/devql/tests.rs
+++ b/bitloops/src/cli/devql/tests.rs
@@ -34,6 +34,7 @@ fn test_daemon_state_root(repo_root: &Path) -> PathBuf {
 }
 
 fn write_envelope_config(repo_root: &Path, settings: serde_json::Value) {
+    let config_path = repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH);
     let sqlite_path = settings["stores"]["relational"]["sqlite_path"]
         .as_str()
         .expect("relational sqlite path");
@@ -42,7 +43,7 @@ fn write_envelope_config(repo_root: &Path, settings: serde_json::Value) {
         .expect("events duckdb path");
 
     fs::write(
-        repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH),
+        &config_path,
         format!(
             r#"[stores]
 [stores.relational]
@@ -54,6 +55,11 @@ duckdb_path = {duckdb_path:?}
         ),
     )
     .expect("write config");
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
 }
 
 fn seed_devql_cli_repo() -> TempDir {

--- a/bitloops/src/cli/init.rs
+++ b/bitloops/src/cli/init.rs
@@ -14,7 +14,10 @@ use crate::cli::embeddings::{
     EmbeddingsInstallState, inspect_embeddings_install_state, install_or_bootstrap_embeddings,
 };
 use crate::cli::telemetry_consent;
-use crate::config::settings::{DEFAULT_STRATEGY, load_settings, write_project_bootstrap_settings};
+use crate::config::settings::{
+    DEFAULT_STRATEGY, load_settings, write_project_bootstrap_settings_with_daemon_binding,
+    write_repo_daemon_binding,
+};
 use crate::config::{
     REPO_POLICY_LOCAL_FILE_NAME, bootstrap_default_daemon_environment, default_daemon_config_exists,
 };
@@ -159,6 +162,9 @@ async fn run_with_io_async_for_project_root(
 
     maybe_install_default_daemon(args.install_default_daemon).await?;
     telemetry_consent::ensure_default_daemon_running().await?;
+    let daemon_config_path = bound_running_daemon_config_path().await?;
+    let local_policy_path = project_root.join(REPO_POLICY_LOCAL_FILE_NAME);
+    write_repo_daemon_binding(&local_policy_path, &daemon_config_path)?;
     if daemon_config_existed_at_entry {
         telemetry_consent::ensure_existing_config_telemetry_consent(
             project_root,
@@ -185,8 +191,12 @@ async fn run_with_io_async_for_project_root(
     let strategy = load_settings(project_root)
         .map(|settings| settings.strategy)
         .unwrap_or_else(|_| DEFAULT_STRATEGY.to_string());
-    let local_policy_path = project_root.join(REPO_POLICY_LOCAL_FILE_NAME);
-    write_project_bootstrap_settings(&local_policy_path, &strategy, &selected_agents)?;
+    write_project_bootstrap_settings_with_daemon_binding(
+        &local_policy_path,
+        &strategy,
+        &selected_agents,
+        Some(&daemon_config_path),
+    )?;
 
     let settings = load_settings(project_root).unwrap_or_default();
     let git_count = git_hooks::install_git_hooks(&git_root, settings.local_dev)?;
@@ -255,6 +265,17 @@ async fn run_with_io_async_for_project_root(
         install_embeddings_during_init(project_root, out)?;
     }
     Ok(())
+}
+
+async fn bound_running_daemon_config_path() -> Result<std::path::PathBuf> {
+    let runtime = crate::daemon::status()
+        .await?
+        .runtime
+        .context("Bitloops daemon is not running")?;
+    Ok(runtime
+        .config_path
+        .canonicalize()
+        .unwrap_or(runtime.config_path))
 }
 
 fn install_embeddings_during_init(project_root: &Path, out: &mut dyn Write) -> Result<()> {

--- a/bitloops/src/cli/init.rs
+++ b/bitloops/src/cli/init.rs
@@ -16,7 +16,6 @@ use crate::cli::embeddings::{
 use crate::cli::telemetry_consent;
 use crate::config::settings::{
     DEFAULT_STRATEGY, load_settings, write_project_bootstrap_settings_with_daemon_binding,
-    write_repo_daemon_binding,
 };
 use crate::config::{
     REPO_POLICY_LOCAL_FILE_NAME, bootstrap_default_daemon_environment, default_daemon_config_exists,
@@ -163,8 +162,6 @@ async fn run_with_io_async_for_project_root(
     maybe_install_default_daemon(args.install_default_daemon).await?;
     telemetry_consent::ensure_default_daemon_running().await?;
     let daemon_config_path = bound_running_daemon_config_path().await?;
-    let local_policy_path = project_root.join(REPO_POLICY_LOCAL_FILE_NAME);
-    write_repo_daemon_binding(&local_policy_path, &daemon_config_path)?;
     if daemon_config_existed_at_entry {
         telemetry_consent::ensure_existing_config_telemetry_consent(
             project_root,
@@ -191,6 +188,7 @@ async fn run_with_io_async_for_project_root(
     let strategy = load_settings(project_root)
         .map(|settings| settings.strategy)
         .unwrap_or_else(|_| DEFAULT_STRATEGY.to_string());
+    let local_policy_path = project_root.join(REPO_POLICY_LOCAL_FILE_NAME);
     write_project_bootstrap_settings_with_daemon_binding(
         &local_policy_path,
         &strategy,
@@ -268,6 +266,28 @@ async fn run_with_io_async_for_project_root(
 }
 
 async fn bound_running_daemon_config_path() -> Result<std::path::PathBuf> {
+    if let Some(runtime) = crate::daemon::status().await?.runtime {
+        return Ok(runtime
+            .config_path
+            .canonicalize()
+            .unwrap_or(runtime.config_path));
+    }
+
+    #[cfg(test)]
+    if crate::cli::telemetry_consent::test_assume_daemon_running_override() == Some(true) {
+        let config_path = crate::config::ensure_daemon_config_exists()?;
+        return Ok(config_path.canonicalize().unwrap_or(config_path));
+    }
+
+    #[cfg(test)]
+    if std::env::var("BITLOOPS_TEST_ASSUME_DAEMON_RUNNING")
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty() && value.trim() != "0")
+    {
+        let config_path = crate::config::ensure_daemon_config_exists()?;
+        return Ok(config_path.canonicalize().unwrap_or(config_path));
+    }
+
     let runtime = crate::daemon::status()
         .await?
         .runtime

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -73,13 +73,6 @@ fn with_temp_app_dirs<T>(
     f: impl FnOnce() -> T,
 ) -> T {
     with_test_platform_dir_overrides(app_dir_overrides(temp), || {
-        if assume_daemon_running {
-            let config_path = ensure_daemon_config_exists().expect("create default daemon config");
-            let config_root = config_path
-                .parent()
-                .expect("daemon config should have a parent directory");
-            write_current_daemon_runtime_state(config_root);
-        }
         with_test_tty_override(tty, || {
             with_test_assume_daemon_running(assume_daemon_running, f)
         })

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -73,6 +73,13 @@ fn with_temp_app_dirs<T>(
     f: impl FnOnce() -> T,
 ) -> T {
     with_test_platform_dir_overrides(app_dir_overrides(temp), || {
+        if assume_daemon_running {
+            let config_path = ensure_daemon_config_exists().expect("create default daemon config");
+            let config_root = config_path
+                .parent()
+                .expect("daemon config should have a parent directory");
+            write_current_daemon_runtime_state(config_root);
+        }
         with_test_tty_override(tty, || {
             with_test_assume_daemon_running(assume_daemon_running, f)
         })
@@ -378,6 +385,111 @@ fn run_init_creates_project_local_policy_and_installs_selected_agents() {
         assert!(!exclude.contains(".bitloops/"));
         assert!(!exclude.contains("config.local.json"));
         assert!(!exclude.contains(".bitloops/config.local.json"));
+    });
+}
+
+#[test]
+fn run_init_binds_repo_to_running_daemon_config() {
+    let repo = tempfile::tempdir().expect("repo tempdir");
+    let app_dirs = tempfile::tempdir().expect("app tempdir");
+    let daemon_root = tempfile::tempdir().expect("daemon tempdir");
+    setup_git_repo(&repo);
+
+    with_temp_app_dirs(&app_dirs, false, false, || {
+        write_current_daemon_runtime_state(daemon_root.path());
+
+        let mut out = Vec::new();
+        run_with_writer_for_project_root(
+            InitArgs {
+                install_default_daemon: false,
+                force: false,
+                agent: None,
+                telemetry: None,
+                no_telemetry: false,
+                skip_baseline: false,
+                sync: Some(false),
+                ingest: Some(false),
+                backfill: None,
+            },
+            repo.path(),
+            &mut out,
+            None,
+        )
+        .expect("run init");
+
+        let local_policy = std::fs::read_to_string(repo.path().join(".bitloops.local.toml"))
+            .expect("read local repo policy");
+        assert!(
+            local_policy.contains(
+                daemon_root
+                    .path()
+                    .join(BITLOOPS_CONFIG_RELATIVE_PATH)
+                    .to_string_lossy()
+                    .as_ref()
+            ),
+            "expected daemon binding in local policy:\n{local_policy}"
+        );
+    });
+}
+
+#[test]
+fn run_init_rewrites_existing_daemon_binding() {
+    let repo = tempfile::tempdir().expect("repo tempdir");
+    let app_dirs = tempfile::tempdir().expect("app tempdir");
+    let old_daemon_root = tempfile::tempdir().expect("old daemon tempdir");
+    let new_daemon_root = tempfile::tempdir().expect("new daemon tempdir");
+    setup_git_repo(&repo);
+
+    crate::config::settings::write_repo_daemon_binding(
+        &repo.path().join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &old_daemon_root.path().join(BITLOOPS_CONFIG_RELATIVE_PATH),
+    )
+    .expect("write initial repo daemon binding");
+
+    with_temp_app_dirs(&app_dirs, false, false, || {
+        write_current_daemon_runtime_state(new_daemon_root.path());
+
+        let mut out = Vec::new();
+        run_with_writer_for_project_root(
+            InitArgs {
+                install_default_daemon: false,
+                force: false,
+                agent: None,
+                telemetry: None,
+                no_telemetry: false,
+                skip_baseline: false,
+                sync: Some(false),
+                ingest: Some(false),
+                backfill: None,
+            },
+            repo.path(),
+            &mut out,
+            None,
+        )
+        .expect("run init");
+
+        let local_policy = std::fs::read_to_string(repo.path().join(".bitloops.local.toml"))
+            .expect("read local repo policy");
+        assert!(
+            local_policy.contains(
+                new_daemon_root
+                    .path()
+                    .join(BITLOOPS_CONFIG_RELATIVE_PATH)
+                    .to_string_lossy()
+                    .as_ref()
+            ),
+            "expected updated daemon binding in local policy:\n{local_policy}"
+        );
+        assert!(
+            !local_policy.contains(
+                old_daemon_root
+                    .path()
+                    .join(BITLOOPS_CONFIG_RELATIVE_PATH)
+                    .to_string_lossy()
+                    .as_ref()
+            ),
+            "old daemon binding should be replaced:\n{local_policy}"
+        );
     });
 }
 

--- a/bitloops/src/cli/root_test.rs
+++ b/bitloops/src/cli/root_test.rs
@@ -265,8 +265,12 @@ fn TestRootCommand_ResolveWatcherAutostartConfigRoot_UsesDaemonOverrideRoot() {
         || {
             let config_root = resolve_watcher_autostart_config_root(&repo_root, &repo_root)
                 .expect("watcher autostart should resolve daemon config root");
+            let expected_root = dir
+                .path()
+                .canonicalize()
+                .unwrap_or_else(|_| dir.path().to_path_buf());
 
-            assert_eq!(config_root, dir.path());
+            assert_eq!(config_root, expected_root);
             assert_ne!(config_root, repo_root);
         },
     );

--- a/bitloops/src/cli/telemetry_consent.rs
+++ b/bitloops/src/cli/telemetry_consent.rs
@@ -206,7 +206,7 @@ async fn execute_global_graphql<T: for<'de> Deserialize<'de>>(
         return Ok(serde_json::from_value(data?)?);
     }
 
-    crate::daemon::execute_graphql(runtime_root, query, variables).await
+    crate::daemon::execute_repo_graphql(runtime_root, query, variables).await
 }
 
 #[cfg(test)]

--- a/bitloops/src/cli/telemetry_consent.rs
+++ b/bitloops/src/cli/telemetry_consent.rs
@@ -206,7 +206,7 @@ async fn execute_global_graphql<T: for<'de> Deserialize<'de>>(
         return Ok(serde_json::from_value(data?)?);
     }
 
-    crate::daemon::execute_repo_graphql(runtime_root, query, variables).await
+    crate::daemon::execute_graphql(runtime_root, query, variables).await
 }
 
 #[cfg(test)]
@@ -247,7 +247,7 @@ pub(crate) fn test_tty_override() -> Option<bool> {
 }
 
 #[cfg(test)]
-fn test_assume_daemon_running_override() -> Option<bool> {
+pub(crate) fn test_assume_daemon_running_override() -> Option<bool> {
     TEST_ASSUME_DAEMON_RUNNING_OVERRIDE.with(|cell| *cell.borrow())
 }
 

--- a/bitloops/src/config.rs
+++ b/bitloops/src/config.rs
@@ -25,9 +25,11 @@ pub use repo_policy::{
     RepoPolicySnapshot, discover_repo_policy, discover_repo_policy_optional,
 };
 pub use resolve::{
-    resolve_blob_local_path, resolve_blob_local_path_for_repo, resolve_daemon_config_path_for_repo,
-    resolve_daemon_config_root_for_repo, resolve_dashboard_config,
-    resolve_dashboard_config_for_repo, resolve_duckdb_db_path_for_repo,
+    resolve_blob_local_path, resolve_blob_local_path_for_repo,
+    resolve_bound_daemon_config_path_for_repo, resolve_bound_daemon_config_root_for_repo,
+    resolve_bound_repo_runtime_db_path_for_repo, resolve_bound_store_backend_config_for_repo,
+    resolve_daemon_config_path_for_repo, resolve_daemon_config_root_for_repo,
+    resolve_dashboard_config, resolve_dashboard_config_for_repo, resolve_duckdb_db_path_for_repo,
     resolve_embedding_capability_config_for_repo, resolve_embeddings_config_for_repo,
     resolve_inference_capability_config_for_repo, resolve_inference_config_for_repo,
     resolve_provider_config, resolve_provider_config_for_repo,

--- a/bitloops/src/config/daemon_config.rs
+++ b/bitloops/src/config/daemon_config.rs
@@ -164,9 +164,15 @@ pub fn load_daemon_settings(explicit_path: Option<&Path>) -> Result<LoadedDaemon
         log_level: file.logging.level.unwrap_or_default(),
     };
 
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.clone());
+    let canonical_root = canonical_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(root.clone());
+
     Ok(LoadedDaemonSettings {
-        path,
-        root,
+        path: canonical_path,
+        root: canonical_root,
         settings: UnifiedSettings {
             enabled: None,
             strategy: None,
@@ -756,7 +762,12 @@ local_path = "stores/blob"
         let returned_path =
             ensure_daemon_store_artifacts(Some(config_path.as_path())).expect("bootstrap stores");
 
-        assert_eq!(returned_path, config_path);
+        assert_eq!(
+            returned_path,
+            config_path
+                .canonicalize()
+                .unwrap_or_else(|_| config_path.clone())
+        );
         assert!(dir.path().join("stores/relational/relational.db").is_file());
         assert!(dir.path().join("stores/event/events.duckdb").is_file());
         assert!(dir.path().join("stores/blob").is_dir());

--- a/bitloops/src/config/repo_policy.rs
+++ b/bitloops/src/config/repo_policy.rs
@@ -14,6 +14,7 @@ pub struct RepoPolicySnapshot {
     pub root: Option<PathBuf>,
     pub shared_path: Option<PathBuf>,
     pub local_path: Option<PathBuf>,
+    pub daemon_config_path: Option<PathBuf>,
     pub capture: Value,
     pub watch: Value,
     pub scope: Value,
@@ -48,7 +49,16 @@ struct RepoPolicyTomlFile {
     #[serde(default)]
     agents: Option<Value>,
     #[serde(default)]
+    daemon: RepoPolicyDaemon,
+    #[serde(default)]
     imports: RepoPolicyImports,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct RepoPolicyDaemon {
+    #[serde(default)]
+    config_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -91,6 +101,30 @@ fn discover_repo_policy_with_mode(start: &Path, strict: bool) -> Result<RepoPoli
         .as_deref()
         .map(load_policy_file)
         .transpose()?;
+
+    if shared
+        .as_ref()
+        .and_then(|value| value.daemon.config_path.as_deref())
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        let shared_path = location
+            .shared_path
+            .as_deref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| REPO_POLICY_FILE_NAME.to_string());
+        anyhow::bail!(
+            "Bitloops daemon binding must be local-only. Move `[daemon].config_path` from {} into `{}`.",
+            shared_path,
+            REPO_POLICY_LOCAL_FILE_NAME
+        );
+    }
+
+    let daemon_config_path = local
+        .as_ref()
+        .and_then(|value| value.daemon.config_path.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
 
     let capture = merge_optional_values(
         shared.as_ref().and_then(|value| value.capture.clone()),
@@ -142,6 +176,7 @@ fn discover_repo_policy_with_mode(start: &Path, strict: bool) -> Result<RepoPoli
         root: Some(location.root),
         shared_path: location.shared_path,
         local_path: location.local_path,
+        daemon_config_path,
         capture,
         watch,
         scope,
@@ -173,6 +208,7 @@ fn default_repo_policy_snapshot() -> RepoPolicySnapshot {
         root: None,
         shared_path: None,
         local_path: None,
+        daemon_config_path: None,
         capture,
         watch,
         scope,
@@ -370,5 +406,96 @@ fn canonicalize_value(value: &Value) -> Value {
         }
         Value::Array(values) => Value::Array(values.iter().map(canonicalize_value).collect()),
         _ => value.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn discover_repo_policy_reads_local_daemon_binding() {
+        let repo = tempdir().expect("temp dir");
+        let local_policy = repo.path().join(REPO_POLICY_LOCAL_FILE_NAME);
+        fs::write(
+            &local_policy,
+            r#"
+[daemon]
+config_path = "/tmp/daemon/config.toml"
+"#,
+        )
+        .expect("write local repo policy");
+
+        let snapshot = discover_repo_policy(repo.path()).expect("discover repo policy");
+
+        assert_eq!(
+            snapshot.daemon_config_path,
+            Some(PathBuf::from("/tmp/daemon/config.toml"))
+        );
+    }
+
+    #[test]
+    fn discover_repo_policy_rejects_shared_daemon_binding() {
+        let repo = tempdir().expect("temp dir");
+        let shared_policy = repo.path().join(REPO_POLICY_FILE_NAME);
+        fs::write(
+            &shared_policy,
+            r#"
+[daemon]
+config_path = "/tmp/daemon/config.toml"
+"#,
+        )
+        .expect("write shared repo policy");
+
+        let err = discover_repo_policy(repo.path()).expect_err("shared daemon binding must fail");
+
+        assert!(
+            err.to_string()
+                .contains("Bitloops daemon binding must be local-only"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn daemon_binding_does_not_change_repo_policy_fingerprint() {
+        let repo = tempdir().expect("temp dir");
+        let shared_policy = repo.path().join(REPO_POLICY_FILE_NAME);
+        let local_policy = repo.path().join(REPO_POLICY_LOCAL_FILE_NAME);
+        fs::write(
+            &shared_policy,
+            r#"
+[capture]
+enabled = true
+"#,
+        )
+        .expect("write shared repo policy");
+        fs::write(
+            &local_policy,
+            r#"
+[daemon]
+config_path = "/tmp/daemon-a/config.toml"
+"#,
+        )
+        .expect("write first local repo policy");
+
+        let first = discover_repo_policy(repo.path())
+            .expect("discover first repo policy")
+            .fingerprint;
+
+        fs::write(
+            &local_policy,
+            r#"
+[daemon]
+config_path = "/tmp/daemon-b/config.toml"
+"#,
+        )
+        .expect("write second local repo policy");
+
+        let second = discover_repo_policy(repo.path())
+            .expect("discover second repo policy")
+            .fingerprint;
+
+        assert_eq!(first, second);
     }
 }

--- a/bitloops/src/config/resolve.rs
+++ b/bitloops/src/config/resolve.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -10,7 +10,7 @@ use super::daemon_config::{
     LoadedDaemonSettings, default_daemon_config_exists, default_daemon_config_path,
     load_daemon_settings,
 };
-use super::repo_policy::discover_repo_policy_optional;
+use super::repo_policy::{REPO_POLICY_LOCAL_FILE_NAME, discover_repo_policy_optional};
 use super::store_config_utils::{
     current_repo_root_or_cwd, current_repo_root_or_cwd_result, normalize_blob_path,
     normalize_sqlite_path, read_any_string, read_any_u64, read_non_empty_env,
@@ -38,6 +38,23 @@ fn explicit_daemon_settings_override() -> Result<Option<(PathBuf, UnifiedSetting
     };
     let loaded = load_daemon_settings(Some(Path::new(&explicit_path)))?;
     Ok(Some((loaded.root, loaded.settings)))
+}
+
+fn canonicalize_loaded_daemon_settings(mut loaded: LoadedDaemonSettings) -> LoadedDaemonSettings {
+    if let Ok(path) = loaded.path.canonicalize() {
+        loaded.root = path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| loaded.root.clone());
+        loaded.path = path;
+    }
+    loaded
+}
+
+fn load_strict_daemon_settings(path: &Path) -> Result<LoadedDaemonSettings> {
+    load_daemon_settings(Some(path))
+        .map(canonicalize_loaded_daemon_settings)
+        .with_context(|| format!("loading Bitloops daemon config {}", path.display()))
 }
 
 fn discover_nearest_daemon_config(start: &Path) -> Option<PathBuf> {
@@ -124,6 +141,50 @@ fn daemon_settings_for_repo(repo_root: &Path) -> Result<(PathBuf, UnifiedSetting
     }
 
     Ok((repo_root.to_path_buf(), UnifiedSettings::default()))
+}
+
+fn repo_bound_daemon_settings_for_repo(repo_root: &Path) -> Result<LoadedDaemonSettings> {
+    if let Some(explicit_path) = env::var_os(ENV_DAEMON_CONFIG_PATH_OVERRIDE) {
+        return load_strict_daemon_settings(Path::new(&explicit_path)).with_context(|| {
+            format!(
+                "resolving repo-bound Bitloops daemon config from `{}`",
+                ENV_DAEMON_CONFIG_PATH_OVERRIDE
+            )
+        });
+    }
+
+    let policy = discover_repo_policy_optional(repo_root)?;
+    let Some(bound_path) = policy.daemon_config_path.as_deref() else {
+        bail!(
+            "Bitloops repo daemon binding is missing. Run `bitloops init` to bind this repo, or set `{}` to an explicit daemon config path.",
+            ENV_DAEMON_CONFIG_PATH_OVERRIDE
+        );
+    };
+
+    load_strict_daemon_settings(bound_path).with_context(|| {
+        format!(
+            "resolving repo-bound Bitloops daemon config from `{}`; rerun `bitloops init` to rebind this repo",
+            REPO_POLICY_LOCAL_FILE_NAME
+        )
+    })
+}
+
+pub fn resolve_bound_daemon_config_root_for_repo(repo_root: &Path) -> Result<PathBuf> {
+    repo_bound_daemon_settings_for_repo(repo_root).map(|loaded| loaded.root)
+}
+
+pub fn resolve_bound_daemon_config_path_for_repo(repo_root: &Path) -> Result<PathBuf> {
+    repo_bound_daemon_settings_for_repo(repo_root).map(|loaded| loaded.path)
+}
+
+pub fn resolve_bound_store_backend_config_for_repo(repo_root: &Path) -> Result<StoreBackendConfig> {
+    let loaded = repo_bound_daemon_settings_for_repo(repo_root)?;
+    resolve_store_backend_from_unified(&loaded.settings, &loaded.root)
+}
+
+pub fn resolve_bound_repo_runtime_db_path_for_repo(repo_root: &Path) -> Result<PathBuf> {
+    let config_root = resolve_bound_daemon_config_root_for_repo(repo_root)?;
+    Ok(resolve_repo_runtime_db_path_for_config_root(&config_root))
 }
 
 #[cfg(not(test))]

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -197,12 +197,37 @@ pub fn write_project_bootstrap_settings(
     strategy: &str,
     supported_agents: &[String],
 ) -> Result<()> {
+    write_project_bootstrap_settings_with_daemon_binding(path, strategy, supported_agents, None)
+}
+
+pub fn write_project_bootstrap_settings_with_daemon_binding(
+    path: &Path,
+    strategy: &str,
+    supported_agents: &[String],
+    daemon_config_path: Option<&Path>,
+) -> Result<()> {
     write_repo_policy_file(path, |doc| {
         ensure_capture_table(doc);
         doc["capture"]["enabled"] = Item::Value(TomlValue::from(true));
         doc["capture"]["strategy"] = Item::Value(TomlValue::from(strategy));
         ensure_agents_table(doc);
         doc["agents"]["supported"] = string_array_item(supported_agents);
+        if let Some(daemon_config_path) = daemon_config_path {
+            ensure_daemon_table(doc);
+            doc["daemon"]["config_path"] = Item::Value(TomlValue::from(
+                daemon_config_path.to_string_lossy().as_ref(),
+            ));
+        }
+        Ok(())
+    })
+}
+
+pub fn write_repo_daemon_binding(path: &Path, daemon_config_path: &Path) -> Result<()> {
+    write_repo_policy_file(path, |doc| {
+        ensure_daemon_table(doc);
+        doc["daemon"]["config_path"] = Item::Value(TomlValue::from(
+            daemon_config_path.to_string_lossy().as_ref(),
+        ));
         Ok(())
     })
 }
@@ -307,6 +332,12 @@ fn ensure_capture_table(doc: &mut DocumentMut) {
 fn ensure_agents_table(doc: &mut DocumentMut) {
     if doc.get("agents").is_none_or(|item| !item.is_table()) {
         doc["agents"] = Item::Table(Table::new());
+    }
+}
+
+fn ensure_daemon_table(doc: &mut DocumentMut) {
+    if doc.get("daemon").is_none_or(|item| !item.is_table()) {
+        doc["daemon"] = Item::Table(Table::new());
     }
 }
 

--- a/bitloops/src/config/store_config_tests/backend.rs
+++ b/bitloops/src/config/store_config_tests/backend.rs
@@ -271,6 +271,59 @@ fn resolve_store_backend_config_for_repo_reads_nearest_ancestor_daemon_config() 
 }
 
 #[test]
+fn resolve_bound_store_backend_config_for_repo_uses_repo_daemon_binding() {
+    let daemon_root = tempfile::tempdir().expect("daemon temp dir");
+    let repo = tempfile::tempdir().expect("repo temp dir");
+
+    write_envelope_config(
+        daemon_root.path(),
+        serde_json::json!({
+            "stores": {
+                "relational": {
+                    "sqlite_path": "stores/relational/bound.db"
+                },
+                "events": {
+                    "duckdb_path": "stores/event/bound.duckdb"
+                }
+            }
+        }),
+    );
+    crate::config::settings::write_repo_daemon_binding(
+        &repo.path().join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &daemon_root.path().join(BITLOOPS_CONFIG_RELATIVE_PATH),
+    )
+    .expect("write repo daemon binding");
+
+    let _guard = enter_process_state(None, &[]);
+    let cfg = crate::config::resolve_bound_store_backend_config_for_repo(repo.path())
+        .expect("bound store backend config");
+
+    assert_eq!(
+        cfg.relational.sqlite_path.as_deref(),
+        Some(resolved_path(daemon_root.path(), "stores/relational/bound.db").as_str())
+    );
+    assert_eq!(
+        cfg.events.duckdb_path.as_deref(),
+        Some(resolved_path(daemon_root.path(), "stores/event/bound.duckdb").as_str())
+    );
+}
+
+#[test]
+fn resolve_bound_store_backend_config_for_repo_rejects_missing_daemon_binding() {
+    let repo = tempfile::tempdir().expect("repo temp dir");
+
+    let _guard = enter_process_state(None, &[]);
+    let err = crate::config::resolve_bound_store_backend_config_for_repo(repo.path())
+        .expect_err("missing binding should fail");
+
+    assert!(
+        err.to_string()
+            .contains("Bitloops repo daemon binding is missing"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
 fn resolve_store_backend_config_for_repo_prefers_repo_scoped_config_over_explicit_override_in_tests()
  {
     let repo = tempfile::tempdir().expect("repo temp dir");

--- a/bitloops/src/config/store_config_tests/backend.rs
+++ b/bitloops/src/config/store_config_tests/backend.rs
@@ -209,22 +209,12 @@ fn resolve_store_backend_config_for_repo_uses_repo_root_parameter() {
     assert!(!cfg.relational.has_postgres());
     assert_eq!(
         cfg.relational.sqlite_path.as_deref(),
-        Some(
-            temp.path()
-                .join("data/devql.sqlite")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(temp.path(), "data/devql.sqlite").as_str())
     );
     assert!(!cfg.events.has_clickhouse());
     assert_eq!(
         cfg.events.duckdb_path.as_deref(),
-        Some(
-            temp.path()
-                .join("data/events.duckdb")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(temp.path(), "data/events.duckdb").as_str())
     );
 }
 
@@ -252,21 +242,11 @@ fn resolve_store_backend_config_for_repo_reads_nearest_ancestor_daemon_config() 
     let cfg = resolve_store_backend_config_for_repo(&repo_root).expect("store backend config");
     assert_eq!(
         cfg.relational.sqlite_path.as_deref(),
-        Some(
-            temp.path()
-                .join("stores/relational/relational.db")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(temp.path(), "stores/relational/relational.db").as_str())
     );
     assert_eq!(
         cfg.events.duckdb_path.as_deref(),
-        Some(
-            temp.path()
-                .join("stores/event/events.duckdb")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(temp.path(), "stores/event/events.duckdb").as_str())
     );
 }
 
@@ -372,21 +352,11 @@ fn resolve_store_backend_config_for_repo_prefers_repo_scoped_config_over_explici
     let cfg = resolve_store_backend_config_for_repo(repo.path()).expect("store backend config");
     assert_eq!(
         cfg.relational.sqlite_path.as_deref(),
-        Some(
-            repo.path()
-                .join("stores/relational/local.db")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(repo.path(), "stores/relational/local.db").as_str())
     );
     assert_eq!(
         cfg.events.duckdb_path.as_deref(),
-        Some(
-            repo.path()
-                .join("stores/event/local.duckdb")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(repo.path(), "stores/event/local.duckdb").as_str())
     );
 }
 
@@ -445,21 +415,11 @@ fn resolve_store_backend_config_honours_explicit_daemon_config_override_inside_g
     assert!(!cfg.relational.has_postgres());
     assert_eq!(
         cfg.relational.sqlite_path.as_deref(),
-        Some(
-            nested
-                .join("stores/relational/relational.db")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(&nested, "stores/relational/relational.db").as_str())
     );
     assert!(!cfg.events.has_clickhouse());
     assert_eq!(
         cfg.events.duckdb_path.as_deref(),
-        Some(
-            nested
-                .join("stores/event/events.duckdb")
-                .to_string_lossy()
-                .as_ref()
-        )
+        Some(resolved_path(&nested, "stores/event/events.duckdb").as_str())
     );
 }

--- a/bitloops/src/daemon.rs
+++ b/bitloops/src/daemon.rs
@@ -318,6 +318,14 @@ pub async fn execute_graphql<T: DeserializeOwned>(
     graphql_client::execute_graphql(repo_root, query, variables).await
 }
 
+pub async fn execute_repo_graphql<T: DeserializeOwned>(
+    repo_root: &Path,
+    query: &str,
+    variables: Value,
+) -> Result<T> {
+    graphql_client::execute_repo_graphql(repo_root, query, variables).await
+}
+
 pub(crate) async fn execute_slim_graphql<T: DeserializeOwned>(
     repo_root: &Path,
     scope: &SlimCliRepoScope,

--- a/bitloops/src/daemon/graphql_client.rs
+++ b/bitloops/src/daemon/graphql_client.rs
@@ -5,7 +5,15 @@ pub(super) async fn execute_graphql<T: DeserializeOwned>(
     query: &str,
     variables: Value,
 ) -> Result<T> {
-    execute_graphql_request(repo_root, "/devql/global", None, query, variables).await
+    execute_graphql_request(repo_root, "/devql/global", None, query, variables, false).await
+}
+
+pub(super) async fn execute_repo_graphql<T: DeserializeOwned>(
+    repo_root: &Path,
+    query: &str,
+    variables: Value,
+) -> Result<T> {
+    execute_graphql_request(repo_root, "/devql/global", None, query, variables, true).await
 }
 
 pub(super) async fn execute_slim_graphql<T: DeserializeOwned>(
@@ -14,7 +22,7 @@ pub(super) async fn execute_slim_graphql<T: DeserializeOwned>(
     query: &str,
     variables: Value,
 ) -> Result<T> {
-    execute_graphql_request(repo_root, "/devql", Some(scope), query, variables).await
+    execute_graphql_request(repo_root, "/devql", Some(scope), query, variables, true).await
 }
 
 async fn execute_graphql_request<T: DeserializeOwned>(
@@ -23,6 +31,7 @@ async fn execute_graphql_request<T: DeserializeOwned>(
     scope: Option<&SlimCliRepoScope>,
     query: &str,
     variables: Value,
+    require_binding: bool,
 ) -> Result<T> {
     let timings_enabled = crate::devql_timing::timings_enabled_from_env();
     let trace = timings_enabled.then(crate::devql_timing::TimingTrace::new);
@@ -57,6 +66,9 @@ async fn execute_graphql_request<T: DeserializeOwned>(
         "query": query,
         "variables": variables,
     }));
+    if require_binding {
+        request = crate::devql_transport::attach_repo_daemon_binding_headers(request, repo_root)?;
+    }
     if let Some(scope) = scope {
         request = attach_slim_cli_scope_headers(request, scope);
     }

--- a/bitloops/src/daemon/server_runtime.rs
+++ b/bitloops/src/daemon/server_runtime.rs
@@ -122,6 +122,7 @@ pub(super) async fn run_server(
             shutdown_message: Some("Bitloops daemon stopped.".to_string()),
             on_ready: Some(ready_hook),
             on_shutdown: Some(on_shutdown),
+            config_path: Some(daemon_config.config_path.clone()),
             config_root: Some(config_root),
             repo_registry_path: Some(daemon_config.repo_registry_path.clone()),
         },

--- a/bitloops/src/devql_transport.rs
+++ b/bitloops/src/devql_transport.rs
@@ -3,6 +3,7 @@ use axum::http::HeaderMap;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use reqwest::RequestBuilder;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
@@ -22,6 +23,7 @@ pub(crate) const HEADER_SCOPE_BRANCH: &str = "x-bitloops-cli-branch";
 pub(crate) const HEADER_SCOPE_PROJECT_PATH: &str = "x-bitloops-cli-project-path";
 pub(crate) const HEADER_SCOPE_GIT_DIR_RELATIVE_PATH: &str = "x-bitloops-cli-git-dir-relative-path";
 pub(crate) const HEADER_SCOPE_CONFIG_FINGERPRINT: &str = "x-bitloops-cli-config-fingerprint";
+pub(crate) const HEADER_DAEMON_BINDING: &str = "x-bitloops-daemon-binding";
 
 #[derive(Debug, Clone)]
 pub(crate) struct SlimCliRepoScope {
@@ -150,6 +152,34 @@ pub(crate) fn attach_slim_cli_scope_headers(
         ),
         None => request,
     }
+}
+
+pub(crate) fn daemon_binding_identifier_for_config_path(config_path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(config_path.to_string_lossy().as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+pub(crate) fn attach_repo_daemon_binding_headers(
+    request: RequestBuilder,
+    repo_root: &Path,
+) -> Result<RequestBuilder> {
+    let config_path = crate::config::resolve_bound_daemon_config_path_for_repo(repo_root)?;
+    let binding = daemon_binding_identifier_for_config_path(&config_path);
+    Ok(request
+        .header(
+            HEADER_SCOPE_REPO_ROOT,
+            encode_scope_header_value(&repo_root.to_string_lossy()),
+        )
+        .header(HEADER_DAEMON_BINDING, binding))
+}
+
+pub(crate) fn parse_repo_root_header(headers: &HeaderMap) -> Result<Option<PathBuf>> {
+    decode_scope_header_value(headers, HEADER_SCOPE_REPO_ROOT).map(|value| value.map(PathBuf::from))
+}
+
+pub(crate) fn parse_daemon_binding_header(headers: &HeaderMap) -> Result<Option<String>> {
+    header_value(headers, HEADER_DAEMON_BINDING)
 }
 
 pub(crate) fn parse_slim_cli_scope_headers(

--- a/bitloops/src/devql_transport.rs
+++ b/bitloops/src/devql_transport.rs
@@ -155,6 +155,9 @@ pub(crate) fn attach_slim_cli_scope_headers(
 }
 
 pub(crate) fn daemon_binding_identifier_for_config_path(config_path: &Path) -> String {
+    let config_path = config_path
+        .canonicalize()
+        .unwrap_or_else(|_| config_path.to_path_buf());
     let mut hasher = Sha256::new();
     hasher.update(config_path.to_string_lossy().as_bytes());
     hex::encode(hasher.finalize())

--- a/bitloops/src/graphql.rs
+++ b/bitloops/src/graphql.rs
@@ -47,7 +47,10 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use crate::devql_transport::{parse_slim_cli_scope_headers, upsert_repo_path_registry_scope};
+use crate::devql_transport::{
+    daemon_binding_identifier_for_config_path, parse_daemon_binding_header, parse_repo_root_header,
+    parse_slim_cli_scope_headers, upsert_repo_path_registry_scope,
+};
 
 pub(crate) type DevqlSchema = Schema<QueryRoot, MutationRoot, SubscriptionRoot>;
 pub(crate) type SlimDevqlSchema = Schema<SlimQueryRoot, MutationRoot, SlimSubscriptionRoot>;
@@ -164,6 +167,25 @@ pub(crate) async fn slim_graphql_handler(
             return response;
         }
     };
+    if let Err(err) = validate_repo_daemon_binding(
+        &headers,
+        &state,
+        scope.as_ref().map(|scope| scope.repo_root.as_path()),
+    ) {
+        let response = graphql_error_response(err).into_response();
+        track_devql_action(DevqlGraphqlTelemetry {
+            repo_root: state.repo_root.as_path(),
+            event: "bitloops devql slim http",
+            scope: "slim",
+            transport: "http",
+            request_kind: &signature.0,
+            operation_family: &signature.1,
+            success: false,
+            status: response.status(),
+            duration: started.elapsed(),
+        });
+        return response;
+    }
     if let (Some(scope), Some(registry_path)) = (scope.as_ref(), state.repo_registry_path())
         && let Err(err) = upsert_repo_path_registry_scope(registry_path, scope)
     {
@@ -220,6 +242,39 @@ pub(crate) async fn global_graphql_handler(
     let started = Instant::now();
     let request = request.into_inner();
     let signature = graphql_request_signature(&request);
+    let repo_root = match parse_repo_root_header(&headers) {
+        Ok(repo_root) => repo_root,
+        Err(err) => {
+            let response = graphql_error_response(err).into_response();
+            track_devql_action(DevqlGraphqlTelemetry {
+                repo_root: state.repo_root.as_path(),
+                event: "bitloops devql global http",
+                scope: "global",
+                transport: "http",
+                request_kind: &signature.0,
+                operation_family: &signature.1,
+                success: false,
+                status: response.status(),
+                duration: started.elapsed(),
+            });
+            return response;
+        }
+    };
+    if let Err(err) = validate_repo_daemon_binding(&headers, &state, repo_root.as_deref()) {
+        let response = graphql_error_response(err).into_response();
+        track_devql_action(DevqlGraphqlTelemetry {
+            repo_root: repo_root.as_deref().unwrap_or(state.repo_root.as_path()),
+            event: "bitloops devql global http",
+            scope: "global",
+            transport: "http",
+            request_kind: &signature.0,
+            operation_family: &signature.1,
+            success: false,
+            status: response.status(),
+            duration: started.elapsed(),
+        });
+        return response;
+    }
     let context = DevqlGraphqlContext::for_global_request(
         state.config_root.clone(),
         state.repo_root.clone(),
@@ -269,6 +324,25 @@ pub(crate) async fn slim_graphql_ws_handler(
             return response;
         }
     };
+    if let Err(err) = validate_repo_daemon_binding(
+        &headers,
+        &state,
+        scope.as_ref().map(|scope| scope.repo_root.as_path()),
+    ) {
+        let response = graphql_error_response(err).into_response();
+        track_devql_action(DevqlGraphqlTelemetry {
+            repo_root: state.repo_root.as_path(),
+            event: "bitloops devql slim ws",
+            scope: "slim",
+            transport: "ws",
+            request_kind: "subscription",
+            operation_family: "anonymous",
+            success: false,
+            status: response.status(),
+            duration: started.elapsed(),
+        });
+        return response;
+    }
     if let (Some(scope), Some(registry_path)) = (scope.as_ref(), state.repo_registry_path())
         && let Err(err) = upsert_repo_path_registry_scope(registry_path, scope)
     {
@@ -325,8 +399,16 @@ pub(crate) async fn global_graphql_ws_handler(
     State(state): State<crate::api::DashboardState>,
     protocol: GraphQLProtocol,
     upgrade: WebSocketUpgrade,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
     let started = Instant::now();
+    let repo_root = match parse_repo_root_header(&headers) {
+        Ok(repo_root) => repo_root,
+        Err(err) => return graphql_error_response(err).into_response(),
+    };
+    if let Err(err) = validate_repo_daemon_binding(&headers, &state, repo_root.as_deref()) {
+        return graphql_error_response(err).into_response();
+    }
     let context = DevqlGraphqlContext::for_global_request(
         state.config_root.clone(),
         state.repo_root.clone(),
@@ -353,6 +435,43 @@ pub(crate) async fn global_graphql_ws_handler(
         duration: started.elapsed(),
     });
     response
+}
+
+fn validate_repo_daemon_binding(
+    headers: &HeaderMap,
+    state: &crate::api::DashboardState,
+    repo_root: Option<&Path>,
+) -> Result<()> {
+    let binding = parse_daemon_binding_header(headers)?;
+    let Some(repo_root) = repo_root else {
+        if binding.is_some() {
+            anyhow::bail!(
+                "This repo is not configured to work with the current Bitloops daemon. Run `bitloops init` to bind or rebind this repo."
+            );
+        }
+        return Ok(());
+    };
+
+    let Some(binding) = binding else {
+        anyhow::bail!(
+            "This repo is not configured to work with the current Bitloops daemon. Run `bitloops init` to bind or rebind this repo."
+        );
+    };
+
+    let expected = daemon_binding_identifier_for_config_path(
+        &state
+            .config_path
+            .canonicalize()
+            .unwrap_or_else(|_| state.config_path.clone()),
+    );
+    if binding == expected {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "This repo at {} is not configured to work with the current Bitloops daemon. Run `bitloops init` to bind or rebind this repo.",
+        repo_root.display()
+    )
 }
 
 async fn execute_graphql_request<Query, Mutation, Subscription>(
@@ -524,20 +643,46 @@ fn graphql_playground_response(
 
 pub(crate) async fn slim_graphql_sdl_handler(
     State(state): State<crate::api::DashboardState>,
-) -> impl IntoResponse {
+    headers: HeaderMap,
+) -> AxumResponse {
+    let scope = match parse_slim_cli_scope_headers(&headers) {
+        Ok(scope) => scope,
+        Err(err) => {
+            return (axum::http::StatusCode::BAD_REQUEST, err.to_string()).into_response();
+        }
+    };
+    if let Err(err) = validate_repo_daemon_binding(
+        &headers,
+        &state,
+        scope.as_ref().map(|scope| scope.repo_root.as_path()),
+    ) {
+        return (axum::http::StatusCode::CONFLICT, err.to_string()).into_response();
+    }
     (
         [("content-type", "text/plain; charset=utf-8")],
         state.devql_slim_schema().sdl(),
     )
+        .into_response()
 }
 
 pub(crate) async fn global_graphql_sdl_handler(
     State(state): State<crate::api::DashboardState>,
-) -> impl IntoResponse {
+    headers: HeaderMap,
+) -> AxumResponse {
+    let repo_root = match parse_repo_root_header(&headers) {
+        Ok(repo_root) => repo_root,
+        Err(err) => {
+            return (axum::http::StatusCode::BAD_REQUEST, err.to_string()).into_response();
+        }
+    };
+    if let Err(err) = validate_repo_daemon_binding(&headers, &state, repo_root.as_deref()) {
+        return (axum::http::StatusCode::CONFLICT, err.to_string()).into_response();
+    }
     (
         [("content-type", "text/plain; charset=utf-8")],
         state.devql_global_schema().sdl(),
     )
+        .into_response()
 }
 
 fn map_execution_error(error: &ServerError) -> anyhow::Error {

--- a/bitloops/src/host/checkpoints/lifecycle/interaction.rs
+++ b/bitloops/src/host/checkpoints/lifecycle/interaction.rs
@@ -5,16 +5,37 @@ use crate::host::interactions::interaction_repository::create_interaction_reposi
 use crate::host::interactions::store::{InteractionEventRepository, InteractionSpool};
 
 pub(crate) fn resolve_interaction_spool(repo_root: &Path) -> Option<SqliteInteractionSpool> {
-    crate::host::runtime_store::RepoSqliteRuntimeStore::open(repo_root)
-        .ok()?
-        .interaction_spool()
-        .ok()
+    match crate::host::runtime_store::RepoSqliteRuntimeStore::open(repo_root) {
+        Ok(store) => match store.interaction_spool() {
+            Ok(spool) => Some(spool),
+            Err(err) => {
+                eprintln!(
+                    "[bitloops] Warning: skipping hook capture because the interaction spool could not be opened: {err:#}"
+                );
+                None
+            }
+        },
+        Err(err) => {
+            eprintln!(
+                "[bitloops] Warning: skipping hook capture because this repo is not bound to a valid Bitloops daemon config: {err:#}"
+            );
+            None
+        }
+    }
 }
 
 pub(crate) fn resolve_interaction_repository(
     repo_root: &Path,
 ) -> Option<impl InteractionEventRepository + use<>> {
-    let backends = crate::config::resolve_store_backend_config_for_repo(repo_root).ok()?;
+    let backends = match crate::config::resolve_bound_store_backend_config_for_repo(repo_root) {
+        Ok(backends) => backends,
+        Err(err) => {
+            eprintln!(
+                "[bitloops] Warning: skipping interaction flush because this repo is not bound to a valid Bitloops daemon config: {err:#}"
+            );
+            return None;
+        }
+    };
     let repo_id = crate::host::devql::resolve_repo_identity(repo_root)
         .ok()?
         .repo_id;

--- a/bitloops/src/host/checkpoints/strategy/manual_commit_tests/common.rs
+++ b/bitloops/src/host/checkpoints/strategy/manual_commit_tests/common.rs
@@ -24,9 +24,11 @@ fn write_test_store_backend_config(repo_root: &Path, include_events: bool) {
     let config = format!(
         "[stores.relational]\nsqlite_path = \"stores/relational/relational.db\"\n{events_section}\n[stores.blob]\nlocal_path = \"stores/blob\"\n"
     );
-    fs::write(
-        repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH),
-        config,
+    let config_path = repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH);
+    fs::write(&config_path, config).unwrap();
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
     )
     .unwrap();
 }

--- a/bitloops/src/host/checkpoints/strategy/manual_commit_tests/post_commit/helpers.rs
+++ b/bitloops/src/host/checkpoints/strategy/manual_commit_tests/post_commit/helpers.rs
@@ -354,8 +354,9 @@ fn write_post_commit_test_config(
             duckdb_path = duckdb_path.to_string_lossy()
         ),
     };
+    let config_path = repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH);
     fs::write(
-        repo_root.join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH),
+        &config_path,
         format!(
             "[stores.relational]\nsqlite_path = {sqlite_path:?}\n{postgres_line}\n[stores.event]\n{clickhouse_lines}\n[stores.blob]\nlocal_path = {blob_local_path:?}\n",
             sqlite_path = sqlite_path.to_string_lossy(),
@@ -364,4 +365,9 @@ fn write_post_commit_test_config(
         ),
     )
     .expect("write repo-local store config for post-commit tests");
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding for post-commit tests");
 }

--- a/bitloops/src/host/devql/types.rs
+++ b/bitloops/src/host/devql/types.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::config::resolve_daemon_config_root_for_repo;
+use crate::config::{
+    resolve_bound_daemon_config_root_for_repo, resolve_bound_store_backend_config_for_repo,
+};
 
 #[derive(Debug, Clone)]
 pub struct RepoIdentity {
@@ -24,8 +26,25 @@ pub struct DevqlConfig {
 
 impl DevqlConfig {
     pub fn from_env(repo_root: PathBuf, repo: RepoIdentity) -> Result<Self> {
-        let daemon_config_root = resolve_daemon_config_root_for_repo(&repo_root)?;
-        Self::from_roots(daemon_config_root, repo_root, repo)
+        let daemon_config_root = resolve_bound_daemon_config_root_for_repo(&repo_root)?;
+        let backend_cfg = resolve_bound_store_backend_config_for_repo(&repo_root)
+            .context("resolving backend config for DevQL runtime")?;
+        Ok(Self {
+            daemon_config_root,
+            repo_root,
+            repo,
+            pg_dsn: backend_cfg.relational.postgres_dsn,
+            clickhouse_url: backend_cfg
+                .events
+                .clickhouse_url
+                .unwrap_or_else(|| "http://localhost:8123".to_string()),
+            clickhouse_user: backend_cfg.events.clickhouse_user,
+            clickhouse_password: backend_cfg.events.clickhouse_password,
+            clickhouse_database: backend_cfg
+                .events
+                .clickhouse_database
+                .unwrap_or_else(|| "default".to_string()),
+        })
     }
 
     pub fn from_roots(

--- a/bitloops/src/host/interactions/db_store.rs
+++ b/bitloops/src/host/interactions/db_store.rs
@@ -14,11 +14,11 @@ mod tests;
 const LEGACY_INTERACTION_SPOOL_FILE_NAME: &str = "interaction_spool.sqlite";
 
 pub fn interaction_spool_db_path(repo_root: &Path) -> Result<PathBuf> {
-    crate::config::resolve_repo_runtime_db_path_for_repo(repo_root)
+    crate::config::resolve_bound_repo_runtime_db_path_for_repo(repo_root)
 }
 
 pub fn legacy_interaction_spool_db_path(repo_root: &Path) -> Result<PathBuf> {
-    let backends = crate::config::resolve_store_backend_config_for_repo(repo_root)
+    let backends = crate::config::resolve_bound_store_backend_config_for_repo(repo_root)
         .context("resolving backend config for interaction spool")?;
     let events_db_path = backends.events.resolve_duckdb_db_path_for_repo(repo_root);
     let parent = events_db_path.parent().with_context(|| {

--- a/bitloops/src/host/runtime_store/repo_blob.rs
+++ b/bitloops/src/host/runtime_store/repo_blob.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use crate::config::resolve_store_backend_config_for_repo;
+use crate::config::resolve_bound_store_backend_config_for_repo;
 use crate::storage::SqliteConnectionPool;
 
 use super::types::RepoSqliteRuntimeStore;
@@ -8,7 +8,7 @@ use super::util::sha256_hex;
 
 impl RepoSqliteRuntimeStore {
     pub(crate) fn open_repo_blob_store(&self) -> Result<crate::storage::blob::ResolvedBlobStore> {
-        let cfg = resolve_store_backend_config_for_repo(&self.repo_root)
+        let cfg = resolve_bound_store_backend_config_for_repo(&self.repo_root)
             .context("resolving backend config for repo runtime metadata")?;
         crate::storage::blob::create_blob_store_with_backend_for_repo(&cfg.blobs, &self.repo_root)
             .context("initialising blob storage for repo runtime metadata")

--- a/bitloops/src/host/runtime_store/repo_open.rs
+++ b/bitloops/src/host/runtime_store/repo_open.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::config::{
-    resolve_daemon_config_root_for_repo, resolve_repo_runtime_db_path_for_config_root,
+    resolve_bound_daemon_config_root_for_repo, resolve_repo_runtime_db_path_for_config_root,
 };
 use crate::host::checkpoints::session::DbSessionBackend;
 use crate::host::interactions::db_store::SqliteInteractionSpool;
@@ -14,7 +14,7 @@ use super::types::RepoSqliteRuntimeStore;
 
 impl RepoSqliteRuntimeStore {
     pub fn open(repo_root: &Path) -> Result<Self> {
-        let daemon_config_root = resolve_daemon_config_root_for_repo(repo_root)
+        let daemon_config_root = resolve_bound_daemon_config_root_for_repo(repo_root)
             .context("resolving daemon config root for runtime store")?;
         Self::open_for_roots(&daemon_config_root, repo_root)
     }

--- a/bitloops/src/host/runtime_store/tests.rs
+++ b/bitloops/src/host/runtime_store/tests.rs
@@ -30,7 +30,16 @@ local_path = "stores/blob"
 "#,
     )
     .expect("write test daemon config");
+    crate::config::settings::write_repo_daemon_binding(
+        &config_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
     config_path
+}
+
+fn canonical_root(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 #[test]
@@ -41,8 +50,8 @@ fn repo_runtime_store_uses_config_root_runtime_sqlite_path() {
     init_test_repo(&repo_root, "main", "Bitloops Test", "bitloops@example.com");
     let config_path = write_test_daemon_config(dir.path());
     let config_path_string = config_path.to_string_lossy().to_string();
-    let expected = dir
-        .path()
+    let expected = dir.path();
+    let expected = canonical_root(expected)
         .join("stores")
         .join("runtime")
         .join("runtime.sqlite");
@@ -68,26 +77,30 @@ fn repo_runtime_store_fails_without_daemon_config() {
         let err = RepoSqliteRuntimeStore::open(dir.path()).expect_err("runtime store should fail");
         let message = format!("{err:#}");
         assert!(
-            message
-                .contains("Bitloops daemon config is required to resolve the repo runtime store"),
+            message.contains("Bitloops repo daemon binding is missing"),
             "expected missing-config runtime store failure, got: {message}"
         );
     });
 }
 
 #[test]
-fn repo_runtime_store_uses_nearest_ancestor_daemon_config_root() {
+fn repo_runtime_store_uses_repo_daemon_binding() {
     let dir = TempDir::new().expect("tempdir");
     let repo_root = dir.path().join("bitloops");
     fs::create_dir_all(&repo_root).expect("create repo root");
     init_test_repo(&repo_root, "main", "Bitloops Test", "bitloops@example.com");
-    let expected = dir
-        .path()
+    let expected = dir.path();
+    let expected = canonical_root(expected)
         .join("stores")
         .join("runtime")
         .join("runtime.sqlite");
 
     write_test_daemon_config(dir.path());
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &dir.path().join(BITLOOPS_CONFIG_RELATIVE_PATH),
+    )
+    .expect("write repo daemon binding");
 
     with_env_var(ENV_DAEMON_CONFIG_PATH_OVERRIDE, None, || {
         let actual = RepoSqliteRuntimeStore::open(&repo_root)
@@ -110,8 +123,8 @@ fn repo_runtime_store_shares_runtime_sqlite_and_fences_rows_by_repo() {
 
     let config_path = write_test_daemon_config(dir.path());
     let config_path_string = config_path.to_string_lossy().to_string();
-    let expected_db_path = dir
-        .path()
+    let expected_db_path = dir.path();
+    let expected_db_path = canonical_root(expected_db_path)
         .join("stores")
         .join("runtime")
         .join("runtime.sqlite");

--- a/bitloops/src/test_support/git_fixtures.rs
+++ b/bitloops/src/test_support/git_fixtures.rs
@@ -73,6 +73,11 @@ local_path = {blob_path:?}
 "#,
     );
     std::fs::write(&config_path, config_contents).expect("write test daemon config");
+    crate::config::settings::write_repo_daemon_binding(
+        &config_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write test repo daemon binding");
     config_path
 }
 

--- a/bitloops/tests/agent_cli_smoke.rs
+++ b/bitloops/tests/agent_cli_smoke.rs
@@ -360,8 +360,9 @@ fn run_git_without_hooks_expect_success_with_home(
 }
 
 fn write_repo_config(repo: &Path) {
+    let config_path = repo.join(bitloops::config::BITLOOPS_CONFIG_RELATIVE_PATH);
     fs::write(
-        repo.join(bitloops::config::BITLOOPS_CONFIG_RELATIVE_PATH),
+        &config_path,
         r#"[stores.relational]
 sqlite_path = "stores/relational/relational.db"
 
@@ -373,6 +374,11 @@ local_path = "stores/blob"
 "#,
     )
     .expect("write repo config");
+    bitloops::config::settings::write_repo_daemon_binding(
+        &repo.join(bitloops::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
 }
 
 fn init_repo_with_home(repo: &Path, home: &Path) {

--- a/bitloops/tests/copilot_integration.rs
+++ b/bitloops/tests/copilot_integration.rs
@@ -224,8 +224,9 @@ fn run_git_without_hooks_expect_success(
 }
 
 fn write_repo_config(repo: &Path) {
+    let config_path = repo.join(bitloops::config::BITLOOPS_CONFIG_RELATIVE_PATH);
     fs::write(
-        repo.join(bitloops::config::BITLOOPS_CONFIG_RELATIVE_PATH),
+        &config_path,
         r#"[stores.relational]
 sqlite_path = "stores/relational/relational.db"
 
@@ -237,6 +238,11 @@ local_path = "stores/blob"
 "#,
     )
     .expect("write repo config");
+    bitloops::config::settings::write_repo_daemon_binding(
+        &repo.join(bitloops::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
 }
 
 fn init_repo(repo: &Path, home: &Path) {

--- a/bitloops/tests/test_command_support.rs
+++ b/bitloops/tests/test_command_support.rs
@@ -29,6 +29,7 @@ pub fn apply_repo_app_env(cmd: &mut Command, repo: &Path) {
 
 #[allow(dead_code)]
 pub fn write_test_daemon_config(repo: &Path) {
+    let config_path = repo.join(bitloops::config::BITLOOPS_CONFIG_RELATIVE_PATH);
     let daemon_state_root = repo
         .parent()
         .map(Path::to_path_buf)
@@ -49,7 +50,7 @@ pub fn write_test_daemon_config(repo: &Path) {
         .join("events.duckdb");
     let blob_path = daemon_state_root.join("stores").join("blob");
     fs::write(
-        repo.join(bitloops::config::BITLOOPS_CONFIG_RELATIVE_PATH),
+        &config_path,
         format!(
             r#"[runtime]
 local_dev = false
@@ -66,6 +67,11 @@ local_path = {blob_path:?}
         ),
     )
     .expect("write repo daemon config");
+    bitloops::config::settings::write_repo_daemon_binding(
+        &repo.join(bitloops::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
 }
 
 #[allow(dead_code)]

--- a/bitloops/tests/test_harness_support/mod.rs
+++ b/bitloops/tests/test_harness_support/mod.rs
@@ -60,6 +60,11 @@ local_path = {blob_path:?}
 "#,
     );
     fs::write(&config_path, config_contents).expect("write test daemon config");
+    bitloops::config::settings::write_repo_daemon_binding(
+        &config_root.join(bitloops::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write test repo daemon binding");
     config_path
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -660,13 +660,22 @@ fn nextest_list_args(run_args: &[String], profile_args: &[String]) -> Result<Vec
         return Err("expected nextest run arguments for test lane".to_string());
     }
     args[1] = "list".to_string();
-    args.extend_from_slice(profile_args);
-    args.push("--list-type".to_string());
-    args.push("binaries-only".to_string());
-    args.push("--message-format".to_string());
-    args.push("json".to_string());
-    args.push("--cargo-message-format".to_string());
-    args.push("json-render-diagnostics".to_string());
+
+    let separator_index = args.iter().position(|arg| arg == "--");
+    let mut list_only_args = profile_args.to_vec();
+    list_only_args.push("--list-type".to_string());
+    list_only_args.push("binaries-only".to_string());
+    list_only_args.push("--message-format".to_string());
+    list_only_args.push("json".to_string());
+    list_only_args.push("--cargo-message-format".to_string());
+    list_only_args.push("json-render-diagnostics".to_string());
+
+    if let Some(index) = separator_index {
+        args.splice(index..index, list_only_args);
+    } else {
+        args.extend(list_only_args);
+    }
+
     Ok(args)
 }
 
@@ -1321,6 +1330,46 @@ mod tests {
         assert!(out.contains(&"--list-type".to_string()));
         assert!(out.contains(&"binaries-only".to_string()));
         assert!(out.contains(&"json-render-diagnostics".to_string()));
+    }
+
+    #[test]
+    fn nextest_list_args_inserts_machine_output_before_test_binary_args() {
+        let args = vec![
+            "nextest".to_string(),
+            "run".to_string(),
+            "--manifest-path".to_string(),
+            BITLOOPS_MANIFEST.to_string(),
+            "--no-default-features".to_string(),
+            "--features".to_string(),
+            "slow-tests".to_string(),
+            "--lib".to_string(),
+            "--".to_string(),
+            "host::devql::cucumber_bdd::devql_bdd_features_pass".to_string(),
+            "--exact".to_string(),
+        ];
+        let out = super::nextest_list_args(&args, &[]).expect("list args");
+
+        let separator_index = out
+            .iter()
+            .position(|arg| arg == "--")
+            .expect("separator should be preserved");
+        assert!(
+            separator_index > 1,
+            "separator should remain after nextest list arguments"
+        );
+        assert_eq!(
+            out[separator_index + 1],
+            "host::devql::cucumber_bdd::devql_bdd_features_pass"
+        );
+        assert_eq!(out[separator_index + 2], "--exact");
+        assert!(
+            out[..separator_index].contains(&"--list-type".to_string()),
+            "list-only flags must stay before the test-binary separator"
+        );
+        assert!(
+            !out[separator_index + 1..].contains(&"--list-type".to_string()),
+            "list-only flags must not be forwarded to the test binary"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a local-only repo binding in .bitloops.local.toml: [daemon] config_path = "/absolute/path/to/config.toml".
- Make that binding the primary source for repo-scoped daemon config resolution after bitloops init; do not use nearest-config or default-config fallback for capture, spool, queue, or turn-data writes.
- Have bitloops init bind the repo to the currently running daemon by storing the daemon’s canonicalised config path.
- Send a daemon-binding identifier on repo-scoped daemon requests and reject mismatches server-side.
- If daemon config information is missing or invalid, accept losing hook data rather than risking writes into another project’s stores.

## Validation

- [X] I ran the relevant tests locally.

## Jira

- [X] Linked Jira issue(s) are updated with implementation notes and test results. CLI-1627

