### PR TITLE
CLI-1626 shared task orchestration for sync and ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Shared DevQL task orchestration for sync and ingest**: replaced the sync-only daemon queue with a generic persisted DevQL task subsystem that manages both sync and ingest work. The daemon now stores typed task records and repo control state, migrates legacy sync queue documents into the new task state on recovery, supports repo-scoped pause/resume plus queued-task cancellation, and schedules independent per-repo `sync` and `ingest` lanes so one sync and one ingest can run concurrently for the same repository. Ingest correctness remains owned by `commit_ingest_ledger` and branch watermarks rather than orchestration state.
+
 ### Changed
+
+- **DevQL GraphQL and CLI surfaces are now task-first**: removed the sync-only GraphQL task fields and the direct/local ingest execution path, and switched the public interface to generic tasks. GraphQL now exposes `enqueueTask`, `task`, `tasks`, `taskQueue`, `pauseTaskQueue`, `resumeTaskQueue`, `cancelTask`, and `taskProgress`, while the CLI now uses `bitloops devql tasks enqueue|watch|status|list|pause|resume|cancel`. `bitloops init`, `bitloops status`, `bitloops daemon status`, and existing sync producers now route through the shared task coordinator, and the checked-in SDL snapshots were refreshed for the new schema.
 
 ### Fixed
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ For other platforms, follow the official installation guide:
 `cargo dev-loop` runs: `fmt` (write fixes) -> `clippy` -> fast tests -> file-size check.
 `cargo dev-test-fast` is the default local feedback loop.
 `cargo-nextest` is the default runner behind `dev-test-*`, `test-*`, and `qat*`.
+That default does not ban `cargo test`: use the checked-in aliases for the standard lanes, and use `cargo test` only where this guide explicitly calls for it or where `cargo-nextest` cannot cover the case.
 The checked-in local `nextest` default is `8` test threads.
 CI uses the `ci` `nextest` profile, pinned to `6` test threads.
 `cargo dev-test-merge` runs the fast lane plus a curated set of slow smoke suites and is the blocking gate for pull requests into `develop`.
@@ -133,7 +134,7 @@ The `postgres-tests` Cargo feature is **not** enabled by `slow-tests`, `dev-test
 cargo test -p bitloops --lib --no-default-features --features postgres-tests
 ```
 
-If the repo gains doctests in future, keep running those through `cargo test --doc`; `cargo-nextest` does not support doctests.
+If the repo gains doctests in future, keep running those through `cargo test --doc`; `cargo-nextest` does not support doctests. This is another explicit exception to the default `nextest`-backed lanes above.
 
 ## Checklist before opening a PR
 

--- a/bitloops/schema.graphql
+++ b/bitloops/schema.graphql
@@ -336,7 +336,11 @@ enum EdgeKind {
 	EXPORTS
 }
 
-input EnqueueSyncInput {
+input EnqueueIngestTaskInput {
+	backfill: Int = null
+}
+
+input EnqueueSyncTaskInput {
 	full: Boolean! = false
 	paths: [String!] = null
 	repair: Boolean! = false
@@ -344,8 +348,14 @@ input EnqueueSyncInput {
 	source: String = null
 }
 
-type EnqueueSyncResult {
-	task: SyncTask!
+input EnqueueTaskInput {
+	kind: TaskKind!
+	sync: EnqueueSyncTaskInput = null
+	ingest: EnqueueIngestTaskInput = null
+}
+
+type EnqueueTaskResult {
+	task: Task!
 	merged: Boolean!
 }
 
@@ -371,10 +381,6 @@ type HealthStatus {
 	blob: HealthBackendStatus!
 }
 
-input IngestInput {
-	backfill: Int = null
-}
-
 type IngestResult {
 	success: Boolean!
 	commitsProcessed: Int!
@@ -387,6 +393,10 @@ type IngestResult {
 	symbolEmbeddingRowsSkipped: Int!
 	symbolCloneEdgesUpserted: Int!
 	symbolCloneSourcesScored: Int!
+}
+
+type IngestTaskSpec {
+	backfill: Int
 }
 
 enum IngestionPhase {
@@ -579,8 +589,10 @@ type MigrationRecord {
 type MutationRoot {
 	updateCliTelemetryConsent(cliVersion: String!, telemetry: Boolean): UpdateCliTelemetryConsentResult!
 	initSchema: InitSchemaResult!
-	ingest(input: IngestInput): IngestResult!
-	enqueueSync(input: EnqueueSyncInput!): EnqueueSyncResult!
+	enqueueTask(input: EnqueueTaskInput!): EnqueueTaskResult!
+	pauseTaskQueue(reason: String): TaskQueueControlResult!
+	resumeTaskQueue(repoId: String): TaskQueueControlResult!
+	cancelTask(id: String!): Task!
 	addKnowledge(input: AddKnowledgeInput!): AddKnowledgeResult!
 	associateKnowledge(input: AssociateKnowledgeInput!): AssociateKnowledgeResult!
 	refreshKnowledge(input: RefreshKnowledgeInput!): RefreshKnowledgeResult!
@@ -613,8 +625,9 @@ type Project {
 type QueryRoot {
 	health: HealthStatus!
 	repo(name: String!): Repository!
-	syncTask(id: String!): SyncTask
-	syncTasks(repoId: String, limit: Int): [SyncTask!]!
+	task(id: String!): Task
+	tasks(repoId: String, kind: TaskKind, status: TaskStatus, limit: Int): [Task!]!
+	taskQueue(repoId: String): TaskQueueStatus!
 }
 
 input RefreshKnowledgeInput {
@@ -660,38 +673,7 @@ enum SaveSelector {
 
 type SubscriptionRoot {
 	checkpointIngested(repoName: String!): Checkpoint!
-	ingestionProgress(repoName: String!): IngestionProgressEvent!
-	syncProgress(taskId: String!): SyncProgressEvent!
-}
-
-type SyncProgressEvent {
-	taskId: String!
-	repoId: String!
-	repoName: String!
-	repoIdentity: String!
-	source: String!
-	mode: String!
-	status: String!
-	submittedAtUnix: Int!
-	startedAtUnix: Int
-	updatedAtUnix: Int!
-	completedAtUnix: Int
-	queuePosition: Int
-	tasksAhead: Int
-	phase: String!
-	currentPath: String
-	pathsTotal: Int!
-	pathsCompleted: Int!
-	pathsRemaining: Int!
-	pathsUnchanged: Int!
-	pathsAdded: Int!
-	pathsChanged: Int!
-	pathsRemoved: Int!
-	cacheHits: Int!
-	cacheMisses: Int!
-	parseErrors: Int!
-	error: String
-	summary: SyncResult
+	taskProgress(taskId: String!): TaskProgressEvent!
 }
 
 type SyncResult {
@@ -712,20 +694,7 @@ type SyncResult {
 	validation: SyncValidationResult
 }
 
-type SyncTask {
-	taskId: String!
-	repoId: String!
-	repoName: String!
-	repoIdentity: String!
-	source: String!
-	mode: String!
-	status: String!
-	submittedAtUnix: Int!
-	startedAtUnix: Int
-	updatedAtUnix: Int!
-	completedAtUnix: Int
-	queuePosition: Int
-	tasksAhead: Int
+type SyncTaskProgress {
 	phase: String!
 	currentPath: String
 	pathsTotal: Int!
@@ -738,8 +707,11 @@ type SyncTask {
 	cacheHits: Int!
 	cacheMisses: Int!
 	parseErrors: Int!
-	error: String
-	summary: SyncResult
+}
+
+type SyncTaskSpec {
+	mode: String!
+	paths: [String!]!
 }
 
 type SyncValidationFileDriftResult {
@@ -765,6 +737,76 @@ type SyncValidationResult {
 	staleEdges: Int!
 	mismatchedEdges: Int!
 	filesWithDrift: [SyncValidationFileDriftResult!]!
+}
+
+type Task {
+	taskId: String!
+	repoId: String!
+	repoName: String!
+	repoIdentity: String!
+	kind: TaskKind!
+	source: String!
+	status: TaskStatus!
+	submittedAtUnix: Int!
+	startedAtUnix: Int
+	updatedAtUnix: Int!
+	completedAtUnix: Int
+	queuePosition: Int
+	tasksAhead: Int
+	error: String
+	syncSpec: SyncTaskSpec
+	ingestSpec: IngestTaskSpec
+	syncProgress: SyncTaskProgress
+	ingestProgress: IngestionProgressEvent
+	syncResult: SyncResult
+	ingestResult: IngestResult
+}
+
+enum TaskKind {
+	SYNC
+	INGEST
+}
+
+type TaskKindCounts {
+	kind: TaskKind!
+	queuedTasks: Int!
+	runningTasks: Int!
+	failedTasks: Int!
+	completedRecentTasks: Int!
+}
+
+type TaskProgressEvent {
+	task: Task!
+}
+
+type TaskQueueControlResult {
+	message: String!
+	repoId: String!
+	paused: Boolean!
+	pausedReason: String
+	updatedAtUnix: Int!
+}
+
+type TaskQueueStatus {
+	persisted: Boolean!
+	queuedTasks: Int!
+	runningTasks: Int!
+	failedTasks: Int!
+	completedRecentTasks: Int!
+	byKind: [TaskKindCounts!]!
+	paused: Boolean!
+	pausedReason: String
+	lastAction: String
+	lastUpdatedUnix: Int!
+	currentRepoTasks: [Task!]!
+}
+
+enum TaskStatus {
+	QUEUED
+	RUNNING
+	COMPLETED
+	FAILED
+	CANCELLED
 }
 
 type TelemetryEvent {

--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -370,7 +370,11 @@ enum EdgeKind {
 	EXPORTS
 }
 
-input EnqueueSyncInput {
+input EnqueueIngestTaskInput {
+	backfill: Int = null
+}
+
+input EnqueueSyncTaskInput {
 	full: Boolean! = false
 	paths: [String!] = null
 	repair: Boolean! = false
@@ -378,8 +382,14 @@ input EnqueueSyncInput {
 	source: String = null
 }
 
-type EnqueueSyncResult {
-	task: SyncTask!
+input EnqueueTaskInput {
+	kind: TaskKind!
+	sync: EnqueueSyncTaskInput = null
+	ingest: EnqueueIngestTaskInput = null
+}
+
+type EnqueueTaskResult {
+	task: Task!
 	merged: Boolean!
 }
 
@@ -405,10 +415,6 @@ type HealthStatus {
 	blob: HealthBackendStatus!
 }
 
-input IngestInput {
-	backfill: Int = null
-}
-
 type IngestResult {
 	success: Boolean!
 	commitsProcessed: Int!
@@ -421,6 +427,10 @@ type IngestResult {
 	symbolEmbeddingRowsSkipped: Int!
 	symbolCloneEdgesUpserted: Int!
 	symbolCloneSourcesScored: Int!
+}
+
+type IngestTaskSpec {
+	backfill: Int
 }
 
 enum IngestionPhase {
@@ -571,8 +581,10 @@ type MigrationRecord {
 type MutationRoot {
 	updateCliTelemetryConsent(cliVersion: String!, telemetry: Boolean): UpdateCliTelemetryConsentResult!
 	initSchema: InitSchemaResult!
-	ingest(input: IngestInput): IngestResult!
-	enqueueSync(input: EnqueueSyncInput!): EnqueueSyncResult!
+	enqueueTask(input: EnqueueTaskInput!): EnqueueTaskResult!
+	pauseTaskQueue(reason: String): TaskQueueControlResult!
+	resumeTaskQueue(repoId: String): TaskQueueControlResult!
+	cancelTask(id: String!): Task!
 	addKnowledge(input: AddKnowledgeInput!): AddKnowledgeResult!
 	associateKnowledge(input: AssociateKnowledgeInput!): AssociateKnowledgeResult!
 	refreshKnowledge(input: RefreshKnowledgeInput!): RefreshKnowledgeResult!
@@ -627,8 +639,9 @@ type SlimQueryRoot {
 	checkpoints(agent: String, since: DateTime, first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	telemetry(eventType: String, agent: String, since: DateTime, first: Int, after: String, last: Int, before: String): TelemetryEventConnection!
 	users: [String!]!
-	syncTask(id: String!): SyncTask
-	syncTasks(limit: Int): [SyncTask!]!
+	task(id: String!): Task
+	tasks(kind: TaskKind, status: TaskStatus, limit: Int): [Task!]!
+	taskQueue: TaskQueueStatus!
 	agents: [String!]!
 	file(path: String!): FileContext!
 	files(path: String!): [FileContext!]!
@@ -645,38 +658,7 @@ type SlimQueryRoot {
 
 type SlimSubscriptionRoot {
 	checkpointIngested: Checkpoint!
-	ingestionProgress: IngestionProgressEvent!
-	syncProgress(taskId: String!): SyncProgressEvent!
-}
-
-type SyncProgressEvent {
-	taskId: String!
-	repoId: String!
-	repoName: String!
-	repoIdentity: String!
-	source: String!
-	mode: String!
-	status: String!
-	submittedAtUnix: Int!
-	startedAtUnix: Int
-	updatedAtUnix: Int!
-	completedAtUnix: Int
-	queuePosition: Int
-	tasksAhead: Int
-	phase: String!
-	currentPath: String
-	pathsTotal: Int!
-	pathsCompleted: Int!
-	pathsRemaining: Int!
-	pathsUnchanged: Int!
-	pathsAdded: Int!
-	pathsChanged: Int!
-	pathsRemoved: Int!
-	cacheHits: Int!
-	cacheMisses: Int!
-	parseErrors: Int!
-	error: String
-	summary: SyncResult
+	taskProgress(taskId: String!): TaskProgressEvent!
 }
 
 type SyncResult {
@@ -697,20 +679,7 @@ type SyncResult {
 	validation: SyncValidationResult
 }
 
-type SyncTask {
-	taskId: String!
-	repoId: String!
-	repoName: String!
-	repoIdentity: String!
-	source: String!
-	mode: String!
-	status: String!
-	submittedAtUnix: Int!
-	startedAtUnix: Int
-	updatedAtUnix: Int!
-	completedAtUnix: Int
-	queuePosition: Int
-	tasksAhead: Int
+type SyncTaskProgress {
 	phase: String!
 	currentPath: String
 	pathsTotal: Int!
@@ -723,8 +692,11 @@ type SyncTask {
 	cacheHits: Int!
 	cacheMisses: Int!
 	parseErrors: Int!
-	error: String
-	summary: SyncResult
+}
+
+type SyncTaskSpec {
+	mode: String!
+	paths: [String!]!
 }
 
 type SyncValidationFileDriftResult {
@@ -750,6 +722,76 @@ type SyncValidationResult {
 	staleEdges: Int!
 	mismatchedEdges: Int!
 	filesWithDrift: [SyncValidationFileDriftResult!]!
+}
+
+type Task {
+	taskId: String!
+	repoId: String!
+	repoName: String!
+	repoIdentity: String!
+	kind: TaskKind!
+	source: String!
+	status: TaskStatus!
+	submittedAtUnix: Int!
+	startedAtUnix: Int
+	updatedAtUnix: Int!
+	completedAtUnix: Int
+	queuePosition: Int
+	tasksAhead: Int
+	error: String
+	syncSpec: SyncTaskSpec
+	ingestSpec: IngestTaskSpec
+	syncProgress: SyncTaskProgress
+	ingestProgress: IngestionProgressEvent
+	syncResult: SyncResult
+	ingestResult: IngestResult
+}
+
+enum TaskKind {
+	SYNC
+	INGEST
+}
+
+type TaskKindCounts {
+	kind: TaskKind!
+	queuedTasks: Int!
+	runningTasks: Int!
+	failedTasks: Int!
+	completedRecentTasks: Int!
+}
+
+type TaskProgressEvent {
+	task: Task!
+}
+
+type TaskQueueControlResult {
+	message: String!
+	repoId: String!
+	paused: Boolean!
+	pausedReason: String
+	updatedAtUnix: Int!
+}
+
+type TaskQueueStatus {
+	persisted: Boolean!
+	queuedTasks: Int!
+	runningTasks: Int!
+	failedTasks: Int!
+	completedRecentTasks: Int!
+	byKind: [TaskKindCounts!]!
+	paused: Boolean!
+	pausedReason: String
+	lastAction: String
+	lastUpdatedUnix: Int!
+	currentRepoTasks: [Task!]!
+}
+
+enum TaskStatus {
+	QUEUED
+	RUNNING
+	COMPLETED
+	FAILED
+	CANCELLED
 }
 
 type TelemetryEvent {

--- a/bitloops/src/api/dashboard_runtime.rs
+++ b/bitloops/src/api/dashboard_runtime.rs
@@ -232,7 +232,7 @@ pub(super) async fn run(
         devql_schema,
         devql_slim_schema,
     };
-    crate::daemon::activate_sync_worker(state.subscription_hub());
+    crate::daemon::activate_task_worker(state.subscription_hub());
 
     match (transport, tls_acceptor) {
         (DashboardTransport::Https, Some(acceptor)) => {

--- a/bitloops/src/api/tests/devql_mutations_and_health.rs
+++ b/bitloops/src/api/tests/devql_mutations_and_health.rs
@@ -574,7 +574,7 @@ async fn slim_graphql_health_and_default_branch_after_init() {
 }
 
 #[tokio::test]
-async fn devql_mutations_initialise_schema_and_ingest_with_typed_results() {
+async fn devql_mutations_initialise_schema_and_enqueue_ingest_with_typed_results() {
     let repo = seed_graphql_mutation_repo();
     let sqlite_path = checkpoint_sqlite_path(repo.path());
     let schema = slim_schema_for_repo(repo.path());
@@ -640,22 +640,30 @@ async fn devql_mutations_initialise_schema_and_ingest_with_typed_results() {
     assert_eq!(second_init_json["initSchema"]["success"], true);
     write_current_repo_runtime_state(repo.path());
 
-    let ingest_response = schema
+    let enqueue_response = schema
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest {
-                success
-                commitsProcessed
-                checkpointCompanionsProcessed
-                eventsInserted
-                artefactsUpserted
-                semanticFeatureRowsUpserted
-                semanticFeatureRowsSkipped
-                symbolEmbeddingRowsUpserted
-                symbolEmbeddingRowsSkipped
-                symbolCloneEdgesUpserted
-                symbolCloneSourcesScored
+              enqueueTask(input: { kind: INGEST, ingest: { backfill: 50 } }) {
+                merged
+                task {
+                  kind
+                  status
+                  ingestSpec {
+                    backfill
+                  }
+                  ingestProgress {
+                    phase
+                    commitsTotal
+                    commitsProcessed
+                    checkpointCompanionsProcessed
+                    eventsInserted
+                    artefactsUpserted
+                  }
+                  ingestResult {
+                    success
+                  }
+                }
               }
             }
             "#,
@@ -663,35 +671,58 @@ async fn devql_mutations_initialise_schema_and_ingest_with_typed_results() {
         .await;
 
     assert!(
-        ingest_response.errors.is_empty(),
+        enqueue_response.errors.is_empty(),
         "graphql errors: {:?}",
-        ingest_response.errors
+        enqueue_response.errors
     );
-    let ingest_json = ingest_response
+    let enqueue_json = enqueue_response
         .data
         .into_json()
         .expect("graphql data to json");
-    assert_eq!(ingest_json["ingest"]["success"], true);
-    assert_eq!(ingest_json["ingest"]["commitsProcessed"], 1);
-    assert_eq!(ingest_json["ingest"]["checkpointCompanionsProcessed"], 0);
-    assert_eq!(ingest_json["ingest"]["eventsInserted"], 0);
-    assert_eq!(ingest_json["ingest"]["artefactsUpserted"], 1);
-    assert_eq!(ingest_json["ingest"]["semanticFeatureRowsUpserted"], 2);
-    assert_eq!(ingest_json["ingest"]["semanticFeatureRowsSkipped"], 0);
-    assert_eq!(ingest_json["ingest"]["symbolEmbeddingRowsUpserted"], 0);
-    assert_eq!(ingest_json["ingest"]["symbolEmbeddingRowsSkipped"], 0);
-    assert_eq!(ingest_json["ingest"]["symbolCloneEdgesUpserted"], 0);
-    assert_eq!(ingest_json["ingest"]["symbolCloneSourcesScored"], 0);
+    assert_eq!(enqueue_json["enqueueTask"]["merged"], false);
+    assert_eq!(enqueue_json["enqueueTask"]["task"]["kind"], "INGEST");
+    assert_eq!(enqueue_json["enqueueTask"]["task"]["status"], "QUEUED");
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestSpec"]["backfill"],
+        50
+    );
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestProgress"]["phase"],
+        "INITIALIZING"
+    );
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestProgress"]["commitsTotal"],
+        0
+    );
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestProgress"]["commitsProcessed"],
+        0
+    );
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestProgress"]["checkpointCompanionsProcessed"],
+        0
+    );
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestProgress"]["eventsInserted"],
+        0
+    );
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestProgress"]["artefactsUpserted"],
+        0
+    );
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestResult"],
+        serde_json::Value::Null
+    );
 
     let repository_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM repositories", [], |row| row.get(0))
         .expect("count repositories");
-    assert_eq!(repository_count, 1, "expected repository row after ingest");
+    assert_eq!(repository_count, 0, "enqueueing should not execute ingest inline");
 }
 
 #[tokio::test]
-async fn devql_ingest_mutation_with_backfill_limits_history_window() {
-    use rusqlite::OptionalExtension;
+async fn enqueue_task_ingest_accepts_backfill_input() {
 
     let repo = seed_graphql_mutation_repo();
     fs::write(
@@ -701,10 +732,6 @@ async fn devql_ingest_mutation_with_backfill_limits_history_window() {
     .expect("write second revision");
     git_ok(repo.path(), &["add", "."]);
     git_ok(repo.path(), &["commit", "-m", "add second"]);
-    let head_sha = git_ok(repo.path(), &["rev-parse", "HEAD"]);
-    let previous_sha = git_ok(repo.path(), &["rev-parse", "HEAD^"]);
-
-    let sqlite_path = checkpoint_sqlite_path(repo.path());
     let schema = slim_schema_for_repo(repo.path());
 
     let init_response = schema
@@ -725,13 +752,19 @@ async fn devql_ingest_mutation_with_backfill_limits_history_window() {
     );
     write_current_repo_runtime_state(repo.path());
 
-    let ingest_response = schema
+    let enqueue_response = schema
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest(input: { backfill: 1 }) {
-                success
-                commitsProcessed
+              enqueueTask(input: { kind: INGEST, ingest: { backfill: 1 } }) {
+                merged
+                task {
+                  kind
+                  ingestSpec {
+                    backfill
+                  }
+                  status
+                }
               }
             }
             "#,
@@ -739,46 +772,21 @@ async fn devql_ingest_mutation_with_backfill_limits_history_window() {
         .await;
 
     assert!(
-        ingest_response.errors.is_empty(),
+        enqueue_response.errors.is_empty(),
         "graphql errors: {:?}",
-        ingest_response.errors
+        enqueue_response.errors
     );
-    let ingest_json = ingest_response
+    let enqueue_json = enqueue_response
         .data
         .into_json()
         .expect("graphql data to json");
-    assert_eq!(ingest_json["ingest"]["success"], true);
-    assert_eq!(ingest_json["ingest"]["commitsProcessed"], 1);
-
-    let sqlite = rusqlite::Connection::open(sqlite_path).expect("open sqlite");
-    let previous_ledger: Option<String> = sqlite
-        .query_row(
-            "SELECT history_status FROM commit_ingest_ledger WHERE commit_sha = ?1",
-            rusqlite::params![previous_sha.as_str()],
-            |row| row.get(0),
-        )
-        .optional()
-        .expect("read previous ledger");
-    let head_ledger: Option<String> = sqlite
-        .query_row(
-            "SELECT history_status FROM commit_ingest_ledger WHERE commit_sha = ?1",
-            rusqlite::params![head_sha.as_str()],
-            |row| row.get(0),
-        )
-        .optional()
-        .expect("read head ledger");
-
-    assert!(
-        previous_ledger.is_none(),
-        "backfill=1 should skip older history"
-    );
-    assert_eq!(head_ledger.as_deref(), Some("completed"));
+    assert_eq!(enqueue_json["enqueueTask"]["task"]["kind"], "INGEST");
+    assert_eq!(enqueue_json["enqueueTask"]["task"]["ingestSpec"]["backfill"], 1);
+    assert_eq!(enqueue_json["enqueueTask"]["task"]["status"], "QUEUED");
 }
 
 #[tokio::test]
-async fn devql_ingest_mutation_without_backfill_keeps_full_missing_segment() {
-    use rusqlite::OptionalExtension;
-
+async fn enqueue_task_ingest_without_backfill_defaults_to_null_backfill() {
     let repo = seed_graphql_mutation_repo();
     fs::write(
         repo.path().join("src/lib.rs"),
@@ -787,10 +795,6 @@ async fn devql_ingest_mutation_without_backfill_keeps_full_missing_segment() {
     .expect("write second revision");
     git_ok(repo.path(), &["add", "."]);
     git_ok(repo.path(), &["commit", "-m", "add second"]);
-    let head_sha = git_ok(repo.path(), &["rev-parse", "HEAD"]);
-    let previous_sha = git_ok(repo.path(), &["rev-parse", "HEAD^"]);
-
-    let sqlite_path = checkpoint_sqlite_path(repo.path());
     let schema = slim_schema_for_repo(repo.path());
 
     let init_response = schema
@@ -811,13 +815,17 @@ async fn devql_ingest_mutation_without_backfill_keeps_full_missing_segment() {
     );
     write_current_repo_runtime_state(repo.path());
 
-    let ingest_response = schema
+    let enqueue_response = schema
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest {
-                success
-                commitsProcessed
+              enqueueTask(input: { kind: INGEST, ingest: {} }) {
+                task {
+                  kind
+                  ingestSpec {
+                    backfill
+                  }
+                }
               }
             }
             "#,
@@ -825,41 +833,23 @@ async fn devql_ingest_mutation_without_backfill_keeps_full_missing_segment() {
         .await;
 
     assert!(
-        ingest_response.errors.is_empty(),
+        enqueue_response.errors.is_empty(),
         "graphql errors: {:?}",
-        ingest_response.errors
+        enqueue_response.errors
     );
-    let ingest_json = ingest_response
+    let enqueue_json = enqueue_response
         .data
         .into_json()
         .expect("graphql data to json");
-    assert_eq!(ingest_json["ingest"]["success"], true);
-    assert_eq!(ingest_json["ingest"]["commitsProcessed"], 2);
-
-    let sqlite = rusqlite::Connection::open(sqlite_path).expect("open sqlite");
-    let previous_ledger: Option<String> = sqlite
-        .query_row(
-            "SELECT history_status FROM commit_ingest_ledger WHERE commit_sha = ?1",
-            rusqlite::params![previous_sha.as_str()],
-            |row| row.get(0),
-        )
-        .optional()
-        .expect("read previous ledger");
-    let head_ledger: Option<String> = sqlite
-        .query_row(
-            "SELECT history_status FROM commit_ingest_ledger WHERE commit_sha = ?1",
-            rusqlite::params![head_sha.as_str()],
-            |row| row.get(0),
-        )
-        .optional()
-        .expect("read head ledger");
-
-    assert_eq!(previous_ledger.as_deref(), Some("completed"));
-    assert_eq!(head_ledger.as_deref(), Some("completed"));
+    assert_eq!(enqueue_json["enqueueTask"]["task"]["kind"], "INGEST");
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestSpec"]["backfill"],
+        serde_json::Value::Null
+    );
 }
 
 #[tokio::test]
-async fn enqueue_sync_rejects_conflicting_mode_selectors() {
+async fn enqueue_task_sync_rejects_conflicting_mode_selectors() {
     let repo = seed_graphql_mutation_repo();
     let schema = slim_schema_for_repo(repo.path());
 
@@ -867,7 +857,7 @@ async fn enqueue_sync_rejects_conflicting_mode_selectors() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              enqueueSync(input: { validate: true, full: true }) {
+              enqueueTask(input: { kind: SYNC, sync: { validate: true, full: true } }) {
                 merged
               }
             }
@@ -876,7 +866,7 @@ async fn enqueue_sync_rejects_conflicting_mode_selectors() {
         .await;
     assert_bad_user_input_error(
         &validate_and_full,
-        "enqueueSync",
+        "enqueueTask",
         "at most one of `full`, `paths`, `repair`, or `validate` may be specified",
     );
 
@@ -884,7 +874,7 @@ async fn enqueue_sync_rejects_conflicting_mode_selectors() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              enqueueSync(input: { repair: true, paths: ["src/lib.rs"] }) {
+              enqueueTask(input: { kind: SYNC, sync: { repair: true, paths: ["src/lib.rs"] } }) {
                 merged
               }
             }
@@ -893,13 +883,13 @@ async fn enqueue_sync_rejects_conflicting_mode_selectors() {
         .await;
     assert_bad_user_input_error(
         &repair_and_paths,
-        "enqueueSync",
+        "enqueueTask",
         "at most one of `full`, `paths`, `repair`, or `validate` may be specified",
     );
 }
 
 #[tokio::test]
-async fn graphql_sync_mutation_is_not_exposed() {
+async fn graphql_sync_and_ingest_mutations_are_not_exposed() {
     let repo = seed_graphql_mutation_repo();
     let schema = slim_schema_for_repo(repo.path());
 
@@ -922,10 +912,30 @@ async fn graphql_sync_mutation_is_not_exposed() {
         "expected GraphQL schema validation error for removed sync mutation, got {:?}",
         response.errors
     );
+
+    let ingest_response = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            mutation {
+              ingest {
+                success
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert_eq!(ingest_response.errors.len(), 1, "expected one graphql error");
+    assert!(
+        ingest_response.errors[0].message.contains("Unknown field")
+            && ingest_response.errors[0].message.contains("ingest"),
+        "expected GraphQL schema validation error for removed ingest mutation, got {:?}",
+        ingest_response.errors
+    );
 }
 
 #[tokio::test]
-async fn enqueue_sync_without_selector_defaults_to_auto_mode() {
+async fn enqueue_task_sync_without_selector_defaults_to_auto_mode() {
     let repo = seed_graphql_mutation_repo();
     let schema = slim_schema_for_repo(repo.path());
 
@@ -933,10 +943,12 @@ async fn enqueue_sync_without_selector_defaults_to_auto_mode() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              enqueueSync(input: {}) {
+              enqueueTask(input: { kind: SYNC, sync: {} }) {
                 merged
                 task {
-                  mode
+                  syncSpec {
+                    mode
+                  }
                 }
               }
             }
@@ -950,7 +962,7 @@ async fn enqueue_sync_without_selector_defaults_to_auto_mode() {
         response.errors
     );
     let json = response.data.into_json().expect("graphql data to json");
-    assert_eq!(json["enqueueSync"]["task"]["mode"], "auto");
+    assert_eq!(json["enqueueTask"]["task"]["syncSpec"]["mode"], "auto");
 }
 
 #[tokio::test]
@@ -1031,19 +1043,43 @@ async fn devql_mutations_report_validation_and_backend_errors() {
     let repo = seed_graphql_mutation_repo();
     let schema = slim_schema_for_repo(repo.path());
 
-    let missing_schema = schema
+    let invalid_input = schema
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest {
+              enqueueTask(input: { kind: INGEST, ingest: {}, sync: { full: true } }) {
+                merged
+              }
+            }
+            "#,
+        ))
+        .await;
+    assert_bad_user_input_error(
+        &invalid_input,
+        "enqueueTask",
+        "`sync` must not be provided when kind is INGEST",
+    );
+
+    let sqlite_file_path = repo.path().join(".bitloops/stores/mutations.sqlite");
+    if sqlite_file_path.exists() {
+        fs::remove_file(&sqlite_file_path).expect("remove seeded sqlite file");
+    }
+    fs::create_dir_all(&sqlite_file_path)
+        .expect("create directory in place of sqlite file");
+    let backend_schema = slim_schema_for_repo(repo.path());
+    let backend_error = backend_schema
+        .execute(async_graphql::Request::new(
+            r#"
+            mutation {
+              initSchema {
                 success
               }
             }
             "#,
         ))
         .await;
-    assert_eq!(missing_schema.errors.len(), 1, "expected one graphql error");
-    let backend_extensions = missing_schema.errors[0]
+    assert_eq!(backend_error.errors.len(), 1, "expected one graphql error");
+    let backend_extensions = backend_error.errors[0]
         .extensions
         .as_ref()
         .expect("graphql error extensions");
@@ -1053,11 +1089,11 @@ async fn devql_mutations_report_validation_and_backend_errors() {
     );
     assert_eq!(
         backend_extensions.get("kind"),
-        Some(&async_graphql::Value::from("configuration"))
+        Some(&async_graphql::Value::from("initialisation"))
     );
     assert_eq!(
         backend_extensions.get("operation"),
-        Some(&async_graphql::Value::from("ingest"))
+        Some(&async_graphql::Value::from("initSchema"))
     );
 }
 
@@ -1427,8 +1463,8 @@ async fn devql_global_repo_mutations_require_slim_cli_scope() {
         .execute(async_graphql::Request::new(
             r#"
             mutation {
-              ingest {
-                success
+              enqueueTask(input: { kind: INGEST, ingest: {} }) {
+                merged
               }
             }
             "#,
@@ -1450,7 +1486,7 @@ async fn devql_global_repo_mutations_require_slim_cli_scope() {
     );
     assert_eq!(
         extensions.get("operation"),
-        Some(&async_graphql::Value::from("ingest"))
+        Some(&async_graphql::Value::from("enqueueTask"))
     );
     assert!(
         response.errors[0]

--- a/bitloops/src/api/tests/devql_mutations_and_health.rs
+++ b/bitloops/src/api/tests/devql_mutations_and_health.rs
@@ -718,12 +718,14 @@ async fn devql_mutations_initialise_schema_and_enqueue_ingest_with_typed_results
     let repository_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM repositories", [], |row| row.get(0))
         .expect("count repositories");
-    assert_eq!(repository_count, 0, "enqueueing should not execute ingest inline");
+    assert_eq!(
+        repository_count, 0,
+        "enqueueing should not execute ingest inline"
+    );
 }
 
 #[tokio::test]
 async fn enqueue_task_ingest_accepts_backfill_input() {
-
     let repo = seed_graphql_mutation_repo();
     fs::write(
         repo.path().join("src/lib.rs"),
@@ -781,7 +783,10 @@ async fn enqueue_task_ingest_accepts_backfill_input() {
         .into_json()
         .expect("graphql data to json");
     assert_eq!(enqueue_json["enqueueTask"]["task"]["kind"], "INGEST");
-    assert_eq!(enqueue_json["enqueueTask"]["task"]["ingestSpec"]["backfill"], 1);
+    assert_eq!(
+        enqueue_json["enqueueTask"]["task"]["ingestSpec"]["backfill"],
+        1
+    );
     assert_eq!(enqueue_json["enqueueTask"]["task"]["status"], "QUEUED");
 }
 
@@ -925,7 +930,11 @@ async fn graphql_sync_and_ingest_mutations_are_not_exposed() {
         ))
         .await;
 
-    assert_eq!(ingest_response.errors.len(), 1, "expected one graphql error");
+    assert_eq!(
+        ingest_response.errors.len(),
+        1,
+        "expected one graphql error"
+    );
     assert!(
         ingest_response.errors[0].message.contains("Unknown field")
             && ingest_response.errors[0].message.contains("ingest"),
@@ -1068,8 +1077,7 @@ async fn devql_mutations_report_validation_and_backend_errors() {
     if sqlite_file_path.exists() {
         fs::remove_file(&sqlite_file_path).expect("remove seeded sqlite file");
     }
-    fs::create_dir_all(&sqlite_file_path)
-        .expect("create directory in place of sqlite file");
+    fs::create_dir_all(&sqlite_file_path).expect("create directory in place of sqlite file");
     let backend_schema = slim_schema_for_repo(repo.path());
     let backend_error = backend_schema
         .execute(async_graphql::Request::new(

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -1255,32 +1255,32 @@ async fn devql_graphql_task_progress_subscription_receives_published_task_events
         completed_at_unix: None,
         queue_position: None,
         tasks_ahead: None,
-        progress: crate::daemon::DevqlTaskProgress::Ingest(crate::host::devql::IngestionProgressUpdate {
-            phase,
-            commits_total: 1,
-            commits_processed,
-            current_checkpoint_id: Some("aabbccddeeff".to_string()),
-            current_commit_sha: Some(git_ok(repo.path(), &["rev-parse", "HEAD"])),
-            counters: crate::host::devql::IngestionCounters {
-                success: matches!(phase, crate::host::devql::IngestionProgressPhase::Complete),
-                checkpoint_companions_processed: commits_processed,
-                events_inserted: commits_processed,
-                artefacts_upserted: commits_processed + 1,
-                ..Default::default()
+        progress: crate::daemon::DevqlTaskProgress::Ingest(
+            crate::host::devql::IngestionProgressUpdate {
+                phase,
+                commits_total: 1,
+                commits_processed,
+                current_checkpoint_id: Some("aabbccddeeff".to_string()),
+                current_commit_sha: Some(git_ok(repo.path(), &["rev-parse", "HEAD"])),
+                counters: crate::host::devql::IngestionCounters {
+                    success: matches!(phase, crate::host::devql::IngestionProgressPhase::Complete),
+                    checkpoint_companions_processed: commits_processed,
+                    events_inserted: commits_processed,
+                    artefacts_upserted: commits_processed + 1,
+                    ..Default::default()
+                },
             },
-        }),
+        ),
         error: None,
         result: None,
     };
 
-    context
-        .subscriptions()
-        .publish_task(make_task(
-            "other-task",
-            crate::daemon::DevqlTaskStatus::Running,
-            crate::host::devql::IngestionProgressPhase::Failed,
-            0,
-        ));
+    context.subscriptions().publish_task(make_task(
+        "other-task",
+        crate::daemon::DevqlTaskStatus::Running,
+        crate::host::devql::IngestionProgressPhase::Failed,
+        0,
+    ));
     context.subscriptions().publish_task(make_task(
         "ingest-task-1",
         crate::daemon::DevqlTaskStatus::Running,
@@ -1354,42 +1354,46 @@ async fn devql_task_and_checkpoint_events_publish_to_subscription_hub() {
         "demo",
         crate::graphql::Checkpoint::from_ingested(&checkpoint_info, Some(head_sha.as_str())),
     );
-    context.subscriptions().publish_task(crate::daemon::DevqlTaskRecord {
-        task_id: "ingest-task-1".to_string(),
-        repo_id: "repo-1".to_string(),
-        repo_name: "demo".to_string(),
-        repo_provider: "local".to_string(),
-        repo_organisation: "local".to_string(),
-        repo_identity: "local/demo".to_string(),
-        daemon_config_root: repo.path().to_path_buf(),
-        repo_root: repo.path().to_path_buf(),
-        kind: crate::daemon::DevqlTaskKind::Ingest,
-        source: crate::daemon::DevqlTaskSource::ManualCli,
-        spec: crate::daemon::DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec::default()),
-        status: crate::daemon::DevqlTaskStatus::Completed,
-        submitted_at_unix: 1,
-        started_at_unix: Some(2),
-        updated_at_unix: 3,
-        completed_at_unix: Some(4),
-        queue_position: None,
-        tasks_ahead: None,
-        progress: crate::daemon::DevqlTaskProgress::Ingest(crate::host::devql::IngestionProgressUpdate {
-            phase: crate::host::devql::IngestionProgressPhase::Complete,
-            commits_total: 1,
-            commits_processed: 1,
-            current_checkpoint_id: Some("checkpoint-1".to_string()),
-            current_commit_sha: Some(head_sha.clone()),
-            counters: crate::host::devql::IngestionCounters {
-                success: true,
-                checkpoint_companions_processed: 1,
-                events_inserted: 1,
-                artefacts_upserted: 1,
-                ..Default::default()
-            },
-        }),
-        error: None,
-        result: None,
-    });
+    context
+        .subscriptions()
+        .publish_task(crate::daemon::DevqlTaskRecord {
+            task_id: "ingest-task-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            repo_name: "demo".to_string(),
+            repo_provider: "local".to_string(),
+            repo_organisation: "local".to_string(),
+            repo_identity: "local/demo".to_string(),
+            daemon_config_root: repo.path().to_path_buf(),
+            repo_root: repo.path().to_path_buf(),
+            kind: crate::daemon::DevqlTaskKind::Ingest,
+            source: crate::daemon::DevqlTaskSource::ManualCli,
+            spec: crate::daemon::DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec::default()),
+            status: crate::daemon::DevqlTaskStatus::Completed,
+            submitted_at_unix: 1,
+            started_at_unix: Some(2),
+            updated_at_unix: 3,
+            completed_at_unix: Some(4),
+            queue_position: None,
+            tasks_ahead: None,
+            progress: crate::daemon::DevqlTaskProgress::Ingest(
+                crate::host::devql::IngestionProgressUpdate {
+                    phase: crate::host::devql::IngestionProgressPhase::Complete,
+                    commits_total: 1,
+                    commits_processed: 1,
+                    current_checkpoint_id: Some("checkpoint-1".to_string()),
+                    current_commit_sha: Some(head_sha.clone()),
+                    counters: crate::host::devql::IngestionCounters {
+                        success: true,
+                        checkpoint_companions_processed: 1,
+                        events_inserted: 1,
+                        artefacts_upserted: 1,
+                        ..Default::default()
+                    },
+                },
+            ),
+            error: None,
+            result: None,
+        });
 
     let checkpoint = tokio::time::timeout(std::time::Duration::from_secs(5), checkpoint_rx.recv())
         .await
@@ -1402,5 +1406,8 @@ async fn devql_task_and_checkpoint_events_publish_to_subscription_hub() {
         .expect("task progress event should arrive")
         .expect("task progress subscription payload");
     assert_eq!(progress.task_id, "ingest-task-1");
-    assert_eq!(progress.task.status, crate::daemon::DevqlTaskStatus::Completed);
+    assert_eq!(
+        progress.task.status,
+        crate::daemon::DevqlTaskStatus::Completed
+    );
 }

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[allow(dead_code)]
 fn write_current_repo_runtime_state(repo_root: &Path) {
     let runtime_path = crate::daemon::repo_local_runtime_state_path_for_tests(repo_root)
         .unwrap_or_else(|| crate::daemon::runtime_state_path(repo_root));
@@ -1107,7 +1108,7 @@ async fn devql_graphql_checkpoint_ingested_subscription_receives_published_check
 }
 
 #[tokio::test]
-async fn devql_graphql_ingestion_progress_subscription_receives_published_progress_events() {
+async fn devql_graphql_task_progress_subscription_receives_published_task_events() {
     let repo = seed_dashboard_repo();
     let context = crate::graphql::DevqlGraphqlContext::new(
         repo.path().to_path_buf(),
@@ -1118,13 +1119,20 @@ async fn devql_graphql_ingestion_progress_subscription_receives_published_progre
     let stream = schema.execute_stream(async_graphql::Request::new(
         r#"
         subscription {
-          ingestionProgress(repoName: "demo") {
-            phase
-            commitsTotal
-            commitsProcessed
-            checkpointCompanionsProcessed
-            currentCheckpointId
-            currentCommitSha
+          taskProgress(taskId: "ingest-task-1") {
+            task {
+              taskId
+              kind
+              status
+              ingestProgress {
+                phase
+                commitsTotal
+                commitsProcessed
+                checkpointCompanionsProcessed
+                currentCheckpointId
+                currentCommitSha
+              }
+            }
           }
         }
         "#,
@@ -1139,45 +1147,68 @@ async fn devql_graphql_ingestion_progress_subscription_receives_published_progre
     });
     tokio::task::yield_now().await;
 
-    context.subscriptions().publish_progress(
-        "other-repo",
-        crate::graphql::IngestionProgressEvent {
-            phase: crate::graphql::IngestionPhase::Failed,
-            commits_total: 99,
-            commits_processed: 13,
-            checkpoint_companions_processed: 8,
-            current_checkpoint_id: Some("wrong-repo-checkpoint".to_string()),
-            current_commit_sha: Some("wrong-repo-sha".to_string()),
-            events_inserted: 8,
-            artefacts_upserted: 5,
-        },
-    );
-    context.subscriptions().publish_progress(
-        "demo",
-        crate::graphql::IngestionProgressEvent {
-            phase: crate::graphql::IngestionPhase::Initializing,
+    let make_task = |task_id: &str,
+                     status: crate::daemon::DevqlTaskStatus,
+                     phase: crate::host::devql::IngestionProgressPhase,
+                     commits_processed: usize| crate::daemon::DevqlTaskRecord {
+        task_id: task_id.to_string(),
+        repo_id: "repo-1".to_string(),
+        repo_name: "demo".to_string(),
+        repo_provider: "local".to_string(),
+        repo_organisation: "local".to_string(),
+        repo_identity: "local/demo".to_string(),
+        daemon_config_root: repo.path().to_path_buf(),
+        repo_root: repo.path().to_path_buf(),
+        kind: crate::daemon::DevqlTaskKind::Ingest,
+        source: crate::daemon::DevqlTaskSource::ManualCli,
+        spec: crate::daemon::DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec {
+            backfill: Some(1),
+        }),
+        status,
+        submitted_at_unix: 1,
+        started_at_unix: Some(2),
+        updated_at_unix: 3,
+        completed_at_unix: None,
+        queue_position: None,
+        tasks_ahead: None,
+        progress: crate::daemon::DevqlTaskProgress::Ingest(crate::host::devql::IngestionProgressUpdate {
+            phase,
             commits_total: 1,
-            commits_processed: 0,
-            checkpoint_companions_processed: 0,
-            current_checkpoint_id: None,
-            current_commit_sha: None,
-            events_inserted: 0,
-            artefacts_upserted: 0,
-        },
-    );
-    context.subscriptions().publish_progress(
-        "demo",
-        crate::graphql::IngestionProgressEvent {
-            phase: crate::graphql::IngestionPhase::Complete,
-            commits_total: 1,
-            commits_processed: 1,
-            checkpoint_companions_processed: 1,
+            commits_processed,
             current_checkpoint_id: Some("aabbccddeeff".to_string()),
             current_commit_sha: Some(git_ok(repo.path(), &["rev-parse", "HEAD"])),
-            events_inserted: 1,
-            artefacts_upserted: 2,
-        },
-    );
+            counters: crate::host::devql::IngestionCounters {
+                success: matches!(phase, crate::host::devql::IngestionProgressPhase::Complete),
+                checkpoint_companions_processed: commits_processed,
+                events_inserted: commits_processed,
+                artefacts_upserted: commits_processed + 1,
+                ..Default::default()
+            },
+        }),
+        error: None,
+        result: None,
+    };
+
+    context
+        .subscriptions()
+        .publish_task(make_task(
+            "other-task",
+            crate::daemon::DevqlTaskStatus::Running,
+            crate::host::devql::IngestionProgressPhase::Failed,
+            0,
+        ));
+    context.subscriptions().publish_task(make_task(
+        "ingest-task-1",
+        crate::daemon::DevqlTaskStatus::Running,
+        crate::host::devql::IngestionProgressPhase::Initializing,
+        0,
+    ));
+    context.subscriptions().publish_task(make_task(
+        "ingest-task-1",
+        crate::daemon::DevqlTaskStatus::Completed,
+        crate::host::devql::IngestionProgressPhase::Complete,
+        1,
+    ));
 
     let mut phases = Vec::new();
     let mut last_payload = Value::Null;
@@ -1192,7 +1223,7 @@ async fn devql_graphql_ingestion_progress_subscription_receives_published_progre
             event.errors
         );
         let json = event.data.into_json().expect("progress event json");
-        let payload = json["ingestionProgress"].clone();
+        let payload = json["taskProgress"]["task"]["ingestProgress"].clone();
         let phase = payload["phase"]
             .as_str()
             .expect("progress phase string")
@@ -1214,21 +1245,9 @@ async fn devql_graphql_ingestion_progress_subscription_receives_published_progre
 }
 
 #[tokio::test]
-async fn devql_ingest_mutation_publishes_progress_and_checkpoint_events_to_subscription_hub() {
+async fn devql_task_and_checkpoint_events_publish_to_subscription_hub() {
     let repo = seed_dashboard_repo();
-    write_envelope_config(
-        repo.path(),
-        json!({
-            "stores": {
-                "relational": {
-                    "sqlite_path": ".bitloops/stores/subscriptions.sqlite"
-                },
-                "events": {
-                    "duckdb_path": ".bitloops/stores/subscriptions.duckdb"
-                }
-            }
-        }),
-    );
+    let head_sha = git_ok(repo.path(), &["rev-parse", "HEAD"]);
     let context = crate::graphql::DevqlGraphqlContext::for_slim_request(
         repo.path().to_path_buf(),
         repo.path().to_path_buf(),
@@ -1238,76 +1257,66 @@ async fn devql_ingest_mutation_publishes_progress_and_checkpoint_events_to_subsc
         true,
         super::super::db::DashboardDbPools::default(),
     );
-    let mut progress_rx = context.subscriptions().subscribe_progress();
+    let mut progress_rx = context.subscriptions().subscribe_task_progress();
     let mut checkpoint_rx = context.subscriptions().subscribe_checkpoints();
-    let schema = crate::graphql::build_slim_schema(context);
-
-    let init_response = schema
-        .execute(async_graphql::Request::new(
-            r#"
-            mutation {
-              initSchema {
-                success
-              }
-            }
-            "#,
-        ))
-        .await;
-    assert!(
-        init_response.errors.is_empty(),
-        "graphql errors: {:?}",
-        init_response.errors
+    let checkpoint_info = crate::host::checkpoints::strategy::manual_commit::CommittedInfo {
+        checkpoint_id: "checkpoint-1".to_string(),
+        session_id: "session-1".to_string(),
+        agent: "assistant".to_string(),
+        created_at: "1970-01-01T00:00:00+00:00".to_string(),
+        ..Default::default()
+    };
+    context.subscriptions().publish_checkpoint(
+        "demo",
+        crate::graphql::Checkpoint::from_ingested(&checkpoint_info, Some(head_sha.as_str())),
     );
-    let init_json = init_response.data.into_json().expect("init data to json");
-    assert_eq!(init_json["initSchema"]["success"], true);
-    write_current_repo_runtime_state(repo.path());
+    context.subscriptions().publish_task(crate::daemon::DevqlTaskRecord {
+        task_id: "ingest-task-1".to_string(),
+        repo_id: "repo-1".to_string(),
+        repo_name: "demo".to_string(),
+        repo_provider: "local".to_string(),
+        repo_organisation: "local".to_string(),
+        repo_identity: "local/demo".to_string(),
+        daemon_config_root: repo.path().to_path_buf(),
+        repo_root: repo.path().to_path_buf(),
+        kind: crate::daemon::DevqlTaskKind::Ingest,
+        source: crate::daemon::DevqlTaskSource::ManualCli,
+        spec: crate::daemon::DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec::default()),
+        status: crate::daemon::DevqlTaskStatus::Completed,
+        submitted_at_unix: 1,
+        started_at_unix: Some(2),
+        updated_at_unix: 3,
+        completed_at_unix: Some(4),
+        queue_position: None,
+        tasks_ahead: None,
+        progress: crate::daemon::DevqlTaskProgress::Ingest(crate::host::devql::IngestionProgressUpdate {
+            phase: crate::host::devql::IngestionProgressPhase::Complete,
+            commits_total: 1,
+            commits_processed: 1,
+            current_checkpoint_id: Some("checkpoint-1".to_string()),
+            current_commit_sha: Some(head_sha.clone()),
+            counters: crate::host::devql::IngestionCounters {
+                success: true,
+                checkpoint_companions_processed: 1,
+                events_inserted: 1,
+                artefacts_upserted: 1,
+                ..Default::default()
+            },
+        }),
+        error: None,
+        result: None,
+    });
 
-    let response = schema
-        .execute(async_graphql::Request::new(
-            r#"
-            mutation {
-              ingest {
-                success
-                commitsProcessed
-                checkpointCompanionsProcessed
-              }
-            }
-            "#,
-        ))
-        .await;
+    let checkpoint = tokio::time::timeout(std::time::Duration::from_secs(5), checkpoint_rx.recv())
+        .await
+        .expect("checkpoint event should arrive")
+        .expect("checkpoint subscription payload");
+    assert_eq!(checkpoint.checkpoint.commit_sha, Some(head_sha.clone()));
 
-    assert!(
-        response.errors.is_empty(),
-        "graphql errors: {:?}",
-        response.errors
-    );
-    let response_json = response.data.into_json().expect("mutation data to json");
-    assert!(
-        response_json["ingest"]["checkpointCompanionsProcessed"].is_number(),
-        "expected checkpoint companion counter in ingest response"
-    );
-    if response_json["ingest"]["commitsProcessed"].as_i64() == Some(1) {
-        let checkpoint =
-            tokio::time::timeout(std::time::Duration::from_secs(5), checkpoint_rx.recv())
-                .await
-                .expect("checkpoint event should arrive")
-                .expect("checkpoint subscription payload");
-        assert_eq!(
-            checkpoint.checkpoint.commit_sha,
-            Some(git_ok(repo.path(), &["rev-parse", "HEAD"]))
-        );
-    }
-
-    let mut saw_complete = false;
-    for _ in 0..8 {
-        let progress = tokio::time::timeout(std::time::Duration::from_secs(5), progress_rx.recv())
-            .await
-            .expect("progress event should arrive")
-            .expect("progress subscription payload");
-        if progress.event.phase == crate::graphql::IngestionPhase::Complete {
-            saw_complete = true;
-            break;
-        }
-    }
-    assert!(saw_complete, "expected a COMPLETE ingestion progress event");
+    let progress = tokio::time::timeout(std::time::Duration::from_secs(5), progress_rx.recv())
+        .await
+        .expect("task progress event should arrive")
+        .expect("task progress subscription payload");
+    assert_eq!(progress.task_id, "ingest-task-1");
+    assert_eq!(progress.task.status, crate::daemon::DevqlTaskStatus::Completed);
 }

--- a/bitloops/src/api/tls.rs
+++ b/bitloops/src/api/tls.rs
@@ -103,18 +103,20 @@ pub fn mkcert_on_path() -> bool {
     which::which("mkcert").is_ok()
 }
 
-fn ensure_rustls_crypto_provider() -> Result<()> {
-    static INIT: OnceLock<std::result::Result<(), String>> = OnceLock::new();
-    let init = INIT.get_or_init(|| {
-        if CryptoProvider::get_default().is_none() {
-            return rustls::crypto::aws_lc_rs::default_provider()
-                .install_default()
-                .map_err(|e| format!("install rustls aws_lc_rs crypto provider: {e:?}"));
+pub(crate) fn rustls_crypto_provider() -> Result<Arc<CryptoProvider>> {
+    static PROVIDER: OnceLock<std::result::Result<Arc<CryptoProvider>, String>> = OnceLock::new();
+    let provider = PROVIDER.get_or_init(|| {
+        if let Some(provider) = CryptoProvider::get_default() {
+            return Ok(Arc::clone(provider));
         }
-        Ok(())
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        CryptoProvider::get_default()
+            .cloned()
+            .ok_or_else(|| "install rustls aws_lc_rs crypto provider".to_string())
     });
-    match init {
-        Ok(()) => Ok(()),
+    match provider {
+        Ok(provider) => Ok(Arc::clone(provider)),
         Err(msg) => Err(anyhow!("{msg}")),
     }
 }
@@ -236,9 +238,10 @@ fn load_server_config(cert_path: &Path, key_path: &Path) -> Result<Arc<ServerCon
         .context("read private key PEM")?
         .ok_or_else(|| anyhow!("no private key found in {}", key_path.display()))?;
 
-    ensure_rustls_crypto_provider()?;
-
-    let config = ServerConfig::builder()
+    let provider = rustls_crypto_provider()?;
+    let config = ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .expect("safe default TLS versions are valid")
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .context("build rustls ServerConfig (check key matches certificate)")?;

--- a/bitloops/src/cli/daemon/display.rs
+++ b/bitloops/src/cli/daemon/display.rs
@@ -251,10 +251,7 @@ fn append_capability_event_lines(
 
 fn append_devql_task_lines(lines: &mut Vec<String>, status: &daemon::DevqlTaskQueueStatus) {
     lines.push("DevQL task queue: available".to_string());
-    lines.push(format!(
-        "DevQL queued tasks: {}",
-        status.state.queued_tasks
-    ));
+    lines.push(format!("DevQL queued tasks: {}", status.state.queued_tasks));
     lines.push(format!(
         "DevQL running tasks: {}",
         status.state.running_tasks
@@ -307,10 +304,7 @@ fn append_devql_task_lines(lines: &mut Vec<String>, status: &daemon::DevqlTaskQu
             }
         }
         if let Some(progress) = task.ingest_progress() {
-            lines.push(format!(
-                "Current repo ingest phase: {:?}",
-                progress.phase
-            ));
+            lines.push(format!("Current repo ingest phase: {:?}", progress.phase));
             if let Some(commit_sha) = progress.current_commit_sha.as_ref() {
                 lines.push(format!("Current repo ingest commit: {commit_sha}"));
             }

--- a/bitloops/src/cli/daemon/display.rs
+++ b/bitloops/src/cli/daemon/display.rs
@@ -30,8 +30,8 @@ pub(super) fn status_lines_with_log_path(
         if let Some(capability_events) = report.capability_events.as_ref() {
             append_capability_event_lines(&mut lines, capability_events);
         }
-        if let Some(sync) = report.sync.as_ref() {
-            append_sync_lines(&mut lines, sync);
+        if let Some(devql_tasks) = report.devql_tasks.as_ref() {
+            append_devql_task_lines(&mut lines, devql_tasks);
         }
         return lines;
     }
@@ -62,8 +62,8 @@ pub(super) fn status_lines_with_log_path(
         if let Some(capability_events) = report.capability_events.as_ref() {
             append_capability_event_lines(&mut lines, capability_events);
         }
-        if let Some(sync) = report.sync.as_ref() {
-            append_sync_lines(&mut lines, sync);
+        if let Some(devql_tasks) = report.devql_tasks.as_ref() {
+            append_devql_task_lines(&mut lines, devql_tasks);
         }
         return lines;
     }
@@ -77,8 +77,8 @@ pub(super) fn status_lines_with_log_path(
     if let Some(capability_events) = report.capability_events.as_ref() {
         append_capability_event_lines(&mut lines, capability_events);
     }
-    if let Some(sync) = report.sync.as_ref() {
-        append_sync_lines(&mut lines, sync);
+    if let Some(devql_tasks) = report.devql_tasks.as_ref() {
+        append_devql_task_lines(&mut lines, devql_tasks);
     }
     lines
 }
@@ -249,56 +249,85 @@ fn append_capability_event_lines(
     ));
 }
 
-fn append_sync_lines(lines: &mut Vec<String>, status: &daemon::SyncQueueStatus) {
+fn append_devql_task_lines(lines: &mut Vec<String>, status: &daemon::DevqlTaskQueueStatus) {
+    lines.push("DevQL task queue: available".to_string());
     lines.push(format!(
-        "Sync pending tasks: {}",
-        status.state.pending_tasks
+        "DevQL queued tasks: {}",
+        status.state.queued_tasks
     ));
     lines.push(format!(
-        "Sync running tasks: {}",
+        "DevQL running tasks: {}",
         status.state.running_tasks
     ));
-    lines.push(format!("Sync failed tasks: {}", status.state.failed_tasks));
+    lines.push(format!("DevQL failed tasks: {}", status.state.failed_tasks));
     lines.push(format!(
-        "Sync completed recent tasks: {}",
+        "DevQL completed recent tasks: {}",
         status.state.completed_recent_tasks
     ));
-    if let Some(action) = status.state.last_action.as_ref() {
-        lines.push(format!("Sync last action: {action}"));
+    for counts in &status.state.by_kind {
+        lines.push(format!(
+            "DevQL {} tasks: queued={}, running={}, failed={}, completed_recent={}",
+            counts.kind,
+            counts.queued_tasks,
+            counts.running_tasks,
+            counts.failed_tasks,
+            counts.completed_recent_tasks
+        ));
     }
-    if let Some(task) = status.current_repo_task.as_ref() {
+    if let Some(action) = status.state.last_action.as_ref() {
+        lines.push(format!("DevQL last action: {action}"));
+    }
+    if let Some(control) = status.current_repo_control.as_ref() {
         lines.push(format!(
-            "Current repo sync task: {} ({}, mode={}, source={})",
-            task.task_id, task.status, task.mode, task.source
+            "Current repo task queue: {}",
+            if control.paused { "paused" } else { "running" }
         ));
+        if let Some(reason) = control.paused_reason.as_ref() {
+            lines.push(format!("Current repo task pause reason: {reason}"));
+        }
+    }
+    for task in &status.current_repo_tasks {
         lines.push(format!(
-            "Current repo sync phase: {}",
-            task.progress.phase.as_str()
+            "Current repo task: {} ({}, kind={}, source={})",
+            task.task_id, task.status, task.kind, task.source
         ));
-        if task.progress.paths_total > 0 {
+        if let Some(progress) = task.sync_progress() {
             lines.push(format!(
-                "Current repo sync progress: {}/{} paths complete ({} remaining)",
-                task.progress.paths_completed,
-                task.progress.paths_total,
-                task.progress.paths_remaining
+                "Current repo sync phase: {}",
+                progress.phase.as_str()
             ));
+            if progress.paths_total > 0 {
+                lines.push(format!(
+                    "Current repo sync progress: {}/{} paths complete ({} remaining)",
+                    progress.paths_completed, progress.paths_total, progress.paths_remaining
+                ));
+            }
+            if let Some(path) = progress.current_path.as_ref() {
+                lines.push(format!("Current repo sync path: {path}"));
+            }
+        }
+        if let Some(progress) = task.ingest_progress() {
+            lines.push(format!(
+                "Current repo ingest phase: {:?}",
+                progress.phase
+            ));
+            if let Some(commit_sha) = progress.current_commit_sha.as_ref() {
+                lines.push(format!("Current repo ingest commit: {commit_sha}"));
+            }
         }
         if let Some(position) = task.queue_position {
             lines.push(format!(
-                "Current repo sync queue position: {} ({} ahead)",
+                "Current repo task queue position: {} ({} ahead)",
                 position,
                 task.tasks_ahead.unwrap_or(position.saturating_sub(1))
             ));
         }
-        if let Some(path) = task.progress.current_path.as_ref() {
-            lines.push(format!("Current repo sync path: {path}"));
-        }
         if let Some(error) = task.error.as_ref() {
-            lines.push(format!("Current repo sync error: {error}"));
+            lines.push(format!("Current repo task error: {error}"));
         }
     }
     lines.push(format!(
-        "Sync persisted: {}",
+        "DevQL persisted: {}",
         if status.persisted { "yes" } else { "no" }
     ));
 }

--- a/bitloops/src/cli/daemon/tests.rs
+++ b/bitloops/src/cli/daemon/tests.rs
@@ -3,8 +3,10 @@ use crate::cli::{Cli, Commands};
 use crate::daemon::{
     CapabilityEventQueueState, CapabilityEventQueueStatus, CapabilityEventRunRecord,
     CapabilityEventRunStatus, DaemonServiceMetadata, DaemonStatusReport, EnrichmentQueueMode,
-    EnrichmentQueueState, EnrichmentQueueStatus, ServiceManagerKind, SyncQueueState,
-    SyncQueueStatus, SyncTaskMode, SyncTaskRecord, SyncTaskSource, SyncTaskStatus,
+    EnrichmentQueueState, EnrichmentQueueStatus, ServiceManagerKind, DevqlTaskKind,
+    DevqlTaskKindCounts, DevqlTaskProgress, DevqlTaskQueueState, DevqlTaskQueueStatus,
+    DevqlTaskRecord, DevqlTaskSource, DevqlTaskSpec, DevqlTaskStatus, RepoTaskControlState,
+    SyncTaskMode, SyncTaskSpec,
 };
 use crate::host::devql::{SyncProgressPhase, SyncProgressUpdate};
 use clap::Parser;
@@ -498,7 +500,7 @@ fn status_lines_show_global_supervisor_install_and_state() {
             },
             persisted: true,
         }),
-        sync: None,
+        devql_tasks: None,
     };
 
     assert_eq!(
@@ -560,7 +562,7 @@ fn status_lines_show_log_file_for_running_daemon() {
         health: None,
         capability_events: None,
         enrichment: None,
-        sync: None,
+        devql_tasks: None,
     };
 
     let lines = super::display::status_lines_with_log_path(&report, &log_path);
@@ -578,7 +580,7 @@ fn status_lines_show_log_file_when_daemon_is_stopped() {
         health: None,
         capability_events: None,
         enrichment: None,
-        sync: None,
+        devql_tasks: None,
     };
 
     assert_eq!(
@@ -621,18 +623,34 @@ fn status_lines_include_sync_queue_and_current_repo_task() {
         health: None,
         capability_events: None,
         enrichment: None,
-        sync: Some(SyncQueueStatus {
-            state: SyncQueueState {
+        devql_tasks: Some(DevqlTaskQueueStatus {
+            state: DevqlTaskQueueState {
                 version: 1,
-                pending_tasks: 2,
+                queued_tasks: 2,
                 running_tasks: 1,
                 failed_tasks: 3,
                 completed_recent_tasks: 4,
+                by_kind: vec![
+                    DevqlTaskKindCounts {
+                        kind: DevqlTaskKind::Sync,
+                        queued_tasks: 2,
+                        running_tasks: 1,
+                        failed_tasks: 3,
+                        completed_recent_tasks: 4,
+                    },
+                    DevqlTaskKindCounts {
+                        kind: DevqlTaskKind::Ingest,
+                        queued_tasks: 0,
+                        running_tasks: 0,
+                        failed_tasks: 0,
+                        completed_recent_tasks: 0,
+                    },
+                ],
                 last_action: Some("running".to_string()),
                 last_updated_unix: 0,
             },
             persisted: true,
-            current_repo_task: Some(SyncTaskRecord {
+            current_repo_tasks: vec![DevqlTaskRecord {
                 task_id: "sync-task-1".to_string(),
                 repo_id: "repo-1".to_string(),
                 repo_name: "demo".to_string(),
@@ -641,16 +659,19 @@ fn status_lines_include_sync_queue_and_current_repo_task() {
                 repo_identity: "local/demo".to_string(),
                 daemon_config_root: std::path::PathBuf::from("/tmp/repo"),
                 repo_root: std::path::PathBuf::from("/tmp/repo"),
-                source: SyncTaskSource::ManualCli,
-                mode: SyncTaskMode::Full,
-                status: SyncTaskStatus::Running,
+                kind: DevqlTaskKind::Sync,
+                source: DevqlTaskSource::ManualCli,
+                spec: DevqlTaskSpec::Sync(SyncTaskSpec {
+                    mode: SyncTaskMode::Full,
+                }),
+                status: DevqlTaskStatus::Running,
                 submitted_at_unix: 1,
                 started_at_unix: Some(2),
                 updated_at_unix: 3,
                 completed_at_unix: None,
                 queue_position: Some(1),
                 tasks_ahead: Some(0),
-                progress: SyncProgressUpdate {
+                progress: DevqlTaskProgress::Sync(SyncProgressUpdate {
                     phase: SyncProgressPhase::ExtractingPaths,
                     current_path: Some("src/lib.rs".to_string()),
                     paths_total: 10,
@@ -663,21 +684,27 @@ fn status_lines_include_sync_queue_and_current_repo_task() {
                     cache_hits: 3,
                     cache_misses: 2,
                     parse_errors: 0,
-                },
+                }),
                 error: None,
-                summary: None,
+                result: None,
+            }],
+            current_repo_control: Some(RepoTaskControlState {
+                repo_id: "repo-1".to_string(),
+                paused: false,
+                paused_reason: None,
+                updated_at_unix: 3,
             }),
         }),
     };
 
     let lines = status_lines(&report);
-    assert!(lines.contains(&"Sync pending tasks: 2".to_string()));
-    assert!(lines.contains(&"Sync running tasks: 1".to_string()));
-    assert!(lines.contains(&"Sync failed tasks: 3".to_string()));
-    assert!(lines.contains(&"Sync completed recent tasks: 4".to_string()));
-    assert!(lines.contains(&"Sync last action: running".to_string()));
+    assert!(lines.contains(&"DevQL queued tasks: 2".to_string()));
+    assert!(lines.contains(&"DevQL running tasks: 1".to_string()));
+    assert!(lines.contains(&"DevQL failed tasks: 3".to_string()));
+    assert!(lines.contains(&"DevQL completed recent tasks: 4".to_string()));
+    assert!(lines.contains(&"DevQL last action: running".to_string()));
     assert!(lines.contains(
-        &"Current repo sync task: sync-task-1 (running, mode=full, source=manual_cli)".to_string()
+        &"Current repo task: sync-task-1 (running, kind=sync, source=manual_cli)".to_string()
     ));
     assert!(lines.contains(&"Current repo sync phase: extracting_paths".to_string()));
     assert!(
@@ -685,7 +712,7 @@ fn status_lines_include_sync_queue_and_current_repo_task() {
             .contains(&"Current repo sync progress: 4/10 paths complete (6 remaining)".to_string())
     );
     assert!(lines.contains(&"Current repo sync path: src/lib.rs".to_string()));
-    assert!(lines.contains(&"Sync persisted: yes".to_string()));
+    assert!(lines.contains(&"DevQL persisted: yes".to_string()));
 }
 
 #[test]
@@ -703,7 +730,7 @@ fn status_lines_include_capability_event_queue_and_current_repo_run() {
             status
         }),
         enrichment: None,
-        sync: None,
+        devql_tasks: None,
     };
 
     let lines = status_lines(&report);
@@ -729,7 +756,7 @@ fn run_status_writes_json_when_requested() {
         health: None,
         capability_events: Some(sample_capability_event_status()),
         enrichment: None,
-        sync: None,
+        devql_tasks: None,
     };
     let mut out = SharedBuffer::default();
 

--- a/bitloops/src/cli/daemon/tests.rs
+++ b/bitloops/src/cli/daemon/tests.rs
@@ -2,10 +2,10 @@ use super::*;
 use crate::cli::{Cli, Commands};
 use crate::daemon::{
     CapabilityEventQueueState, CapabilityEventQueueStatus, CapabilityEventRunRecord,
-    CapabilityEventRunStatus, DaemonServiceMetadata, DaemonStatusReport, EnrichmentQueueMode,
-    EnrichmentQueueState, EnrichmentQueueStatus, ServiceManagerKind, DevqlTaskKind,
+    CapabilityEventRunStatus, DaemonServiceMetadata, DaemonStatusReport, DevqlTaskKind,
     DevqlTaskKindCounts, DevqlTaskProgress, DevqlTaskQueueState, DevqlTaskQueueStatus,
-    DevqlTaskRecord, DevqlTaskSource, DevqlTaskSpec, DevqlTaskStatus, RepoTaskControlState,
+    DevqlTaskRecord, DevqlTaskSource, DevqlTaskSpec, DevqlTaskStatus, EnrichmentQueueMode,
+    EnrichmentQueueState, EnrichmentQueueStatus, RepoTaskControlState, ServiceManagerKind,
     SyncTaskMode, SyncTaskSpec,
 };
 use crate::host::devql::{SyncProgressPhase, SyncProgressUpdate};

--- a/bitloops/src/cli/devql.rs
+++ b/bitloops/src/cli/devql.rs
@@ -4,8 +4,6 @@ use std::io::Write;
 use std::time::Instant;
 
 use crate::capability_packs::knowledge::run_knowledge_versions_via_host;
-use crate::capability_packs::semantic_clones::runtime_config::embeddings_enabled;
-use crate::config::{SemanticSummaryMode, resolve_embedding_capability_config_for_repo};
 use crate::devql_transport::{
     SlimCliRepoScope, discover_slim_cli_repo_scope, is_repo_root_discovery_error,
 };
@@ -27,15 +25,17 @@ mod tests;
 pub use crate::host::devql::run_connection_status;
 pub use args::{
     DevqlArgs, DevqlCheckpointFileSnapshotsArgs, DevqlCommand, DevqlConnectionStatusArgs,
-    DevqlIngestArgs, DevqlInitArgs, DevqlKnowledgeAddArgs, DevqlKnowledgeArgs,
-    DevqlKnowledgeAssociateArgs, DevqlKnowledgeCommand, DevqlKnowledgeRefArgs, DevqlPacksArgs,
-    DevqlProjectionArgs, DevqlProjectionCommand, DevqlQueryArgs, DevqlSchemaArgs, DevqlSyncArgs,
-    DevqlTestHarnessArgs, DevqlTestHarnessCommand, DevqlTestHarnessIngestCoverageArgs,
-    DevqlTestHarnessIngestCoverageBatchArgs, DevqlTestHarnessIngestResultsArgs,
-    DevqlTestHarnessIngestTestsArgs,
+    DevqlInitArgs, DevqlKnowledgeAddArgs, DevqlKnowledgeArgs, DevqlKnowledgeAssociateArgs,
+    DevqlKnowledgeCommand, DevqlKnowledgeRefArgs, DevqlPacksArgs, DevqlProjectionArgs,
+    DevqlProjectionCommand, DevqlQueryArgs, DevqlSchemaArgs, DevqlTaskCancelArgs,
+    DevqlTaskEnqueueArgs, DevqlTaskKindArg, DevqlTaskListArgs, DevqlTaskPauseArgs,
+    DevqlTaskResumeArgs, DevqlTaskStatusArg, DevqlTaskStatusArgs, DevqlTaskWatchArgs,
+    DevqlTasksArgs, DevqlTasksCommand, DevqlTestHarnessArgs, DevqlTestHarnessCommand,
+    DevqlTestHarnessIngestCoverageArgs, DevqlTestHarnessIngestCoverageBatchArgs,
+    DevqlTestHarnessIngestResultsArgs, DevqlTestHarnessIngestTestsArgs,
 };
 
-pub(crate) const MISSING_SUBCOMMAND_MESSAGE: &str = "missing subcommand. Use one of: `bitloops devql init`, `bitloops devql ingest`, `bitloops devql sync`, `bitloops devql projection checkpoint-file-snapshots`, `bitloops devql schema`, `bitloops devql query`, `bitloops devql connection-status`, `bitloops devql packs`, `bitloops devql knowledge add`, `bitloops devql knowledge associate`, `bitloops devql knowledge refresh`, `bitloops devql knowledge versions`, `bitloops devql test-harness ingest-tests`, `bitloops devql test-harness ingest-coverage`, `bitloops devql test-harness ingest-coverage-batch`, `bitloops devql test-harness ingest-results`";
+pub(crate) const MISSING_SUBCOMMAND_MESSAGE: &str = "missing subcommand. Use one of: `bitloops devql init`, `bitloops devql tasks enqueue`, `bitloops devql tasks watch`, `bitloops devql tasks status`, `bitloops devql tasks list`, `bitloops devql tasks pause`, `bitloops devql tasks resume`, `bitloops devql tasks cancel`, `bitloops devql projection checkpoint-file-snapshots`, `bitloops devql schema`, `bitloops devql query`, `bitloops devql connection-status`, `bitloops devql packs`, `bitloops devql knowledge add`, `bitloops devql knowledge associate`, `bitloops devql knowledge refresh`, `bitloops devql knowledge versions`, `bitloops devql test-harness ingest-tests`, `bitloops devql test-harness ingest-coverage`, `bitloops devql test-harness ingest-coverage-batch`, `bitloops devql test-harness ingest-results`";
 const SCHEMA_SCOPE_REQUIRED_MESSAGE: &str = "`bitloops devql schema` requires a Git repository scope. Run it from within a repository or use `bitloops devql schema --global`.";
 
 fn format_schema_sdl_output(args: &DevqlSchemaArgs, sdl: &str) -> String {
@@ -241,44 +241,10 @@ where
     }
 
     let cfg = DevqlConfig::from_env(repo_root, repo)?;
-    let enrichment_capability = resolve_embedding_capability_config_for_repo(&cfg.repo_root);
-    let enrichment_enabled = enrichment_capability.semantic_clones.summary_mode
-        != SemanticSummaryMode::Off
-        || embeddings_enabled(&enrichment_capability.semantic_clones);
 
     match command {
         DevqlCommand::Init(_) => graphql::run_init_via_graphql(&scope).await,
-        DevqlCommand::Ingest(args) => {
-            if enrichment_enabled {
-                graphql::run_ingest_via_graphql(&scope, None, args.require_daemon).await
-            } else {
-                let _ = args;
-                crate::daemon::require_current_repo_runtime(&cfg.repo_root, "`devql ingest`")?;
-                crate::host::devql::run_ingest(&cfg).await
-            }
-        }
-        DevqlCommand::Sync(args) => {
-            let (task, merged) = graphql::enqueue_sync_via_graphql(
-                &scope,
-                args.full,
-                args.paths,
-                args.repair,
-                args.validate,
-                "manual_cli",
-                args.require_daemon,
-            )
-            .await?;
-            if args.status {
-                if let Some(summary) =
-                    graphql::watch_sync_task_via_graphql(&scope, task.clone()).await?
-                {
-                    println!("{}", format_sync_completion_summary(&summary));
-                }
-            } else {
-                println!("{}", format_sync_queue_submission(&task, merged));
-            }
-            Ok(())
-        }
+        DevqlCommand::Tasks(args) => run_tasks_command(&scope, args).await,
         DevqlCommand::Projection(args) => match args.command {
             DevqlProjectionCommand::CheckpointFileSnapshots(backfill) => {
                 run_checkpoint_file_snapshot_backfill(
@@ -404,6 +370,120 @@ where
     }
 }
 
+async fn run_tasks_command(scope: &SlimCliRepoScope, args: DevqlTasksArgs) -> Result<()> {
+    match args.command {
+        DevqlTasksCommand::Enqueue(args) => run_task_enqueue(scope, args).await,
+        DevqlTasksCommand::Watch(args) => run_task_watch(scope, args).await,
+        DevqlTasksCommand::Status(_) => {
+            let status = graphql::task_queue_status_via_graphql(scope).await?;
+            print_task_queue_status(&status);
+            Ok(())
+        }
+        DevqlTasksCommand::List(args) => {
+            let tasks = graphql::list_tasks_via_graphql(
+                scope,
+                args.kind.as_ref().map(task_kind_arg_name),
+                args.status.as_ref().map(task_status_arg_name),
+                args.limit,
+            )
+            .await?;
+            print_task_list(&tasks);
+            Ok(())
+        }
+        DevqlTasksCommand::Pause(args) => {
+            let result = graphql::pause_task_queue_via_graphql(scope, args.reason.as_deref()).await?;
+            println!("{}", format_task_queue_control_result(&result));
+            Ok(())
+        }
+        DevqlTasksCommand::Resume(_) => {
+            let result = graphql::resume_task_queue_via_graphql(scope).await?;
+            println!("{}", format_task_queue_control_result(&result));
+            Ok(())
+        }
+        DevqlTasksCommand::Cancel(args) => {
+            let task = graphql::cancel_task_via_graphql(scope, args.task_id.as_str()).await?;
+            println!("{}", format_task_brief(&task));
+            Ok(())
+        }
+    }
+}
+
+async fn run_task_enqueue(scope: &SlimCliRepoScope, args: DevqlTaskEnqueueArgs) -> Result<()> {
+    validate_task_enqueue_args(&args)?;
+    let (task, merged) = match args.kind {
+        DevqlTaskKindArg::Sync => {
+            graphql::enqueue_sync_task_via_graphql(
+                scope,
+                args.full,
+                args.paths,
+                args.repair,
+                args.validate,
+                "manual_cli",
+                args.require_daemon,
+            )
+            .await?
+        }
+        DevqlTaskKindArg::Ingest => {
+            graphql::enqueue_ingest_task_via_graphql(scope, args.backfill, args.require_daemon)
+                .await?
+        }
+    };
+
+    if args.status {
+        if let Some(task) = graphql::watch_task_via_graphql(scope, task.clone()).await? {
+            println!("{}", format_task_completion_summary(&task));
+        }
+    } else {
+        println!("{}", format_task_queue_submission(&task, merged));
+    }
+    Ok(())
+}
+
+async fn run_task_watch(scope: &SlimCliRepoScope, args: DevqlTaskWatchArgs) -> Result<()> {
+    if let Some(task) =
+        graphql::watch_task_id_via_graphql(scope, args.task_id.as_str(), args.require_daemon)
+            .await?
+    {
+        println!("{}", format_task_completion_summary(&task));
+    }
+    Ok(())
+}
+
+fn validate_task_enqueue_args(args: &DevqlTaskEnqueueArgs) -> Result<()> {
+    match args.kind {
+        DevqlTaskKindArg::Sync => {
+            if args.backfill.is_some() {
+                bail!("`--backfill` is only supported for `bitloops devql tasks enqueue --kind ingest`");
+            }
+        }
+        DevqlTaskKindArg::Ingest => {
+            if args.full || args.paths.is_some() || args.repair || args.validate {
+                bail!(
+                    "sync mode flags are only supported for `bitloops devql tasks enqueue --kind sync`"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn task_kind_arg_name(kind: &DevqlTaskKindArg) -> &'static str {
+    match kind {
+        DevqlTaskKindArg::Sync => "sync",
+        DevqlTaskKindArg::Ingest => "ingest",
+    }
+}
+
+fn task_status_arg_name(status: &DevqlTaskStatusArg) -> &'static str {
+    match status {
+        DevqlTaskStatusArg::Queued => "queued",
+        DevqlTaskStatusArg::Running => "running",
+        DevqlTaskStatusArg::Completed => "completed",
+        DevqlTaskStatusArg::Failed => "failed",
+        DevqlTaskStatusArg::Cancelled => "cancelled",
+    }
+}
+
 pub async fn run(args: DevqlArgs) -> Result<()> {
     if matches!(args.command.as_ref(), Some(DevqlCommand::Schema(_))) {
         let stdout = std::io::stdout();
@@ -416,18 +496,106 @@ pub async fn run(args: DevqlArgs) -> Result<()> {
     run_with_scope_discovery(args, &mut writer, || discover_slim_cli_repo_scope(None)).await
 }
 
-pub(crate) fn format_sync_queue_submission(
-    task: &graphql::SyncTaskGraphqlRecord,
-    merged: bool,
-) -> String {
+pub(crate) fn format_task_queue_submission(task: &graphql::TaskGraphqlRecord, merged: bool) -> String {
     let mut line = format!(
-        "sync queued: task={} repo={} mode={}",
-        task.task_id, task.repo_name, task.mode
+        "task queued: task={} repo={} kind={}",
+        task.task_id,
+        task.repo_name,
+        task.kind.to_ascii_lowercase()
     );
+    if let Some(sync_spec) = task.sync_spec.as_ref() {
+        line.push_str(&format!(" mode={}", sync_spec.mode));
+    }
+    if let Some(ingest_spec) = task.ingest_spec.as_ref()
+        && let Some(backfill) = ingest_spec.backfill
+    {
+        line.push_str(&format!(" backfill={backfill}"));
+    }
     if merged {
         line.push_str(" (merged into existing task)");
     }
     line
+}
+
+pub(crate) fn format_task_completion_summary(task: &graphql::TaskGraphqlRecord) -> String {
+    if let Some(summary) = task.sync_summary() {
+        return format_sync_completion_summary(&summary);
+    }
+    if let Some(summary) = task.ingest_result.as_ref() {
+        return crate::host::devql::format_ingestion_summary(summary);
+    }
+    format!(
+        "task complete: {} {}",
+        task.kind.to_ascii_lowercase(),
+        task.task_id
+    )
+}
+
+fn format_task_queue_control_result(result: &graphql::TaskQueueControlGraphqlRecord) -> String {
+    let mut line = result.message.clone();
+    line.push_str(&format!(
+        " (repo={}, paused={})",
+        result.repo_id,
+        if result.paused { "yes" } else { "no" }
+    ));
+    if let Some(reason) = result.paused_reason.as_ref() {
+        line.push_str(&format!(", reason={reason}"));
+    }
+    line
+}
+
+fn format_task_brief(task: &graphql::TaskGraphqlRecord) -> String {
+    format!(
+        "task {}: kind={} status={} repo={}",
+        task.task_id,
+        task.kind.to_ascii_lowercase(),
+        task.status.to_ascii_lowercase(),
+        task.repo_name
+    )
+}
+
+fn print_task_queue_status(status: &graphql::TaskQueueGraphqlRecord) {
+    println!("DevQL task queue");
+    println!(
+        "state: {}",
+        if status.paused { "paused" } else { "running" }
+    );
+    println!("queued: {}", status.queued_tasks);
+    println!("running: {}", status.running_tasks);
+    println!("failed: {}", status.failed_tasks);
+    println!("completed_recent: {}", status.completed_recent_tasks);
+    if let Some(reason) = status.paused_reason.as_ref() {
+        println!("pause_reason: {reason}");
+    }
+    if let Some(action) = status.last_action.as_ref() {
+        println!("last_action: {action}");
+    }
+    for counts in &status.by_kind {
+        println!(
+            "kind={} queued={} running={} failed={} completed_recent={}",
+            counts.kind.to_ascii_lowercase(),
+            counts.queued_tasks,
+            counts.running_tasks,
+            counts.failed_tasks,
+            counts.completed_recent_tasks
+        );
+    }
+    if !status.current_repo_tasks.is_empty() {
+        println!("current_repo_tasks:");
+        for task in &status.current_repo_tasks {
+            println!("{}", format_task_brief(task));
+        }
+    }
+}
+
+fn print_task_list(tasks: &[graphql::TaskGraphqlRecord]) {
+    if tasks.is_empty() {
+        println!("no tasks");
+        return;
+    }
+    for task in tasks {
+        println!("{}", format_task_brief(task));
+    }
 }
 
 pub(crate) fn format_sync_completion_summary(summary: &SyncSummary) -> String {

--- a/bitloops/src/cli/devql.rs
+++ b/bitloops/src/cli/devql.rs
@@ -391,7 +391,8 @@ async fn run_tasks_command(scope: &SlimCliRepoScope, args: DevqlTasksArgs) -> Re
             Ok(())
         }
         DevqlTasksCommand::Pause(args) => {
-            let result = graphql::pause_task_queue_via_graphql(scope, args.reason.as_deref()).await?;
+            let result =
+                graphql::pause_task_queue_via_graphql(scope, args.reason.as_deref()).await?;
             println!("{}", format_task_queue_control_result(&result));
             Ok(())
         }
@@ -453,7 +454,9 @@ fn validate_task_enqueue_args(args: &DevqlTaskEnqueueArgs) -> Result<()> {
     match args.kind {
         DevqlTaskKindArg::Sync => {
             if args.backfill.is_some() {
-                bail!("`--backfill` is only supported for `bitloops devql tasks enqueue --kind ingest`");
+                bail!(
+                    "`--backfill` is only supported for `bitloops devql tasks enqueue --kind ingest`"
+                );
             }
         }
         DevqlTaskKindArg::Ingest => {
@@ -496,7 +499,10 @@ pub async fn run(args: DevqlArgs) -> Result<()> {
     run_with_scope_discovery(args, &mut writer, || discover_slim_cli_repo_scope(None)).await
 }
 
-pub(crate) fn format_task_queue_submission(task: &graphql::TaskGraphqlRecord, merged: bool) -> String {
+pub(crate) fn format_task_queue_submission(
+    task: &graphql::TaskGraphqlRecord,
+    merged: bool,
+) -> String {
     let mut line = format!(
         "task queued: task={} repo={} kind={}",
         task.task_id,

--- a/bitloops/src/cli/devql/args.rs
+++ b/bitloops/src/cli/devql/args.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 
 #[derive(Args, Debug, Clone, Default)]
 pub struct DevqlArgs {
@@ -10,10 +10,8 @@ pub struct DevqlArgs {
 pub enum DevqlCommand {
     /// Create schema for configured relational/events backends.
     Init(DevqlInitArgs),
-    /// Ingest checkpoint/events and relational artefacts for configured backends.
-    Ingest(DevqlIngestArgs),
-    /// Synchronize current workspace artefacts into DevQL state.
-    Sync(DevqlSyncArgs),
+    /// Manage daemon-owned DevQL sync and ingest tasks.
+    Tasks(DevqlTasksArgs),
     /// Backfill or repair DevQL relational projections.
     Projection(DevqlProjectionArgs),
     /// Print the DevQL GraphQL schema SDL.
@@ -33,20 +31,56 @@ pub enum DevqlCommand {
 #[derive(Args, Debug, Clone, Default)]
 pub struct DevqlInitArgs {}
 
-#[derive(Args, Debug, Clone, Default)]
-pub struct DevqlIngestArgs {
-    /// Fail immediately if the daemon is not already running.
-    #[arg(long, default_value_t = false)]
-    pub require_daemon: bool,
+#[derive(Args, Debug, Clone)]
+pub struct DevqlTasksArgs {
+    #[command(subcommand)]
+    pub command: DevqlTasksCommand,
 }
 
-#[derive(Debug, Clone, clap::Args)]
-pub struct DevqlSyncArgs {
-    /// Run a full workspace reconciliation.
+#[derive(Subcommand, Debug, Clone)]
+pub enum DevqlTasksCommand {
+    /// Enqueue a sync or ingest task.
+    Enqueue(DevqlTaskEnqueueArgs),
+    /// Watch a task until it reaches a terminal state.
+    Watch(DevqlTaskWatchArgs),
+    /// Show the current repository task queue status.
+    Status(DevqlTaskStatusArgs),
+    /// List recent tasks for the current repository.
+    List(DevqlTaskListArgs),
+    /// Pause scheduling for the current repository task queue.
+    Pause(DevqlTaskPauseArgs),
+    /// Resume scheduling for the current repository task queue.
+    Resume(DevqlTaskResumeArgs),
+    /// Cancel a queued task.
+    Cancel(DevqlTaskCancelArgs),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub enum DevqlTaskKindArg {
+    Sync,
+    Ingest,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, ValueEnum)]
+pub enum DevqlTaskStatusArg {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct DevqlTaskEnqueueArgs {
+    /// Which kind of task to enqueue.
+    #[arg(long, value_enum)]
+    pub kind: DevqlTaskKindArg,
+
+    /// Run a full workspace reconciliation for sync tasks.
     #[arg(long, conflicts_with_all = ["paths", "repair", "validate"])]
     pub full: bool,
 
-    /// Reconcile only the specified workspace paths.
+    /// Reconcile only the specified workspace paths for sync tasks.
     #[arg(long, value_delimiter = ',', conflicts_with_all = ["full", "repair", "validate"])]
     pub paths: Option<Vec<String>>,
 
@@ -54,17 +88,59 @@ pub struct DevqlSyncArgs {
     #[arg(long, conflicts_with_all = ["full", "paths", "validate"])]
     pub repair: bool,
 
-    /// Validate current-state tables against a full read-only workspace reconciliation.
+    /// Validate current-state tables against a read-only full reconciliation.
     #[arg(long, conflicts_with_all = ["full", "paths", "repair"])]
     pub validate: bool,
 
-    /// Follow the queued sync task until it reaches a terminal state.
+    /// Limit ingest to the most recent N commits.
+    #[arg(long)]
+    pub backfill: Option<usize>,
+
+    /// Follow the queued task until it reaches a terminal state.
     #[arg(long, default_value_t = false)]
     pub status: bool,
 
     /// Fail immediately if the daemon is not already running.
     #[arg(long, default_value_t = false)]
     pub require_daemon: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct DevqlTaskWatchArgs {
+    pub task_id: String,
+
+    /// Fail immediately if the daemon is not already running.
+    #[arg(long, default_value_t = false)]
+    pub require_daemon: bool,
+}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct DevqlTaskStatusArgs {}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct DevqlTaskListArgs {
+    #[arg(long, value_enum)]
+    pub kind: Option<DevqlTaskKindArg>,
+
+    #[arg(long, value_enum)]
+    pub status: Option<DevqlTaskStatusArg>,
+
+    #[arg(long)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct DevqlTaskPauseArgs {
+    #[arg(long)]
+    pub reason: Option<String>,
+}
+
+#[derive(Args, Debug, Clone, Default)]
+pub struct DevqlTaskResumeArgs {}
+
+#[derive(Args, Debug, Clone)]
+pub struct DevqlTaskCancelArgs {
+    pub task_id: String,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/bitloops/src/cli/devql/graphql.rs
+++ b/bitloops/src/cli/devql/graphql.rs
@@ -11,12 +11,16 @@ pub(crate) use self::client::with_graphql_executor_hook;
 #[cfg(test)]
 pub(crate) use self::client::with_ingest_daemon_bootstrap_hook;
 #[cfg(test)]
-pub(crate) use self::client::with_ingest_daemon_bootstrap_hook as with_ingest_daemon_runtime_hook;
+pub(crate) use self::client::with_task_daemon_bootstrap_hook as with_ingest_daemon_runtime_hook;
 #[cfg(test)]
 pub(crate) use self::client::with_schema_sdl_fetch_hook;
-pub(crate) use self::client::{enqueue_sync_via_graphql, watch_sync_task_via_graphql};
 pub(crate) use self::client::{
+    cancel_task_via_graphql, enqueue_ingest_task_via_graphql, enqueue_sync_task_via_graphql,
     execute_devql_graphql, fetch_global_schema_sdl_via_daemon, fetch_slim_schema_sdl_via_daemon,
-    run_ingest_via_graphql, run_init_via_graphql,
+    list_tasks_via_graphql, pause_task_queue_via_graphql, resume_task_queue_via_graphql,
+    run_init_via_graphql, task_queue_status_via_graphql, watch_task_id_via_graphql,
+    watch_task_via_graphql,
 };
-pub(crate) use self::types::SyncTaskGraphqlRecord;
+pub(crate) use self::types::{
+    TaskGraphqlRecord, TaskQueueControlGraphqlRecord, TaskQueueGraphqlRecord,
+};

--- a/bitloops/src/cli/devql/graphql.rs
+++ b/bitloops/src/cli/devql/graphql.rs
@@ -11,9 +11,9 @@ pub(crate) use self::client::with_graphql_executor_hook;
 #[cfg(test)]
 pub(crate) use self::client::with_ingest_daemon_bootstrap_hook;
 #[cfg(test)]
-pub(crate) use self::client::with_task_daemon_bootstrap_hook as with_ingest_daemon_runtime_hook;
-#[cfg(test)]
 pub(crate) use self::client::with_schema_sdl_fetch_hook;
+#[cfg(test)]
+pub(crate) use self::client::with_task_daemon_bootstrap_hook as with_ingest_daemon_runtime_hook;
 pub(crate) use self::client::{
     cancel_task_via_graphql, enqueue_ingest_task_via_graphql, enqueue_sync_task_via_graphql,
     execute_devql_graphql, fetch_global_schema_sdl_via_daemon, fetch_slim_schema_sdl_via_daemon,

--- a/bitloops/src/cli/devql/graphql/client.rs
+++ b/bitloops/src/cli/devql/graphql/client.rs
@@ -6,18 +6,20 @@ use serde::de::DeserializeOwned;
 use serde_json::json;
 
 use super::documents::{
-    ENQUEUE_SYNC_MUTATION, INGEST_MUTATION, INIT_SCHEMA_MUTATION, SYNC_TASK_QUERY,
+    CANCEL_TASK_MUTATION, ENQUEUE_TASK_MUTATION, INIT_SCHEMA_MUTATION,
+    PAUSE_TASK_QUEUE_MUTATION, RESUME_TASK_QUEUE_MUTATION, TASK_QUERY, TASK_QUEUE_QUERY,
+    TASKS_QUERY,
 };
-use super::progress::{
-    SYNC_PROGRESS_POLL_INTERVAL, SYNC_RENDER_TICK_INTERVAL, SyncProgressRenderer,
-};
-use super::subscription::watch_sync_task_via_subscription;
+use super::progress::{TASK_PROGRESS_POLL_INTERVAL, TASK_RENDER_TICK_INTERVAL, TaskProgressRenderer};
+use super::subscription::watch_task_via_subscription;
 use super::types::{
-    EnqueueSyncMutationData, IngestMutationData, InitSchemaMutationData, SyncTaskGraphqlRecord,
-    SyncTaskQueryData,
+    CancelTaskMutationData, EnqueueTaskMutationData, InitSchemaMutationData,
+    PauseTaskQueueMutationData, ResumeTaskQueueMutationData, TaskGraphqlRecord,
+    TaskQueryData, TaskQueueControlGraphqlRecord, TaskQueueGraphqlRecord, TaskQueueQueryData,
+    TasksQueryData,
 };
 use crate::devql_transport::SlimCliRepoScope;
-use crate::host::devql::{SyncSummary, format_ingestion_summary, format_init_schema_summary};
+use crate::host::devql::format_init_schema_summary;
 use crate::{api::DashboardServerConfig, daemon};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -27,15 +29,15 @@ enum DaemonStartPolicy {
 }
 
 #[cfg(test)]
-type IngestDaemonBootstrapHook = dyn Fn(&Path) -> Result<()> + 'static;
+type TaskDaemonBootstrapHook = dyn Fn(&Path) -> Result<()> + 'static;
 
 #[cfg(test)]
-type IngestDaemonBootstrapHookCell =
-    std::cell::RefCell<Option<std::rc::Rc<IngestDaemonBootstrapHook>>>;
+type TaskDaemonBootstrapHookCell =
+    std::cell::RefCell<Option<std::rc::Rc<TaskDaemonBootstrapHook>>>;
 
 #[cfg(test)]
 thread_local! {
-    static INGEST_DAEMON_BOOTSTRAP_HOOK: IngestDaemonBootstrapHookCell =
+    static TASK_DAEMON_BOOTSTRAP_HOOK: TaskDaemonBootstrapHookCell =
         std::cell::RefCell::new(None);
 }
 
@@ -99,33 +101,7 @@ pub(crate) async fn fetch_global_schema_sdl_via_daemon() -> Result<String> {
     fetch_schema_sdl_via_daemon("/devql/global/sdl", None).await
 }
 
-pub(crate) async fn run_ingest_via_graphql(
-    scope: &SlimCliRepoScope,
-    backfill: Option<usize>,
-    require_daemon: bool,
-) -> Result<()> {
-    ensure_daemon_available_for_ingest(
-        scope.repo_root.as_path(),
-        daemon_start_policy(require_daemon),
-    )
-    .await?;
-    let variables = backfill.map_or_else(
-        || json!({}),
-        |backfill| {
-            json!({
-                "input": {
-                    "backfill": backfill,
-                }
-            })
-        },
-    );
-    let response: IngestMutationData =
-        execute_devql_graphql(scope, INGEST_MUTATION, variables).await?;
-    println!("{}", format_ingestion_summary(&response.ingest));
-    Ok(())
-}
-
-pub(crate) async fn enqueue_sync_via_graphql(
+pub(crate) async fn enqueue_sync_task_via_graphql(
     scope: &SlimCliRepoScope,
     full: bool,
     paths: Option<Vec<String>>,
@@ -133,93 +109,226 @@ pub(crate) async fn enqueue_sync_via_graphql(
     validate: bool,
     source: &str,
     require_daemon: bool,
-) -> Result<(SyncTaskGraphqlRecord, bool)> {
-    ensure_daemon_available_for_ingest(
+) -> Result<(TaskGraphqlRecord, bool)> {
+    ensure_daemon_available_for_tasks(
         scope.repo_root.as_path(),
         daemon_start_policy(require_daemon),
     )
     .await?;
-    let response: EnqueueSyncMutationData = execute_devql_graphql(
+
+    let response: EnqueueTaskMutationData = execute_devql_graphql(
         scope,
-        ENQUEUE_SYNC_MUTATION,
+        ENQUEUE_TASK_MUTATION,
         json!({
             "input": {
-                "full": full,
-                "paths": paths,
-                "repair": repair,
-                "validate": validate,
-                "source": source,
+                "kind": "SYNC",
+                "sync": {
+                    "full": full,
+                    "paths": paths,
+                    "repair": repair,
+                    "validate": validate,
+                    "source": source,
+                }
             }
         }),
     )
     .await?;
-    Ok((response.enqueue_sync.task, response.enqueue_sync.merged))
+    Ok((response.enqueue_task.task, response.enqueue_task.merged))
 }
 
-pub(crate) async fn query_sync_task_via_graphql(
+pub(crate) async fn enqueue_ingest_task_via_graphql(
+    scope: &SlimCliRepoScope,
+    backfill: Option<usize>,
+    require_daemon: bool,
+) -> Result<(TaskGraphqlRecord, bool)> {
+    ensure_daemon_available_for_tasks(
+        scope.repo_root.as_path(),
+        daemon_start_policy(require_daemon),
+    )
+    .await?;
+
+    let response: EnqueueTaskMutationData = execute_devql_graphql(
+        scope,
+        ENQUEUE_TASK_MUTATION,
+        json!({
+            "input": {
+                "kind": "INGEST",
+                "ingest": {
+                    "backfill": backfill,
+                }
+            }
+        }),
+    )
+    .await?;
+    Ok((response.enqueue_task.task, response.enqueue_task.merged))
+}
+
+pub(crate) async fn query_task_via_graphql(
     scope: &SlimCliRepoScope,
     task_id: &str,
-) -> Result<Option<SyncTaskGraphqlRecord>> {
-    let response: SyncTaskQueryData = execute_devql_graphql(
+) -> Result<Option<TaskGraphqlRecord>> {
+    let response: TaskQueryData = execute_devql_graphql(
         scope,
-        SYNC_TASK_QUERY,
+        TASK_QUERY,
         json!({
             "id": task_id,
         }),
     )
     .await?;
-    Ok(response.sync_task)
+    Ok(response.task)
 }
 
-pub(crate) async fn watch_sync_task_via_graphql(
+pub(crate) async fn list_tasks_via_graphql(
     scope: &SlimCliRepoScope,
-    initial_task: SyncTaskGraphqlRecord,
-) -> Result<Option<SyncSummary>> {
+    kind: Option<&str>,
+    status: Option<&str>,
+    limit: Option<usize>,
+) -> Result<Vec<TaskGraphqlRecord>> {
+    let response: TasksQueryData = execute_devql_graphql(
+        scope,
+        TASKS_QUERY,
+        json!({
+            "kind": kind.map(graphql_enum_name),
+            "status": status.map(graphql_enum_name),
+            "limit": limit.map(|value| i32::try_from(value).unwrap_or(i32::MAX)),
+        }),
+    )
+    .await?;
+    Ok(response.tasks)
+}
+
+pub(crate) async fn task_queue_status_via_graphql(
+    scope: &SlimCliRepoScope,
+) -> Result<TaskQueueGraphqlRecord> {
+    let response: TaskQueueQueryData =
+        execute_devql_graphql(scope, TASK_QUEUE_QUERY, json!({})).await?;
+    Ok(response.task_queue)
+}
+
+pub(crate) async fn pause_task_queue_via_graphql(
+    scope: &SlimCliRepoScope,
+    reason: Option<&str>,
+) -> Result<TaskQueueControlGraphqlRecord> {
+    let response: PauseTaskQueueMutationData = execute_devql_graphql(
+        scope,
+        PAUSE_TASK_QUEUE_MUTATION,
+        json!({
+            "reason": reason,
+        }),
+    )
+    .await?;
+    Ok(response.pause_task_queue)
+}
+
+pub(crate) async fn resume_task_queue_via_graphql(
+    scope: &SlimCliRepoScope,
+) -> Result<TaskQueueControlGraphqlRecord> {
+    let response: ResumeTaskQueueMutationData = execute_devql_graphql(
+        scope,
+        RESUME_TASK_QUEUE_MUTATION,
+        json!({
+            "repoId": null,
+        }),
+    )
+    .await?;
+    Ok(response.resume_task_queue)
+}
+
+pub(crate) async fn cancel_task_via_graphql(
+    scope: &SlimCliRepoScope,
+    task_id: &str,
+) -> Result<TaskGraphqlRecord> {
+    let response: CancelTaskMutationData = execute_devql_graphql(
+        scope,
+        CANCEL_TASK_MUTATION,
+        json!({
+            "id": task_id,
+        }),
+    )
+    .await?;
+    Ok(response.cancel_task)
+}
+
+pub(crate) async fn watch_task_via_graphql(
+    scope: &SlimCliRepoScope,
+    initial_task: TaskGraphqlRecord,
+) -> Result<Option<TaskGraphqlRecord>> {
     let task_id = initial_task.task_id.clone();
-    let mut renderer = SyncProgressRenderer::new();
+    let mut renderer = TaskProgressRenderer::new();
     renderer.render(&initial_task)?;
 
-    match watch_sync_task_via_subscription(task_id.as_str(), &mut renderer).await {
-        Ok(summary) => {
+    if initial_task.is_terminal() {
+        renderer.finish()?;
+        return handle_terminal_task(task_id.as_str(), initial_task).map(Some);
+    }
+
+    match watch_task_via_subscription(task_id.as_str(), &mut renderer).await {
+        Ok(final_task) => {
             renderer.finish()?;
-            return Ok(summary);
+            return Ok(final_task);
         }
         Err(err) => {
-            log::debug!("sync subscription unavailable; falling back to polling: {err:#}");
+            log::debug!("task subscription unavailable; falling back to polling: {err:#}");
         }
     }
 
     let mut latest_task = initial_task;
-    let mut poll_interval = tokio::time::interval(SYNC_PROGRESS_POLL_INTERVAL);
-    let mut render_tick = tokio::time::interval(SYNC_RENDER_TICK_INTERVAL);
+    let mut poll_interval = tokio::time::interval(TASK_PROGRESS_POLL_INTERVAL);
+    let mut render_tick = tokio::time::interval(TASK_RENDER_TICK_INTERVAL);
     loop {
         tokio::select! {
             _ = render_tick.tick(), if renderer.is_interactive() => {
                 renderer.tick(&latest_task)?;
             }
             _ = poll_interval.tick() => {
-                let Some(task) = query_sync_task_via_graphql(scope, task_id.as_str()).await? else {
+                let Some(task) = query_task_via_graphql(scope, task_id.as_str()).await? else {
                     renderer.finish()?;
                     return Ok(None);
                 };
                 latest_task = task;
                 renderer.render(&latest_task)?;
-                match latest_task.status.as_str() {
+                match latest_task.status.to_ascii_lowercase().as_str() {
                     "completed" => {
                         renderer.finish()?;
-                        return Ok(latest_task.summary.clone().map(Into::into));
+                        return Ok(Some(latest_task));
                     }
                     "failed" | "cancelled" => {
                         renderer.finish()?;
-                        if let Some(error) = latest_task.error.clone() {
-                            bail!("sync task {task_id} failed: {error}");
-                        }
-                        bail!("sync task {task_id} ended with status {}", latest_task.status);
+                        return handle_terminal_task(task_id.as_str(), latest_task).map(Some);
                     }
                     _ => {}
                 }
             }
         }
+    }
+}
+
+pub(crate) async fn watch_task_id_via_graphql(
+    scope: &SlimCliRepoScope,
+    task_id: &str,
+    require_daemon: bool,
+) -> Result<Option<TaskGraphqlRecord>> {
+    ensure_daemon_available_for_tasks(
+        scope.repo_root.as_path(),
+        daemon_start_policy(require_daemon),
+    )
+    .await?;
+    let Some(initial_task) = query_task_via_graphql(scope, task_id).await? else {
+        bail!("unknown task `{task_id}`");
+    };
+    watch_task_via_graphql(scope, initial_task).await
+}
+
+fn handle_terminal_task(task_id: &str, task: TaskGraphqlRecord) -> Result<TaskGraphqlRecord> {
+    match task.status.to_ascii_lowercase().as_str() {
+        "completed" => Ok(task),
+        "failed" | "cancelled" => {
+            if let Some(error) = task.error.clone() {
+                bail!("task {task_id} failed: {error}");
+            }
+            bail!("task {task_id} ended with status {}", task.status);
+        }
+        _ => Ok(task),
     }
 }
 
@@ -297,7 +406,11 @@ fn daemon_start_policy(require_daemon: bool) -> DaemonStartPolicy {
     }
 }
 
-async fn ensure_daemon_available_for_ingest(
+fn graphql_enum_name(raw: &str) -> String {
+    raw.trim().to_ascii_uppercase().replace('-', "_")
+}
+
+async fn ensure_daemon_available_for_tasks(
     _repo_root: &Path,
     policy: DaemonStartPolicy,
 ) -> Result<()> {
@@ -337,31 +450,36 @@ async fn ensure_daemon_available_for_ingest(
 }
 
 #[cfg(test)]
-pub(crate) fn with_ingest_daemon_bootstrap_hook<T>(
+pub(crate) fn with_task_daemon_bootstrap_hook<T>(
     hook: impl Fn(&Path) -> Result<()> + 'static,
     f: impl FnOnce() -> T,
 ) -> T {
-    INGEST_DAEMON_BOOTSTRAP_HOOK.with(|cell: &IngestDaemonBootstrapHookCell| {
-        assert!(
-            cell.borrow().is_none(),
-            "ingest daemon hook already installed"
-        );
+    TASK_DAEMON_BOOTSTRAP_HOOK.with(|cell: &TaskDaemonBootstrapHookCell| {
+        assert!(cell.borrow().is_none(), "task daemon hook already installed");
         *cell.borrow_mut() = Some(std::rc::Rc::new(hook));
     });
-    let _guard = ThreadLocalHookGuard(clear_ingest_daemon_bootstrap_hook);
+    let _guard = ThreadLocalHookGuard(clear_task_daemon_bootstrap_hook);
     f()
 }
 
 #[cfg(test)]
+pub(crate) fn with_ingest_daemon_bootstrap_hook<T>(
+    hook: impl Fn(&Path) -> Result<()> + 'static,
+    f: impl FnOnce() -> T,
+) -> T {
+    with_task_daemon_bootstrap_hook(hook, f)
+}
+
+#[cfg(test)]
 fn maybe_bootstrap_daemon_via_hook(repo_root: &Path) -> Option<Result<()>> {
-    INGEST_DAEMON_BOOTSTRAP_HOOK.with(|hook: &IngestDaemonBootstrapHookCell| {
+    TASK_DAEMON_BOOTSTRAP_HOOK.with(|hook: &TaskDaemonBootstrapHookCell| {
         hook.borrow().as_ref().map(|hook| hook(repo_root))
     })
 }
 
 #[cfg(test)]
-fn clear_ingest_daemon_bootstrap_hook() {
-    INGEST_DAEMON_BOOTSTRAP_HOOK.with(|cell: &IngestDaemonBootstrapHookCell| {
+fn clear_task_daemon_bootstrap_hook() {
+    TASK_DAEMON_BOOTSTRAP_HOOK.with(|cell: &TaskDaemonBootstrapHookCell| {
         *cell.borrow_mut() = None;
     });
 }

--- a/bitloops/src/cli/devql/graphql/client.rs
+++ b/bitloops/src/cli/devql/graphql/client.rs
@@ -6,17 +6,17 @@ use serde::de::DeserializeOwned;
 use serde_json::json;
 
 use super::documents::{
-    CANCEL_TASK_MUTATION, ENQUEUE_TASK_MUTATION, INIT_SCHEMA_MUTATION,
-    PAUSE_TASK_QUEUE_MUTATION, RESUME_TASK_QUEUE_MUTATION, TASK_QUERY, TASK_QUEUE_QUERY,
-    TASKS_QUERY,
+    CANCEL_TASK_MUTATION, ENQUEUE_TASK_MUTATION, INIT_SCHEMA_MUTATION, PAUSE_TASK_QUEUE_MUTATION,
+    RESUME_TASK_QUEUE_MUTATION, TASK_QUERY, TASK_QUEUE_QUERY, TASKS_QUERY,
 };
-use super::progress::{TASK_PROGRESS_POLL_INTERVAL, TASK_RENDER_TICK_INTERVAL, TaskProgressRenderer};
+use super::progress::{
+    TASK_PROGRESS_POLL_INTERVAL, TASK_RENDER_TICK_INTERVAL, TaskProgressRenderer,
+};
 use super::subscription::watch_task_via_subscription;
 use super::types::{
     CancelTaskMutationData, EnqueueTaskMutationData, InitSchemaMutationData,
-    PauseTaskQueueMutationData, ResumeTaskQueueMutationData, TaskGraphqlRecord,
-    TaskQueryData, TaskQueueControlGraphqlRecord, TaskQueueGraphqlRecord, TaskQueueQueryData,
-    TasksQueryData,
+    PauseTaskQueueMutationData, ResumeTaskQueueMutationData, TaskGraphqlRecord, TaskQueryData,
+    TaskQueueControlGraphqlRecord, TaskQueueGraphqlRecord, TaskQueueQueryData, TasksQueryData,
 };
 use crate::devql_transport::SlimCliRepoScope;
 use crate::host::devql::format_init_schema_summary;
@@ -32,8 +32,7 @@ enum DaemonStartPolicy {
 type TaskDaemonBootstrapHook = dyn Fn(&Path) -> Result<()> + 'static;
 
 #[cfg(test)]
-type TaskDaemonBootstrapHookCell =
-    std::cell::RefCell<Option<std::rc::Rc<TaskDaemonBootstrapHook>>>;
+type TaskDaemonBootstrapHookCell = std::cell::RefCell<Option<std::rc::Rc<TaskDaemonBootstrapHook>>>;
 
 #[cfg(test)]
 thread_local! {
@@ -460,7 +459,10 @@ pub(crate) fn with_task_daemon_bootstrap_hook<T>(
     f: impl FnOnce() -> T,
 ) -> T {
     TASK_DAEMON_BOOTSTRAP_HOOK.with(|cell: &TaskDaemonBootstrapHookCell| {
-        assert!(cell.borrow().is_none(), "task daemon hook already installed");
+        assert!(
+            cell.borrow().is_none(),
+            "task daemon hook already installed"
+        );
         *cell.borrow_mut() = Some(std::rc::Rc::new(hook));
     });
     let _guard = ThreadLocalHookGuard(clear_task_daemon_bootstrap_hook);

--- a/bitloops/src/cli/devql/graphql/documents.rs
+++ b/bitloops/src/cli/devql/graphql/documents.rs
@@ -10,56 +10,57 @@ pub(super) const INIT_SCHEMA_MUTATION: &str = r#"
     }
 "#;
 
-pub(super) const INGEST_MUTATION: &str = r#"
-    mutation Ingest($input: IngestInput) {
-      ingest(input: $input) {
-        success
-        commitsProcessed
-        checkpointCompanionsProcessed
-        eventsInserted
-        artefactsUpserted
-        semanticFeatureRowsUpserted
-        semanticFeatureRowsSkipped
-        symbolEmbeddingRowsUpserted
-        symbolEmbeddingRowsSkipped
-        symbolCloneEdgesUpserted
-        symbolCloneSourcesScored
-      }
-    }
-"#;
-
-pub(super) const ENQUEUE_SYNC_MUTATION: &str = r#"
-    mutation EnqueueSync($input: EnqueueSyncInput!) {
-      enqueueSync(input: $input) {
+pub(super) const ENQUEUE_TASK_MUTATION: &str = r#"
+    mutation EnqueueTask($input: EnqueueTaskInput!) {
+      enqueueTask(input: $input) {
         merged
         task {
           taskId
           repoId
           repoName
           repoIdentity
+          kind
           source
-          mode
           status
-          phase
           submittedAtUnix
           startedAtUnix
           updatedAtUnix
           completedAtUnix
           queuePosition
           tasksAhead
-          currentPath
-          pathsTotal
-          pathsCompleted
-          pathsRemaining
-          pathsUnchanged
-          pathsAdded
-          pathsChanged
-          pathsRemoved
-          cacheHits
-          cacheMisses
-          parseErrors
           error
-          summary {
+          syncSpec {
+            mode
+            paths
+          }
+          ingestSpec {
+            backfill
+          }
+          syncProgress {
+            phase
+            currentPath
+            pathsTotal
+            pathsCompleted
+            pathsRemaining
+            pathsUnchanged
+            pathsAdded
+            pathsChanged
+            pathsRemoved
+            cacheHits
+            cacheMisses
+            parseErrors
+          }
+          ingestProgress {
+            phase
+            commitsTotal
+            commitsProcessed
+            checkpointCompanionsProcessed
+            currentCheckpointId
+            currentCommitSha
+            eventsInserted
+            artefactsUpserted
+          }
+          syncResult {
             success
             mode
             parserVersion
@@ -97,41 +98,73 @@ pub(super) const ENQUEUE_SYNC_MUTATION: &str = r#"
               }
             }
           }
+          ingestResult {
+            success
+            commitsProcessed
+            checkpointCompanionsProcessed
+            eventsInserted
+            artefactsUpserted
+            semanticFeatureRowsUpserted
+            semanticFeatureRowsSkipped
+            symbolEmbeddingRowsUpserted
+            symbolEmbeddingRowsSkipped
+            symbolCloneEdgesUpserted
+            symbolCloneSourcesScored
+          }
         }
       }
     }
 "#;
 
-pub(super) const SYNC_TASK_QUERY: &str = r#"
-    query SyncTask($id: String!) {
-      syncTask(id: $id) {
+pub(super) const TASK_QUERY: &str = r#"
+    query Task($id: String!) {
+      task(id: $id) {
         taskId
         repoId
         repoName
         repoIdentity
+        kind
         source
-        mode
         status
-        phase
         submittedAtUnix
         startedAtUnix
         updatedAtUnix
         completedAtUnix
         queuePosition
         tasksAhead
-        currentPath
-        pathsTotal
-        pathsCompleted
-        pathsRemaining
-        pathsUnchanged
-        pathsAdded
-        pathsChanged
-        pathsRemoved
-        cacheHits
-        cacheMisses
-        parseErrors
         error
-        summary {
+        syncSpec {
+          mode
+          paths
+        }
+        ingestSpec {
+          backfill
+        }
+        syncProgress {
+          phase
+          currentPath
+          pathsTotal
+          pathsCompleted
+          pathsRemaining
+          pathsUnchanged
+          pathsAdded
+          pathsChanged
+          pathsRemoved
+          cacheHits
+          cacheMisses
+          parseErrors
+        }
+        ingestProgress {
+          phase
+          commitsTotal
+          commitsProcessed
+          checkpointCompanionsProcessed
+          currentCheckpointId
+          currentCommitSha
+          eventsInserted
+          artefactsUpserted
+        }
+        syncResult {
           success
           mode
           parserVersion
@@ -169,47 +202,53 @@ pub(super) const SYNC_TASK_QUERY: &str = r#"
             }
           }
         }
+        ingestResult {
+          success
+          commitsProcessed
+          checkpointCompanionsProcessed
+          eventsInserted
+          artefactsUpserted
+          semanticFeatureRowsUpserted
+          semanticFeatureRowsSkipped
+          symbolEmbeddingRowsUpserted
+          symbolEmbeddingRowsSkipped
+          symbolCloneEdgesUpserted
+          symbolCloneSourcesScored
+        }
       }
     }
 "#;
 
-pub(super) const SYNC_PROGRESS_SUBSCRIPTION: &str = r#"
-    subscription SyncProgress($taskId: String!) {
-      syncProgress(taskId: $taskId) {
+pub(super) const TASKS_QUERY: &str = r#"
+    query Tasks($kind: TaskKind, $status: TaskStatus, $limit: Int) {
+      tasks(kind: $kind, status: $status, limit: $limit) {
         taskId
         repoId
         repoName
         repoIdentity
+        kind
         source
-        mode
         status
-        phase
         submittedAtUnix
         startedAtUnix
         updatedAtUnix
         completedAtUnix
         queuePosition
         tasksAhead
-        currentPath
-        pathsTotal
-        pathsCompleted
-        pathsRemaining
-        pathsUnchanged
-        pathsAdded
-        pathsChanged
-        pathsRemoved
-        cacheHits
-        cacheMisses
-        parseErrors
         error
-        summary {
-          success
+        syncSpec {
           mode
-          parserVersion
-          extractorVersion
-          activeBranch
-          headCommitSha
-          headTreeSha
+          paths
+        }
+        ingestSpec {
+          backfill
+        }
+        syncProgress {
+          phase
+          currentPath
+          pathsTotal
+          pathsCompleted
+          pathsRemaining
           pathsUnchanged
           pathsAdded
           pathsChanged
@@ -217,27 +256,296 @@ pub(super) const SYNC_PROGRESS_SUBSCRIPTION: &str = r#"
           cacheHits
           cacheMisses
           parseErrors
-          validation {
-            valid
-            expectedArtefacts
-            actualArtefacts
-            expectedEdges
-            actualEdges
-            missingArtefacts
-            staleArtefacts
-            mismatchedArtefacts
-            missingEdges
-            staleEdges
-            mismatchedEdges
-            filesWithDrift {
-              path
+        }
+        ingestProgress {
+          phase
+          commitsTotal
+          commitsProcessed
+          checkpointCompanionsProcessed
+          currentCheckpointId
+          currentCommitSha
+          eventsInserted
+          artefactsUpserted
+        }
+        syncResult {
+          success
+          mode
+        }
+        ingestResult {
+          success
+          commitsProcessed
+          eventsInserted
+          artefactsUpserted
+        }
+      }
+    }
+"#;
+
+pub(super) const TASK_QUEUE_QUERY: &str = r#"
+    query TaskQueue {
+      taskQueue {
+        persisted
+        queuedTasks
+        runningTasks
+        failedTasks
+        completedRecentTasks
+        byKind {
+          kind
+          queuedTasks
+          runningTasks
+          failedTasks
+          completedRecentTasks
+        }
+        paused
+        pausedReason
+        lastAction
+        lastUpdatedUnix
+        currentRepoTasks {
+          taskId
+          repoId
+          repoName
+          repoIdentity
+          kind
+          source
+          status
+          submittedAtUnix
+          startedAtUnix
+          updatedAtUnix
+          completedAtUnix
+          queuePosition
+          tasksAhead
+          error
+          syncSpec {
+            mode
+            paths
+          }
+          ingestSpec {
+            backfill
+          }
+          syncProgress {
+            phase
+            currentPath
+            pathsTotal
+            pathsCompleted
+            pathsRemaining
+            pathsUnchanged
+            pathsAdded
+            pathsChanged
+            pathsRemoved
+            cacheHits
+            cacheMisses
+            parseErrors
+          }
+          ingestProgress {
+            phase
+            commitsTotal
+            commitsProcessed
+            checkpointCompanionsProcessed
+            currentCheckpointId
+            currentCommitSha
+            eventsInserted
+            artefactsUpserted
+          }
+          syncResult {
+            success
+            mode
+          }
+          ingestResult {
+            success
+            commitsProcessed
+            eventsInserted
+            artefactsUpserted
+          }
+        }
+      }
+    }
+"#;
+
+pub(super) const PAUSE_TASK_QUEUE_MUTATION: &str = r#"
+    mutation PauseTaskQueue($reason: String) {
+      pauseTaskQueue(reason: $reason) {
+        message
+        repoId
+        paused
+        pausedReason
+        updatedAtUnix
+      }
+    }
+"#;
+
+pub(super) const RESUME_TASK_QUEUE_MUTATION: &str = r#"
+    mutation ResumeTaskQueue($repoId: String) {
+      resumeTaskQueue(repoId: $repoId) {
+        message
+        repoId
+        paused
+        pausedReason
+        updatedAtUnix
+      }
+    }
+"#;
+
+pub(super) const CANCEL_TASK_MUTATION: &str = r#"
+    mutation CancelTask($id: String!) {
+      cancelTask(id: $id) {
+        taskId
+        repoId
+        repoName
+        repoIdentity
+        kind
+        source
+        status
+        submittedAtUnix
+        startedAtUnix
+        updatedAtUnix
+        completedAtUnix
+        queuePosition
+        tasksAhead
+        error
+        syncSpec {
+          mode
+          paths
+        }
+        ingestSpec {
+          backfill
+        }
+        syncProgress {
+          phase
+          currentPath
+          pathsTotal
+          pathsCompleted
+          pathsRemaining
+          pathsUnchanged
+          pathsAdded
+          pathsChanged
+          pathsRemoved
+          cacheHits
+          cacheMisses
+          parseErrors
+        }
+        ingestProgress {
+          phase
+          commitsTotal
+          commitsProcessed
+          checkpointCompanionsProcessed
+          currentCheckpointId
+          currentCommitSha
+          eventsInserted
+          artefactsUpserted
+        }
+        syncResult {
+          success
+          mode
+        }
+        ingestResult {
+          success
+          commitsProcessed
+          eventsInserted
+          artefactsUpserted
+        }
+      }
+    }
+"#;
+
+pub(super) const TASK_PROGRESS_SUBSCRIPTION: &str = r#"
+    subscription TaskProgress($taskId: String!) {
+      taskProgress(taskId: $taskId) {
+        task {
+          taskId
+          repoId
+          repoName
+          repoIdentity
+          kind
+          source
+          status
+          submittedAtUnix
+          startedAtUnix
+          updatedAtUnix
+          completedAtUnix
+          queuePosition
+          tasksAhead
+          error
+          syncSpec {
+            mode
+            paths
+          }
+          ingestSpec {
+            backfill
+          }
+          syncProgress {
+            phase
+            currentPath
+            pathsTotal
+            pathsCompleted
+            pathsRemaining
+            pathsUnchanged
+            pathsAdded
+            pathsChanged
+            pathsRemoved
+            cacheHits
+            cacheMisses
+            parseErrors
+          }
+          ingestProgress {
+            phase
+            commitsTotal
+            commitsProcessed
+            checkpointCompanionsProcessed
+            currentCheckpointId
+            currentCommitSha
+            eventsInserted
+            artefactsUpserted
+          }
+          syncResult {
+            success
+            mode
+            parserVersion
+            extractorVersion
+            activeBranch
+            headCommitSha
+            headTreeSha
+            pathsUnchanged
+            pathsAdded
+            pathsChanged
+            pathsRemoved
+            cacheHits
+            cacheMisses
+            parseErrors
+            validation {
+              valid
+              expectedArtefacts
+              actualArtefacts
+              expectedEdges
+              actualEdges
               missingArtefacts
               staleArtefacts
               mismatchedArtefacts
               missingEdges
               staleEdges
               mismatchedEdges
+              filesWithDrift {
+                path
+                missingArtefacts
+                staleArtefacts
+                mismatchedArtefacts
+                missingEdges
+                staleEdges
+                mismatchedEdges
+              }
             }
+          }
+          ingestResult {
+            success
+            commitsProcessed
+            checkpointCompanionsProcessed
+            eventsInserted
+            artefactsUpserted
+            semanticFeatureRowsUpserted
+            semanticFeatureRowsSkipped
+            symbolEmbeddingRowsUpserted
+            symbolEmbeddingRowsSkipped
+            symbolCloneEdgesUpserted
+            symbolCloneSourcesScored
           }
         }
       }

--- a/bitloops/src/cli/devql/graphql/documents.rs
+++ b/bitloops/src/cli/devql/graphql/documents.rs
@@ -267,16 +267,6 @@ pub(super) const TASKS_QUERY: &str = r#"
           eventsInserted
           artefactsUpserted
         }
-        syncResult {
-          success
-          mode
-        }
-        ingestResult {
-          success
-          commitsProcessed
-          eventsInserted
-          artefactsUpserted
-        }
       }
     }
 "#;
@@ -343,16 +333,6 @@ pub(super) const TASK_QUEUE_QUERY: &str = r#"
             checkpointCompanionsProcessed
             currentCheckpointId
             currentCommitSha
-            eventsInserted
-            artefactsUpserted
-          }
-          syncResult {
-            success
-            mode
-          }
-          ingestResult {
-            success
-            commitsProcessed
             eventsInserted
             artefactsUpserted
           }

--- a/bitloops/src/cli/devql/graphql/progress.rs
+++ b/bitloops/src/cli/devql/graphql/progress.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 use anyhow::Result;
 use terminal_size::{Width, terminal_size};
 
-use super::types::SyncTaskGraphqlRecord;
+use super::types::TaskGraphqlRecord;
 use crate::utils::branding::{BITLOOPS_PURPLE_HEX, color_hex_if_enabled};
 
-pub(super) const SYNC_PROGRESS_POLL_INTERVAL: Duration = Duration::from_secs(1);
-pub(super) const SYNC_RENDER_TICK_INTERVAL: Duration = Duration::from_millis(120);
-const SYNC_SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+pub(super) const TASK_PROGRESS_POLL_INTERVAL: Duration = Duration::from_secs(1);
+pub(super) const TASK_RENDER_TICK_INTERVAL: Duration = Duration::from_millis(120);
+const TASK_SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-pub(super) struct SyncProgressRenderer {
+pub(super) struct TaskProgressRenderer {
     interactive: bool,
     terminal_width: Option<usize>,
     spinner_index: usize,
@@ -19,7 +19,7 @@ pub(super) struct SyncProgressRenderer {
     wrote_in_place: bool,
 }
 
-impl SyncProgressRenderer {
+impl TaskProgressRenderer {
     pub(super) fn new() -> Self {
         Self {
             interactive: std::io::stdout().is_terminal() && std::env::var("ACCESSIBLE").is_err(),
@@ -34,16 +34,16 @@ impl SyncProgressRenderer {
         self.interactive
     }
 
-    pub(super) fn render(&mut self, task: &SyncTaskGraphqlRecord) -> Result<()> {
+    pub(super) fn render(&mut self, task: &TaskGraphqlRecord) -> Result<()> {
         let frame = self.render_frame(task);
         self.write_frame(frame, false)
     }
 
-    pub(super) fn tick(&mut self, task: &SyncTaskGraphqlRecord) -> Result<()> {
-        if !self.interactive || !matches!(task.status.as_str(), "queued" | "running") {
+    pub(super) fn tick(&mut self, task: &TaskGraphqlRecord) -> Result<()> {
+        if !self.interactive || !matches!(status_key(task).as_str(), "queued" | "running") {
             return Ok(());
         }
-        self.spinner_index = (self.spinner_index + 1) % SYNC_SPINNER_FRAMES.len();
+        self.spinner_index = (self.spinner_index + 1) % TASK_SPINNER_FRAMES.len();
         let frame = self.render_frame(task);
         self.write_frame(frame, true)
     }
@@ -59,18 +59,18 @@ impl SyncProgressRenderer {
     }
 
     fn spinner_frame(&self) -> String {
-        color_hex_if_enabled(SYNC_SPINNER_FRAMES[self.spinner_index], BITLOOPS_PURPLE_HEX)
+        color_hex_if_enabled(TASK_SPINNER_FRAMES[self.spinner_index], BITLOOPS_PURPLE_HEX)
     }
 
-    fn render_frame(&self, task: &SyncTaskGraphqlRecord) -> String {
+    fn render_frame(&self, task: &TaskGraphqlRecord) -> String {
         if self.interactive {
             let bar =
-                format_live_sync_progress_bar_line(task, self.spinner_index, self.terminal_width);
+                format_live_task_progress_bar_line(task, self.spinner_index, self.terminal_width);
             let status =
-                format_live_sync_task_status_line(task, &self.spinner_frame(), self.terminal_width);
+                format_live_task_status_line(task, &self.spinner_frame(), self.terminal_width);
             format!("{bar}\n{status}")
         } else {
-            format_live_sync_task_status_line(task, &self.spinner_frame(), self.terminal_width)
+            format_live_task_status_line(task, &self.spinner_frame(), self.terminal_width)
         }
     }
 
@@ -99,36 +99,82 @@ impl SyncProgressRenderer {
     }
 }
 
-pub(super) fn format_live_sync_task_status_line(
-    task: &SyncTaskGraphqlRecord,
+pub(super) fn format_live_task_status_line(
+    task: &TaskGraphqlRecord,
     spinner: &str,
     terminal_width: Option<usize>,
 ) -> String {
-    let status = match task.status.as_str() {
-        "queued" => format!(
+    let status = match (kind_key(task).as_str(), status_key(task).as_str()) {
+        ("sync", "queued") => format!(
             "Sync queued for {} · mode={} · {} ahead",
             task.repo_name,
-            task.mode,
+            task.sync_spec
+                .as_ref()
+                .map(|spec| spec.mode.as_str())
+                .unwrap_or("auto"),
             task.tasks_ahead.unwrap_or(0),
         ),
-        "running" => {
+        ("sync", "running") => {
+            let progress = task.sync_progress.as_ref();
             let mut line = format!(
                 "Syncing {} · {}",
                 task.repo_name,
-                humanise_sync_phase(task.phase.as_str()),
+                progress
+                    .map(|progress| humanise_sync_phase(progress.phase.as_str()))
+                    .unwrap_or("working"),
             );
-            if task.paths_total > 0 {
-                line.push_str(&format!(" · {}/{}", task.paths_completed, task.paths_total));
-            }
-            if let Some(path) = task.current_path.as_ref() {
-                line.push_str(&format!(" · {path}"));
+            if let Some(progress) = progress {
+                if progress.paths_total > 0 {
+                    line.push_str(&format!(
+                        " · {}/{}",
+                        progress.paths_completed, progress.paths_total
+                    ));
+                }
+                if let Some(path) = progress.current_path.as_ref() {
+                    line.push_str(&format!(" · {path}"));
+                }
             }
             line
         }
-        "completed" => format!("✓ Sync complete for {}", task.repo_name),
-        "failed" => format!("✖ Sync failed for {}", task.repo_name),
-        "cancelled" => format!("✖ Sync cancelled for {}", task.repo_name),
-        other => format!("Sync {other} for {}", task.repo_name),
+        ("ingest", "queued") => format!(
+            "Ingest queued for {} · {} ahead",
+            task.repo_name,
+            task.tasks_ahead.unwrap_or(0),
+        ),
+        ("ingest", "running") => {
+            let progress = task.ingest_progress.as_ref();
+            let mut line = format!(
+                "Ingesting {} · {}",
+                task.repo_name,
+                progress
+                    .map(|progress| humanise_ingest_phase(progress.phase.as_str()))
+                    .unwrap_or("working"),
+            );
+            if let Some(progress) = progress {
+                if progress.commits_total > 0 {
+                    line.push_str(&format!(
+                        " · {}/{}",
+                        progress.commits_processed, progress.commits_total
+                    ));
+                }
+                if let Some(commit_sha) = progress.current_commit_sha.as_ref() {
+                    line.push_str(&format!(" · {commit_sha}"));
+                }
+            }
+            line
+        }
+        ("sync", "completed") => format!("✓ Sync complete for {}", task.repo_name),
+        ("ingest", "completed") => format!("✓ Ingest complete for {}", task.repo_name),
+        ("sync", "failed") => format!("✖ Sync failed for {}", task.repo_name),
+        ("ingest", "failed") => format!("✖ Ingest failed for {}", task.repo_name),
+        ("sync", "cancelled") => format!("✖ Sync cancelled for {}", task.repo_name),
+        ("ingest", "cancelled") => format!("✖ Ingest cancelled for {}", task.repo_name),
+        _ => format!(
+            "{} {} for {}",
+            humanise_kind(task),
+            status_key(task),
+            task.repo_name
+        ),
     };
     let fitted = fit_live_status_text(
         status.as_str(),
@@ -137,22 +183,17 @@ pub(super) fn format_live_sync_task_status_line(
     format!("{spinner} {fitted}")
 }
 
-pub(super) fn format_live_sync_progress_bar_line(
-    task: &SyncTaskGraphqlRecord,
+pub(super) fn format_live_task_progress_bar_line(
+    task: &TaskGraphqlRecord,
     spinner_index: usize,
     terminal_width: Option<usize>,
 ) -> String {
     let available_width = terminal_width.unwrap_or(80).max(16);
     let ratio = progress_ratio(task);
-    let summary = if let Some(ratio) = ratio {
-        format!(
-            " {:>3}% {}/{}",
-            (ratio * 100.0).round() as usize,
-            task.paths_completed,
-            task.paths_total
-        )
+    let summary = if let Some((ratio, done, total)) = ratio {
+        format!(" {:>3}% {done}/{total}", (ratio * 100.0).round() as usize)
     } else {
-        format!(" {} ", humanise_sync_phase(task.phase.as_str()))
+        format!(" {} ", humanise_phase(task))
     };
     let reserved = summary.chars().count() + 2;
     if available_width <= reserved + 1 {
@@ -160,7 +201,7 @@ pub(super) fn format_live_sync_progress_bar_line(
     }
 
     let bar_width = available_width - reserved;
-    let bar = if let Some(ratio) = ratio {
+    let bar = if let Some((ratio, _, _)) = ratio {
         render_determinate_progress_bar(bar_width, ratio)
     } else {
         render_indeterminate_progress_bar(bar_width, spinner_index)
@@ -169,19 +210,35 @@ pub(super) fn format_live_sync_progress_bar_line(
     format!("[{bar}]{summary}")
 }
 
-fn progress_ratio(task: &SyncTaskGraphqlRecord) -> Option<f64> {
-    match task.status.as_str() {
-        "completed" => Some(1.0),
-        "failed" | "cancelled" => {
-            if task.paths_total > 0 {
-                Some((task.paths_completed as f64 / task.paths_total as f64).clamp(0.0, 1.0))
+fn progress_ratio(task: &TaskGraphqlRecord) -> Option<(f64, i32, i32)> {
+    match kind_key(task).as_str() {
+        "sync" => task.sync_progress.as_ref().and_then(|progress| {
+            if progress.paths_total > 0 {
+                Some((
+                    (progress.paths_completed as f64 / progress.paths_total as f64).clamp(0.0, 1.0),
+                    progress.paths_completed,
+                    progress.paths_total,
+                ))
+            } else if status_key(task) == "completed" {
+                Some((1.0, 1, 1))
             } else {
-                Some(0.0)
+                None
             }
-        }
-        _ if task.paths_total > 0 => {
-            Some((task.paths_completed as f64 / task.paths_total as f64).clamp(0.0, 1.0))
-        }
+        }),
+        "ingest" => task.ingest_progress.as_ref().and_then(|progress| {
+            if progress.commits_total > 0 {
+                Some((
+                    (progress.commits_processed as f64 / progress.commits_total as f64)
+                        .clamp(0.0, 1.0),
+                    progress.commits_processed,
+                    progress.commits_total,
+                ))
+            } else if status_key(task) == "completed" {
+                Some((1.0, 1, 1))
+            } else {
+                None
+            }
+        }),
         _ => None,
     }
 }
@@ -244,6 +301,38 @@ fn elide_middle(text: &str, max_width: usize) -> String {
     format!("{prefix}…{suffix}")
 }
 
+fn kind_key(task: &TaskGraphqlRecord) -> String {
+    task.kind.to_ascii_lowercase()
+}
+
+fn status_key(task: &TaskGraphqlRecord) -> String {
+    task.status.to_ascii_lowercase()
+}
+
+fn humanise_kind(task: &TaskGraphqlRecord) -> &'static str {
+    match kind_key(task).as_str() {
+        "sync" => "Sync",
+        "ingest" => "Ingest",
+        _ => "Task",
+    }
+}
+
+fn humanise_phase(task: &TaskGraphqlRecord) -> &'static str {
+    match kind_key(task).as_str() {
+        "sync" => task
+            .sync_progress
+            .as_ref()
+            .map(|progress| humanise_sync_phase(progress.phase.as_str()))
+            .unwrap_or("working"),
+        "ingest" => task
+            .ingest_progress
+            .as_ref()
+            .map(|progress| humanise_ingest_phase(progress.phase.as_str()))
+            .unwrap_or("working"),
+        _ => "working",
+    }
+}
+
 fn humanise_sync_phase(phase: &str) -> &'static str {
     match phase {
         "queued" => "waiting in queue",
@@ -256,6 +345,17 @@ fn humanise_sync_phase(phase: &str) -> &'static str {
         "extracting_paths" => "extracting artefacts",
         "materialising_paths" => "materialising artefacts",
         "running_gc" => "cleaning caches",
+        "complete" => "complete",
+        "failed" => "failed",
+        _ => "working",
+    }
+}
+
+fn humanise_ingest_phase(phase: &str) -> &'static str {
+    match phase.to_ascii_lowercase().as_str() {
+        "initializing" => "initialising",
+        "extracting" => "extracting checkpoints",
+        "persisting" => "persisting state",
         "complete" => "complete",
         "failed" => "failed",
         _ => "working",

--- a/bitloops/src/cli/devql/graphql/subscription.rs
+++ b/bitloops/src/cli/devql/graphql/subscription.rs
@@ -285,20 +285,41 @@ pub(super) fn should_accept_invalid_daemon_websocket_certs(url: &str) -> bool {
 }
 
 fn insecure_loopback_websocket_tls_config() -> Result<Arc<rustls::ClientConfig>> {
-    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
-    Ok(CONFIG
-        .get_or_init(|| {
-            let config = rustls::ClientConfig::builder()
+    static CONFIG: OnceLock<std::result::Result<Arc<rustls::ClientConfig>, String>> =
+        OnceLock::new();
+    let config = CONFIG.get_or_init(|| {
+        let provider = crate::api::tls::rustls_crypto_provider().map_err(|err| err.to_string())?;
+        let verifier = Arc::new(LoopbackCertVerifier::new(
+            provider.signature_verification_algorithms,
+        ));
+        Ok(Arc::new(
+            rustls::ClientConfig::builder_with_provider(provider)
+                .with_safe_default_protocol_versions()
+                .expect("safe default TLS versions are valid")
                 .dangerous()
-                .with_custom_certificate_verifier(Arc::new(LoopbackCertVerifier))
-                .with_no_client_auth();
-            Arc::new(config)
-        })
-        .clone())
+                .with_custom_certificate_verifier(verifier)
+                .with_no_client_auth(),
+        ))
+    });
+
+    config
+        .as_ref()
+        .map(Arc::clone)
+        .map_err(|message| anyhow::anyhow!(message.clone()))
 }
 
 #[derive(Debug)]
-struct LoopbackCertVerifier;
+struct LoopbackCertVerifier {
+    supported_algorithms: rustls::crypto::WebPkiSupportedAlgorithms,
+}
+
+impl LoopbackCertVerifier {
+    fn new(supported_algorithms: rustls::crypto::WebPkiSupportedAlgorithms) -> Self {
+        Self {
+            supported_algorithms,
+        }
+    }
+}
 
 impl ServerCertVerifier for LoopbackCertVerifier {
     fn verify_server_cert(
@@ -329,12 +350,7 @@ impl ServerCertVerifier for LoopbackCertVerifier {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls12_signature(
-            message,
-            cert,
-            dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
-        )
+        rustls::crypto::verify_tls12_signature(message, cert, dss, &self.supported_algorithms)
     }
 
     fn verify_tls13_signature(
@@ -343,17 +359,10 @@ impl ServerCertVerifier for LoopbackCertVerifier {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
-        rustls::crypto::verify_tls13_signature(
-            message,
-            cert,
-            dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
-        )
+        rustls::crypto::verify_tls13_signature(message, cert, dss, &self.supported_algorithms)
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        rustls::crypto::ring::default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
+        self.supported_algorithms.supported_schemes()
     }
 }

--- a/bitloops/src/cli/devql/graphql/subscription.rs
+++ b/bitloops/src/cli/devql/graphql/subscription.rs
@@ -10,16 +10,15 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::{Connector, connect_async, connect_async_tls_with_config};
 
-use super::documents::SYNC_PROGRESS_SUBSCRIPTION;
-use super::progress::{SYNC_RENDER_TICK_INTERVAL, SyncProgressRenderer};
-use super::types::{SyncProgressSubscriptionData, SyncTaskGraphqlRecord};
+use super::documents::TASK_PROGRESS_SUBSCRIPTION;
+use super::progress::{TASK_RENDER_TICK_INTERVAL, TaskProgressRenderer};
+use super::types::{TaskGraphqlRecord, TaskProgressSubscriptionData};
 use crate::daemon;
-use crate::host::devql::SyncSummary;
 
-pub(super) async fn watch_sync_task_via_subscription(
+pub(super) async fn watch_task_via_subscription(
     task_id: &str,
-    renderer: &mut SyncProgressRenderer,
-) -> Result<Option<SyncSummary>> {
+    renderer: &mut TaskProgressRenderer,
+) -> Result<Option<TaskGraphqlRecord>> {
     let endpoint = devql_global_websocket_endpoint()?;
     let mut request = endpoint
         .as_str()
@@ -104,10 +103,10 @@ pub(super) async fn watch_sync_task_via_subscription(
     websocket
         .send(Message::Text(
             json!({
-                "id": "sync-progress",
+                "id": "task-progress",
                 "type": "subscribe",
                 "payload": {
-                    "query": SYNC_PROGRESS_SUBSCRIPTION,
+                    "query": TASK_PROGRESS_SUBSCRIPTION,
                     "variables": {
                         "taskId": task_id,
                     }
@@ -117,10 +116,10 @@ pub(super) async fn watch_sync_task_via_subscription(
             .into(),
         ))
         .await
-        .context("sending sync progress subscription")?;
+        .context("sending task progress subscription")?;
 
-    let mut latest_task = None::<SyncTaskGraphqlRecord>;
-    let mut render_tick = tokio::time::interval(SYNC_RENDER_TICK_INTERVAL);
+    let mut latest_task = None::<TaskGraphqlRecord>;
+    let mut render_tick = tokio::time::interval(TASK_RENDER_TICK_INTERVAL);
     loop {
         tokio::select! {
             _ = render_tick.tick(), if renderer.is_interactive() => {
@@ -132,11 +131,11 @@ pub(super) async fn watch_sync_task_via_subscription(
                 let Some(message) = message else {
                     return Ok(None);
                 };
-                let message = message.context("reading sync progress subscription message")?;
+                let message = message.context("reading task progress subscription message")?;
                 match message {
                     Message::Text(payload) => {
                         let envelope: serde_json::Value = serde_json::from_str(payload.as_str())
-                            .context("decoding sync progress subscription message")?;
+                            .context("decoding task progress subscription message")?;
                         match envelope
                             .get("type")
                             .and_then(serde_json::Value::as_str)
@@ -154,19 +153,19 @@ pub(super) async fn watch_sync_task_via_subscription(
                                     .get("data")
                                     .cloned()
                                     .context("subscription event missing data")?;
-                                let response: SyncProgressSubscriptionData =
+                                let response: TaskProgressSubscriptionData =
                                     serde_json::from_value(data)
-                                        .context("decoding sync progress subscription data")?;
-                                let task = response.sync_progress;
+                                        .context("decoding task progress subscription data")?;
+                                let task = response.task_progress.task;
                                 latest_task = Some(task.clone());
                                 renderer.render(&task)?;
-                                match task.status.as_str() {
-                                    "completed" => return Ok(task.summary.map(Into::into)),
+                                match task.status.to_ascii_lowercase().as_str() {
+                                    "completed" => return Ok(Some(task)),
                                     "failed" | "cancelled" => {
                                         if let Some(error) = task.error {
-                                            bail!("sync task {task_id} failed: {error}");
+                                            bail!("task {task_id} failed: {error}");
                                         }
-                                        bail!("sync task {task_id} ended with status {}", task.status);
+                                        bail!("task {task_id} ended with status {}", task.status);
                                     }
                                     _ => {}
                                 }
@@ -202,7 +201,7 @@ pub(super) async fn watch_sync_task_via_subscription(
                             .map(|frame| frame.reason.to_string())
                             .filter(|reason| !reason.is_empty())
                             .unwrap_or_else(|| "no close reason".to_string());
-                        bail!("Bitloops daemon closed the websocket sync subscription: {detail}");
+                        bail!("Bitloops daemon closed the websocket task subscription: {detail}");
                     }
                     _ => {}
                 }
@@ -259,74 +258,49 @@ pub(super) fn should_accept_invalid_daemon_websocket_certs(url: &str) -> bool {
     if parsed.scheme() != "wss" {
         return false;
     }
-
     matches!(
         parsed.host_str(),
-        Some("localhost") | Some("127.0.0.1") | Some("::1") | Some("[::1]")
+        Some("localhost" | "127.0.0.1" | "::1" | "[::1]")
     )
 }
 
 fn insecure_loopback_websocket_tls_config() -> Result<Arc<rustls::ClientConfig>> {
-    static CONFIG: OnceLock<Result<Arc<rustls::ClientConfig>, String>> = OnceLock::new();
-    let config = CONFIG.get_or_init(|| {
-        ensure_rustls_crypto_provider()
-            .map_err(|err| err.to_string())
-            .map(|_| {
-                Arc::new(
-                    rustls::ClientConfig::builder_with_provider(Arc::new(
-                        rustls::crypto::aws_lc_rs::default_provider(),
-                    ))
-                    .with_safe_default_protocol_versions()
-                    .expect("safe default TLS versions are valid")
-                    .dangerous()
-                    .with_custom_certificate_verifier(SkipLoopbackServerVerification::new())
-                    .with_no_client_auth(),
-                )
-            })
-    });
-
-    config
-        .as_ref()
-        .map(Arc::clone)
-        .map_err(|message| anyhow::anyhow!(message.clone()))
-}
-
-fn ensure_rustls_crypto_provider() -> Result<()> {
-    static INIT: OnceLock<Result<(), String>> = OnceLock::new();
-    let init = INIT.get_or_init(|| {
-        if rustls::crypto::CryptoProvider::get_default().is_none() {
-            return rustls::crypto::aws_lc_rs::default_provider()
-                .install_default()
-                .map_err(|err| format!("install rustls aws_lc_rs crypto provider: {err:?}"));
-        }
-        Ok(())
-    });
-    init.as_ref()
-        .map(|_| ())
-        .map_err(|message| anyhow::anyhow!(message.clone()))
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    Ok(CONFIG
+        .get_or_init(|| {
+            let config = rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(LoopbackCertVerifier))
+                .with_no_client_auth();
+            Arc::new(config)
+        })
+        .clone())
 }
 
 #[derive(Debug)]
-struct SkipLoopbackServerVerification(Arc<rustls::crypto::CryptoProvider>);
+struct LoopbackCertVerifier;
 
-impl SkipLoopbackServerVerification {
-    fn new() -> Arc<Self> {
-        Arc::new(Self(
-            Arc::new(rustls::crypto::aws_lc_rs::default_provider()),
-        ))
-    }
-}
-
-impl ServerCertVerifier for SkipLoopbackServerVerification {
+impl ServerCertVerifier for LoopbackCertVerifier {
     fn verify_server_cert(
         &self,
         _end_entity: &CertificateDer<'_>,
         _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
+        server_name: &ServerName<'_>,
         _ocsp_response: &[u8],
         _now: UnixTime,
     ) -> std::result::Result<ServerCertVerified, rustls::Error> {
-        Ok(ServerCertVerified::assertion())
+        let hostname = match server_name {
+            ServerName::DnsName(dns) => dns.as_ref(),
+            ServerName::IpAddress(_) => return Ok(ServerCertVerified::assertion()),
+            _ => return Err(rustls::Error::General("unsupported server name".into())),
+        };
+
+        match hostname {
+            "localhost" | "127.0.0.1" | "::1" => Ok(ServerCertVerified::assertion()),
+            _ => Err(rustls::Error::General(format!(
+                "refusing insecure websocket TLS for non-loopback host `{hostname}`"
+            ))),
+        }
     }
 
     fn verify_tls12_signature(
@@ -339,7 +313,7 @@ impl ServerCertVerifier for SkipLoopbackServerVerification {
             message,
             cert,
             dss,
-            &self.0.signature_verification_algorithms,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
         )
     }
 
@@ -353,68 +327,13 @@ impl ServerCertVerifier for SkipLoopbackServerVerification {
             message,
             cert,
             dss,
-            &self.0.signature_verification_algorithms,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.0.signature_verification_algorithms.supported_schemes()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn graphql_websocket_error_message_prefers_top_level_message() {
-        let envelope = serde_json::json!({
-            "message": "top-level message",
-            "payload": {
-                "message": "payload message"
-            }
-        });
-        assert_eq!(
-            graphql_websocket_error_message(&envelope).as_deref(),
-            Some("top-level message")
-        );
-    }
-
-    #[test]
-    fn graphql_websocket_error_message_falls_back_to_payload_fields() {
-        let payload_message = serde_json::json!({
-            "payload": {
-                "message": "payload message"
-            }
-        });
-        assert_eq!(
-            graphql_websocket_error_message(&payload_message).as_deref(),
-            Some("\"payload message\"")
-        );
-
-        let payload_errors = serde_json::json!({
-            "payload": {
-                "errors": [{"message": "boom"}]
-            }
-        });
-        assert_eq!(
-            graphql_websocket_error_message(&payload_errors).as_deref(),
-            Some(r#"[{"message":"boom"}]"#)
-        );
-
-        assert!(graphql_websocket_error_message(&serde_json::json!({})).is_none());
-    }
-
-    #[test]
-    fn insecure_loopback_websocket_tls_config_is_cached() {
-        let first = insecure_loopback_websocket_tls_config().expect("first tls config");
-        let second = insecure_loopback_websocket_tls_config().expect("second tls config");
-        assert!(Arc::ptr_eq(&first, &second));
-    }
-
-    #[test]
-    fn ensure_rustls_crypto_provider_is_idempotent() {
-        ensure_rustls_crypto_provider().expect("first install check");
-        ensure_rustls_crypto_provider().expect("second install check");
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
     }
 }

--- a/bitloops/src/cli/devql/graphql/tests.rs
+++ b/bitloops/src/cli/devql/graphql/tests.rs
@@ -1,41 +1,50 @@
 use crate::test_support::process_state::with_env_vars;
 
-use super::progress::{format_live_sync_progress_bar_line, format_live_sync_task_status_line};
+use super::progress::{format_live_task_progress_bar_line, format_live_task_status_line};
 use super::subscription::should_accept_invalid_daemon_websocket_certs;
 use super::types::{
-    SyncMutationResult, SyncTaskGraphqlRecord, SyncValidationFileDriftMutationResult,
-    SyncValidationMutationResult,
+    SyncMutationResult, SyncTaskProgressGraphqlRecord, SyncTaskSpecGraphqlRecord,
+    SyncValidationFileDriftMutationResult, SyncValidationMutationResult, TaskGraphqlRecord,
 };
 
-fn sample_task(status: &str) -> SyncTaskGraphqlRecord {
-    SyncTaskGraphqlRecord {
+fn sample_task(status: &str) -> TaskGraphqlRecord {
+    TaskGraphqlRecord {
         task_id: "sync-task-1".to_string(),
         repo_id: "repo-1".to_string(),
         repo_name: "bitloops".to_string(),
         repo_identity: "local/bitloops".to_string(),
+        kind: "SYNC".to_string(),
         source: "init".to_string(),
-        mode: "auto".to_string(),
-        status: status.to_string(),
-        phase: "extracting_paths".to_string(),
+        status: status.to_ascii_uppercase(),
         submitted_at_unix: 1,
         started_at_unix: Some(2),
         updated_at_unix: 3,
         completed_at_unix: None,
         queue_position: Some(1),
         tasks_ahead: Some(0),
-        current_path: Some("src/lib.rs".to_string()),
-        paths_total: 12,
-        paths_completed: 4,
-        paths_remaining: 8,
-        paths_unchanged: 1,
-        paths_added: 1,
-        paths_changed: 2,
-        paths_removed: 0,
-        cache_hits: 1,
-        cache_misses: 2,
-        parse_errors: 0,
         error: None,
-        summary: None,
+        sync_spec: Some(SyncTaskSpecGraphqlRecord {
+            mode: "auto".to_string(),
+            paths: Vec::new(),
+        }),
+        ingest_spec: None,
+        sync_progress: Some(SyncTaskProgressGraphqlRecord {
+            phase: "extracting_paths".to_string(),
+            current_path: Some("src/lib.rs".to_string()),
+            paths_total: 12,
+            paths_completed: 4,
+            paths_remaining: 8,
+            paths_unchanged: 1,
+            paths_added: 1,
+            paths_changed: 2,
+            paths_removed: 0,
+            cache_hits: 1,
+            cache_misses: 2,
+            parse_errors: 0,
+        }),
+        ingest_progress: None,
+        sync_result: None,
+        ingest_result: None,
     }
 }
 
@@ -60,10 +69,10 @@ fn websocket_client_only_relaxes_loopback_wss_urls() {
 }
 
 #[test]
-fn live_sync_status_line_is_compact_and_single_line() {
+fn live_task_status_line_is_compact_and_single_line() {
     let task = sample_task("running");
 
-    let rendered = format_live_sync_task_status_line(&task, "*", None);
+    let rendered = format_live_task_status_line(&task, "*", None);
     assert_eq!(
         rendered,
         "* Syncing bitloops · extracting artefacts · 4/12 · src/lib.rs"
@@ -72,42 +81,37 @@ fn live_sync_status_line_is_compact_and_single_line() {
 }
 
 #[test]
-fn live_sync_status_line_elides_to_terminal_width() {
+fn live_task_status_line_elides_to_terminal_width() {
     let mut task = sample_task("running");
-    task.current_path = Some("bitloops/src/host/devql/commands_sync/orchestrator.rs".to_string());
-    task.paths_total = 764;
-    task.paths_completed = 472;
-    task.paths_remaining = 292;
-    task.paths_unchanged = 0;
-    task.paths_added = 0;
-    task.paths_changed = 0;
-    task.paths_removed = 0;
-    task.cache_hits = 0;
-    task.cache_misses = 0;
+    task.sync_progress
+        .as_mut()
+        .expect("sync progress")
+        .current_path = Some("bitloops/src/host/devql/commands_sync/orchestrator.rs".to_string());
+    task.sync_progress.as_mut().expect("sync progress").paths_total = 764;
+    task.sync_progress.as_mut().expect("sync progress").paths_completed = 472;
+    task.sync_progress.as_mut().expect("sync progress").paths_remaining = 292;
 
-    let rendered = format_live_sync_task_status_line(&task, "*", Some(48));
+    let rendered = format_live_task_status_line(&task, "*", Some(48));
     assert!(rendered.chars().count() <= 48);
     assert!(rendered.contains('…'));
     assert!(!rendered.contains('\n'));
 }
 
 #[test]
-fn live_sync_progress_bar_line_fits_requested_width() {
+fn live_task_progress_bar_line_fits_requested_width() {
     with_env_vars(&[("NO_COLOR", Some("1"))], || {
         let mut task = sample_task("running");
-        task.phase = "materialising_paths".to_string();
-        task.current_path = None;
-        task.paths_total = 764;
-        task.paths_completed = 472;
-        task.paths_remaining = 292;
-        task.paths_unchanged = 0;
-        task.paths_added = 0;
-        task.paths_changed = 0;
-        task.paths_removed = 0;
-        task.cache_hits = 0;
-        task.cache_misses = 0;
+        task.sync_progress.as_mut().expect("sync progress").phase =
+            "materialising_paths".to_string();
+        task.sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .current_path = None;
+        task.sync_progress.as_mut().expect("sync progress").paths_total = 764;
+        task.sync_progress.as_mut().expect("sync progress").paths_completed = 472;
+        task.sync_progress.as_mut().expect("sync progress").paths_remaining = 292;
 
-        let rendered = format_live_sync_progress_bar_line(&task, 0, Some(48));
+        let rendered = format_live_task_progress_bar_line(&task, 0, Some(48));
         assert!(rendered.chars().count() <= 48);
         assert!(rendered.contains("472/764"));
         assert!(!rendered.contains('\n'));
@@ -115,54 +119,55 @@ fn live_sync_progress_bar_line_fits_requested_width() {
 }
 
 #[test]
-fn live_sync_status_line_covers_terminal_states() {
-    let queued = format_live_sync_task_status_line(&sample_task("queued"), "*", None);
+fn live_task_status_line_covers_terminal_states() {
+    let queued = format_live_task_status_line(&sample_task("queued"), "*", None);
     assert!(queued.contains("Sync queued for bitloops"));
     assert!(queued.contains("mode=auto"));
 
-    let completed = format_live_sync_task_status_line(&sample_task("completed"), "*", None);
+    let completed = format_live_task_status_line(&sample_task("completed"), "*", None);
     assert!(completed.contains("Sync complete"));
 
-    let failed = format_live_sync_task_status_line(&sample_task("failed"), "*", None);
+    let failed = format_live_task_status_line(&sample_task("failed"), "*", None);
     assert!(failed.contains("Sync failed"));
 
-    let cancelled = format_live_sync_task_status_line(&sample_task("cancelled"), "*", None);
+    let cancelled = format_live_task_status_line(&sample_task("cancelled"), "*", None);
     assert!(cancelled.contains("Sync cancelled"));
 
-    let unknown = format_live_sync_task_status_line(&sample_task("paused"), "*", None);
+    let unknown = format_live_task_status_line(&sample_task("paused"), "*", None);
     assert!(unknown.contains("Sync paused for bitloops"));
 }
 
 #[test]
-fn live_sync_progress_bar_line_handles_non_progress_states() {
+fn live_task_progress_bar_line_handles_non_progress_states() {
     with_env_vars(&[("NO_COLOR", Some("1"))], || {
         let mut queued = sample_task("queued");
-        queued.paths_total = 0;
-        queued.paths_completed = 0;
-        queued.paths_remaining = 0;
-        queued.phase = "building_manifest".to_string();
+        queued.sync_progress.as_mut().expect("sync progress").paths_total = 0;
+        queued.sync_progress.as_mut().expect("sync progress").paths_completed = 0;
+        queued.sync_progress.as_mut().expect("sync progress").paths_remaining = 0;
+        queued.sync_progress.as_mut().expect("sync progress").phase =
+            "building_manifest".to_string();
 
-        let rendered = format_live_sync_progress_bar_line(&queued, 2, Some(40));
+        let rendered = format_live_task_progress_bar_line(&queued, 2, Some(40));
         assert!(rendered.contains("building manifest"));
 
         let mut failed = sample_task("failed");
-        failed.paths_total = 10;
-        failed.paths_completed = 3;
-        failed.paths_remaining = 7;
-        let failed_line = format_live_sync_progress_bar_line(&failed, 0, Some(40));
+        failed.sync_progress.as_mut().expect("sync progress").paths_total = 10;
+        failed.sync_progress.as_mut().expect("sync progress").paths_completed = 3;
+        failed.sync_progress.as_mut().expect("sync progress").paths_remaining = 7;
+        let failed_line = format_live_task_progress_bar_line(&failed, 0, Some(40));
         assert!(failed_line.contains(" 30% 3/10"));
     });
 }
 
 #[test]
-fn live_sync_progress_bar_line_elides_when_too_narrow() {
+fn live_task_progress_bar_line_elides_when_too_narrow() {
     with_env_vars(&[("NO_COLOR", Some("1"))], || {
         let mut task = sample_task("running");
-        task.paths_total = 100;
-        task.paths_completed = 20;
-        task.paths_remaining = 80;
+        task.sync_progress.as_mut().expect("sync progress").paths_total = 100;
+        task.sync_progress.as_mut().expect("sync progress").paths_completed = 20;
+        task.sync_progress.as_mut().expect("sync progress").paths_remaining = 80;
 
-        let rendered = format_live_sync_progress_bar_line(&task, 0, Some(8));
+        let rendered = format_live_task_progress_bar_line(&task, 0, Some(8));
         assert!(rendered.chars().count() <= 16);
     });
 }

--- a/bitloops/src/cli/devql/graphql/tests.rs
+++ b/bitloops/src/cli/devql/graphql/tests.rs
@@ -87,9 +87,18 @@ fn live_task_status_line_elides_to_terminal_width() {
         .as_mut()
         .expect("sync progress")
         .current_path = Some("bitloops/src/host/devql/commands_sync/orchestrator.rs".to_string());
-    task.sync_progress.as_mut().expect("sync progress").paths_total = 764;
-    task.sync_progress.as_mut().expect("sync progress").paths_completed = 472;
-    task.sync_progress.as_mut().expect("sync progress").paths_remaining = 292;
+    task.sync_progress
+        .as_mut()
+        .expect("sync progress")
+        .paths_total = 764;
+    task.sync_progress
+        .as_mut()
+        .expect("sync progress")
+        .paths_completed = 472;
+    task.sync_progress
+        .as_mut()
+        .expect("sync progress")
+        .paths_remaining = 292;
 
     let rendered = format_live_task_status_line(&task, "*", Some(48));
     assert!(rendered.chars().count() <= 48);
@@ -107,9 +116,18 @@ fn live_task_progress_bar_line_fits_requested_width() {
             .as_mut()
             .expect("sync progress")
             .current_path = None;
-        task.sync_progress.as_mut().expect("sync progress").paths_total = 764;
-        task.sync_progress.as_mut().expect("sync progress").paths_completed = 472;
-        task.sync_progress.as_mut().expect("sync progress").paths_remaining = 292;
+        task.sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_total = 764;
+        task.sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_completed = 472;
+        task.sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_remaining = 292;
 
         let rendered = format_live_task_progress_bar_line(&task, 0, Some(48));
         assert!(rendered.chars().count() <= 48);
@@ -141,9 +159,21 @@ fn live_task_status_line_covers_terminal_states() {
 fn live_task_progress_bar_line_handles_non_progress_states() {
     with_env_vars(&[("NO_COLOR", Some("1"))], || {
         let mut queued = sample_task("queued");
-        queued.sync_progress.as_mut().expect("sync progress").paths_total = 0;
-        queued.sync_progress.as_mut().expect("sync progress").paths_completed = 0;
-        queued.sync_progress.as_mut().expect("sync progress").paths_remaining = 0;
+        queued
+            .sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_total = 0;
+        queued
+            .sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_completed = 0;
+        queued
+            .sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_remaining = 0;
         queued.sync_progress.as_mut().expect("sync progress").phase =
             "building_manifest".to_string();
 
@@ -151,9 +181,21 @@ fn live_task_progress_bar_line_handles_non_progress_states() {
         assert!(rendered.contains("building manifest"));
 
         let mut failed = sample_task("failed");
-        failed.sync_progress.as_mut().expect("sync progress").paths_total = 10;
-        failed.sync_progress.as_mut().expect("sync progress").paths_completed = 3;
-        failed.sync_progress.as_mut().expect("sync progress").paths_remaining = 7;
+        failed
+            .sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_total = 10;
+        failed
+            .sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_completed = 3;
+        failed
+            .sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_remaining = 7;
         let failed_line = format_live_task_progress_bar_line(&failed, 0, Some(40));
         assert!(failed_line.contains(" 30% 3/10"));
     });
@@ -163,9 +205,18 @@ fn live_task_progress_bar_line_handles_non_progress_states() {
 fn live_task_progress_bar_line_elides_when_too_narrow() {
     with_env_vars(&[("NO_COLOR", Some("1"))], || {
         let mut task = sample_task("running");
-        task.sync_progress.as_mut().expect("sync progress").paths_total = 100;
-        task.sync_progress.as_mut().expect("sync progress").paths_completed = 20;
-        task.sync_progress.as_mut().expect("sync progress").paths_remaining = 80;
+        task.sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_total = 100;
+        task.sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_completed = 20;
+        task.sync_progress
+            .as_mut()
+            .expect("sync progress")
+            .paths_remaining = 80;
 
         let rendered = format_live_task_progress_bar_line(&task, 0, Some(8));
         assert!(rendered.chars().count() <= 16);

--- a/bitloops/src/cli/devql/graphql/tests.rs
+++ b/bitloops/src/cli/devql/graphql/tests.rs
@@ -1,5 +1,8 @@
 use crate::test_support::process_state::with_env_vars;
 
+use serde_json::json;
+use std::path::Path;
+
 use super::progress::{format_live_task_progress_bar_line, format_live_task_status_line};
 use super::subscription::should_accept_invalid_daemon_websocket_certs;
 use super::types::{
@@ -46,6 +49,52 @@ fn sample_task(status: &str) -> TaskGraphqlRecord {
         sync_result: None,
         ingest_result: None,
     }
+}
+
+fn sample_task_json(status: &str) -> serde_json::Value {
+    json!({
+        "taskId": "sync-task-1",
+        "repoId": "repo-1",
+        "repoName": "bitloops",
+        "repoIdentity": "local/bitloops",
+        "kind": "SYNC",
+        "source": "init",
+        "status": status.to_ascii_uppercase(),
+        "submittedAtUnix": 1,
+        "startedAtUnix": 2,
+        "updatedAtUnix": 3,
+        "completedAtUnix": if status.eq_ignore_ascii_case("completed") { json!(4) } else { serde_json::Value::Null },
+        "queuePosition": 1,
+        "tasksAhead": 0,
+        "error": serde_json::Value::Null,
+        "syncSpec": {
+            "mode": "auto",
+            "paths": []
+        },
+        "ingestSpec": serde_json::Value::Null,
+        "syncProgress": {
+            "phase": "complete",
+            "currentPath": serde_json::Value::Null,
+            "pathsTotal": 12,
+            "pathsCompleted": 12,
+            "pathsRemaining": 0,
+            "pathsUnchanged": 1,
+            "pathsAdded": 1,
+            "pathsChanged": 2,
+            "pathsRemoved": 0,
+            "cacheHits": 1,
+            "cacheMisses": 2,
+            "parseErrors": 0
+        },
+        "ingestProgress": serde_json::Value::Null
+    })
+}
+
+fn test_scope() -> crate::devql_transport::SlimCliRepoScope {
+    crate::devql_transport::discover_slim_cli_repo_scope(Some(Path::new(env!(
+        "CARGO_MANIFEST_DIR"
+    ))))
+    .expect("discover test repo scope")
 }
 
 #[test]
@@ -273,4 +322,94 @@ fn sync_mutation_result_converts_to_sync_summary_with_validation_details() {
     assert!(!validation.valid);
     assert_eq!(validation.files_with_drift.len(), 1);
     assert_eq!(validation.files_with_drift[0].path, "src/lib.rs");
+}
+
+#[test]
+fn tasks_query_omits_result_payloads_and_deserializes_completed_tasks() {
+    let scope = test_scope();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    super::with_graphql_executor_hook(
+        |_, query, _| {
+            assert_eq!(query, super::documents::TASKS_QUERY);
+            assert!(!query.contains("syncResult"));
+            assert!(!query.contains("ingestResult"));
+            Ok(json!({
+                "tasks": [sample_task_json("completed")]
+            }))
+        },
+        || {
+            let tasks = runtime
+                .block_on(super::list_tasks_via_graphql(
+                    &scope,
+                    Some("sync"),
+                    Some("completed"),
+                    Some(1),
+                ))
+                .expect("list tasks via graphql");
+            assert_eq!(tasks.len(), 1);
+            assert!(tasks[0].is_terminal());
+            assert!(tasks[0].sync_result.is_none());
+            assert!(tasks[0].ingest_result.is_none());
+        },
+    );
+}
+
+#[test]
+fn task_queue_query_omits_result_payloads_and_deserializes_current_repo_tasks() {
+    let scope = test_scope();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    super::with_graphql_executor_hook(
+        |_, query, _| {
+            assert_eq!(query, super::documents::TASK_QUEUE_QUERY);
+            assert!(!query.contains("syncResult"));
+            assert!(!query.contains("ingestResult"));
+            Ok(json!({
+                "taskQueue": {
+                    "persisted": true,
+                    "queuedTasks": 0,
+                    "runningTasks": 0,
+                    "failedTasks": 0,
+                    "completedRecentTasks": 1,
+                    "byKind": [
+                        {
+                            "kind": "SYNC",
+                            "queuedTasks": 0,
+                            "runningTasks": 0,
+                            "failedTasks": 0,
+                            "completedRecentTasks": 1
+                        },
+                        {
+                            "kind": "INGEST",
+                            "queuedTasks": 0,
+                            "runningTasks": 0,
+                            "failedTasks": 0,
+                            "completedRecentTasks": 0
+                        }
+                    ],
+                    "paused": false,
+                    "pausedReason": serde_json::Value::Null,
+                    "lastAction": "completed",
+                    "lastUpdatedUnix": 3,
+                    "currentRepoTasks": [sample_task_json("completed")]
+                }
+            }))
+        },
+        || {
+            let status = runtime
+                .block_on(super::task_queue_status_via_graphql(&scope))
+                .expect("load task queue via graphql");
+            assert_eq!(status.current_repo_tasks.len(), 1);
+            assert!(status.current_repo_tasks[0].is_terminal());
+            assert!(status.current_repo_tasks[0].sync_result.is_none());
+            assert!(status.current_repo_tasks[0].ingest_result.is_none());
+        },
+    );
 }

--- a/bitloops/src/cli/devql/graphql/tests.rs
+++ b/bitloops/src/cli/devql/graphql/tests.rs
@@ -1,7 +1,7 @@
 use crate::test_support::process_state::with_env_vars;
 
 use serde_json::json;
-use std::path::Path;
+use std::path::PathBuf;
 
 use super::progress::{format_live_task_progress_bar_line, format_live_task_status_line};
 use super::subscription::should_accept_invalid_daemon_websocket_certs;
@@ -91,10 +91,20 @@ fn sample_task_json(status: &str) -> serde_json::Value {
 }
 
 fn test_scope() -> crate::devql_transport::SlimCliRepoScope {
-    crate::devql_transport::discover_slim_cli_repo_scope(Some(Path::new(env!(
-        "CARGO_MANIFEST_DIR"
-    ))))
-    .expect("discover test repo scope")
+    crate::devql_transport::SlimCliRepoScope {
+        repo: crate::host::devql::RepoIdentity {
+            provider: "local".to_string(),
+            organization: "local".to_string(),
+            name: "bitloops".to_string(),
+            identity: "local://local/bitloops".to_string(),
+            repo_id: "repo-1".to_string(),
+        },
+        repo_root: PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        branch_name: "main".to_string(),
+        project_path: None,
+        git_dir_relative_path: ".git".to_string(),
+        config_fingerprint: "test-config-fingerprint".to_string(),
+    }
 }
 
 #[test]

--- a/bitloops/src/cli/devql/graphql/types.rs
+++ b/bitloops/src/cli/devql/graphql/types.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::host::devql::{
     IngestionCounters, InitSchemaSummary, SyncSummary, SyncValidationFileDrift,
     SyncValidationSummary,
@@ -11,33 +13,188 @@ pub(super) struct InitSchemaMutationData {
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct IngestMutationData {
-    pub(super) ingest: IngestionCounters,
+pub(super) struct EnqueueTaskMutationData {
+    pub(super) enqueue_task: EnqueueTaskMutationResult,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct EnqueueSyncMutationData {
-    pub(super) enqueue_sync: EnqueueSyncMutationResult,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct EnqueueSyncMutationResult {
+pub(super) struct EnqueueTaskMutationResult {
     pub(super) merged: bool,
-    pub(super) task: SyncTaskGraphqlRecord,
+    pub(super) task: TaskGraphqlRecord,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct SyncTaskQueryData {
-    pub(super) sync_task: Option<SyncTaskGraphqlRecord>,
+pub(super) struct TaskQueryData {
+    pub(super) task: Option<TaskGraphqlRecord>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct SyncProgressSubscriptionData {
-    pub(super) sync_progress: SyncTaskGraphqlRecord,
+pub(super) struct TasksQueryData {
+    pub(super) tasks: Vec<TaskGraphqlRecord>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TaskQueueQueryData {
+    pub(super) task_queue: TaskQueueGraphqlRecord,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct PauseTaskQueueMutationData {
+    pub(super) pause_task_queue: TaskQueueControlGraphqlRecord,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ResumeTaskQueueMutationData {
+    pub(super) resume_task_queue: TaskQueueControlGraphqlRecord,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct CancelTaskMutationData {
+    pub(super) cancel_task: TaskGraphqlRecord,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TaskProgressSubscriptionData {
+    pub(super) task_progress: TaskProgressEventGraphqlRecord,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TaskProgressEventGraphqlRecord {
+    pub(super) task: TaskGraphqlRecord,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TaskGraphqlRecord {
+    pub task_id: String,
+    pub repo_id: String,
+    pub repo_name: String,
+    pub repo_identity: String,
+    pub kind: String,
+    pub source: String,
+    pub status: String,
+    pub submitted_at_unix: i64,
+    pub started_at_unix: Option<i64>,
+    pub updated_at_unix: i64,
+    pub completed_at_unix: Option<i64>,
+    pub queue_position: Option<i32>,
+    pub tasks_ahead: Option<i32>,
+    pub error: Option<String>,
+    pub sync_spec: Option<SyncTaskSpecGraphqlRecord>,
+    pub ingest_spec: Option<IngestTaskSpecGraphqlRecord>,
+    pub sync_progress: Option<SyncTaskProgressGraphqlRecord>,
+    pub ingest_progress: Option<IngestTaskProgressGraphqlRecord>,
+    pub sync_result: Option<SyncMutationResult>,
+    pub ingest_result: Option<IngestionCounters>,
+}
+
+impl TaskGraphqlRecord {
+    pub(crate) fn is_sync(&self) -> bool {
+        self.kind.eq_ignore_ascii_case("sync")
+    }
+
+    pub(crate) fn is_ingest(&self) -> bool {
+        self.kind.eq_ignore_ascii_case("ingest")
+    }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        matches!(
+            self.status.to_ascii_lowercase().as_str(),
+            "completed" | "failed" | "cancelled"
+        )
+    }
+
+    pub(crate) fn sync_summary(&self) -> Option<SyncSummary> {
+        self.sync_result.clone().map(Into::into)
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SyncTaskSpecGraphqlRecord {
+    pub mode: String,
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IngestTaskSpecGraphqlRecord {
+    pub backfill: Option<i32>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SyncTaskProgressGraphqlRecord {
+    pub phase: String,
+    pub current_path: Option<String>,
+    pub paths_total: i32,
+    pub paths_completed: i32,
+    pub paths_remaining: i32,
+    pub paths_unchanged: i32,
+    pub paths_added: i32,
+    pub paths_changed: i32,
+    pub paths_removed: i32,
+    pub cache_hits: i32,
+    pub cache_misses: i32,
+    pub parse_errors: i32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IngestTaskProgressGraphqlRecord {
+    pub phase: String,
+    pub commits_total: i32,
+    pub commits_processed: i32,
+    pub checkpoint_companions_processed: i32,
+    pub current_checkpoint_id: Option<String>,
+    pub current_commit_sha: Option<String>,
+    pub events_inserted: i32,
+    pub artefacts_upserted: i32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TaskQueueGraphqlRecord {
+    pub persisted: bool,
+    pub queued_tasks: i32,
+    pub running_tasks: i32,
+    pub failed_tasks: i32,
+    pub completed_recent_tasks: i32,
+    pub by_kind: Vec<TaskKindCountsGraphqlRecord>,
+    pub paused: bool,
+    pub paused_reason: Option<String>,
+    pub last_action: Option<String>,
+    pub last_updated_unix: i64,
+    pub current_repo_tasks: Vec<TaskGraphqlRecord>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TaskKindCountsGraphqlRecord {
+    pub kind: String,
+    pub queued_tasks: i32,
+    pub running_tasks: i32,
+    pub failed_tasks: i32,
+    pub completed_recent_tasks: i32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TaskQueueControlGraphqlRecord {
+    pub message: String,
+    pub repo_id: String,
+    pub paused: bool,
+    pub paused_reason: Option<String>,
+    pub updated_at_unix: i64,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -87,39 +244,6 @@ pub(crate) struct SyncValidationFileDriftMutationResult {
     pub(crate) missing_edges: usize,
     pub(crate) stale_edges: usize,
     pub(crate) mismatched_edges: usize,
-}
-
-#[derive(Debug, Clone, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
-pub(crate) struct SyncTaskGraphqlRecord {
-    pub task_id: String,
-    pub repo_id: String,
-    pub repo_name: String,
-    pub repo_identity: String,
-    pub source: String,
-    pub mode: String,
-    pub status: String,
-    pub phase: String,
-    pub submitted_at_unix: i64,
-    pub started_at_unix: Option<i64>,
-    pub updated_at_unix: i64,
-    pub completed_at_unix: Option<i64>,
-    pub queue_position: Option<i32>,
-    pub tasks_ahead: Option<i32>,
-    pub current_path: Option<String>,
-    pub paths_total: i32,
-    pub paths_completed: i32,
-    pub paths_remaining: i32,
-    pub paths_unchanged: i32,
-    pub paths_added: i32,
-    pub paths_changed: i32,
-    pub paths_removed: i32,
-    pub cache_hits: i32,
-    pub cache_misses: i32,
-    pub parse_errors: i32,
-    pub error: Option<String>,
-    pub summary: Option<SyncMutationResult>,
 }
 
 impl From<SyncMutationResult> for SyncSummary {

--- a/bitloops/src/cli/devql/tests.rs
+++ b/bitloops/src/cli/devql/tests.rs
@@ -56,7 +56,11 @@ fn sync_enqueue_command(
     })
 }
 
-fn queued_sync_task_payload(task_id: &str, mode: &str, paths: Option<Vec<&str>>) -> serde_json::Value {
+fn queued_sync_task_payload(
+    task_id: &str,
+    mode: &str,
+    paths: Option<Vec<&str>>,
+) -> serde_json::Value {
     json!({
         "taskId": task_id,
         "repoId": "repo-1",
@@ -340,13 +344,7 @@ fn devql_cli_parses_sync_enqueue_modes() {
     assert!(!sync.require_daemon);
 
     let parsed = Cli::try_parse_from([
-        "bitloops",
-        "devql",
-        "tasks",
-        "enqueue",
-        "--kind",
-        "sync",
-        "--repair",
+        "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--repair",
     ])
     .expect("devql task sync repair should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
@@ -366,13 +364,7 @@ fn devql_cli_parses_sync_enqueue_modes() {
     assert!(!sync.require_daemon);
 
     let parsed = Cli::try_parse_from([
-        "bitloops",
-        "devql",
-        "tasks",
-        "enqueue",
-        "--kind",
-        "sync",
-        "--full",
+        "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--full",
     ])
     .expect("devql task sync full should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
@@ -421,13 +413,7 @@ fn devql_cli_parses_sync_enqueue_modes() {
 #[test]
 fn devql_cli_parses_sync_enqueue_status_flag() {
     let parsed = Cli::try_parse_from([
-        "bitloops",
-        "devql",
-        "tasks",
-        "enqueue",
-        "--kind",
-        "sync",
-        "--status",
+        "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--status",
     ])
     .expect("devql task sync enqueue --status should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
@@ -496,10 +482,24 @@ fn devql_cli_rejects_conflicting_sync_enqueue_modes() {
             "--repair",
         ],
         vec![
-            "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--validate", "--repair",
+            "bitloops",
+            "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
+            "sync",
+            "--validate",
+            "--repair",
         ],
         vec![
-            "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--validate", "--full",
+            "bitloops",
+            "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
+            "sync",
+            "--validate",
+            "--full",
         ],
         vec![
             "bitloops",
@@ -1328,7 +1328,9 @@ fn devql_run_ingest_require_daemon_fails_without_bootstrap() {
                     .block_on(run(DevqlArgs {
                         command: Some(ingest_enqueue_command(true)),
                     }))
-                    .expect_err("devql task ingest enqueue --require-daemon should fail without a daemon");
+                    .expect_err(
+                        "devql task ingest enqueue --require-daemon should fail without a daemon",
+                    );
 
                 assert!(
                     err.to_string().contains("Bitloops daemon is not running"),
@@ -1582,9 +1584,7 @@ fn devql_run_sync_require_daemon_fails_without_bootstrap() {
             || {
                 let err = test_runtime()
                     .block_on(run(DevqlArgs {
-                        command: Some(sync_enqueue_command(
-                            false, None, false, false, false, true,
-                        )),
+                        command: Some(sync_enqueue_command(false, None, false, false, false, true)),
                     }))
                     .expect_err("devql sync --require-daemon should fail without a daemon");
 

--- a/bitloops/src/cli/devql/tests.rs
+++ b/bitloops/src/cli/devql/tests.rs
@@ -19,6 +19,111 @@ fn test_runtime() -> tokio::runtime::Runtime {
         .expect("tokio runtime")
 }
 
+fn ingest_enqueue_command(require_daemon: bool) -> DevqlCommand {
+    DevqlCommand::Tasks(DevqlTasksArgs {
+        command: DevqlTasksCommand::Enqueue(DevqlTaskEnqueueArgs {
+            kind: DevqlTaskKindArg::Ingest,
+            full: false,
+            paths: None,
+            repair: false,
+            validate: false,
+            backfill: None,
+            status: false,
+            require_daemon,
+        }),
+    })
+}
+
+fn sync_enqueue_command(
+    full: bool,
+    paths: Option<Vec<String>>,
+    repair: bool,
+    validate: bool,
+    status: bool,
+    require_daemon: bool,
+) -> DevqlCommand {
+    DevqlCommand::Tasks(DevqlTasksArgs {
+        command: DevqlTasksCommand::Enqueue(DevqlTaskEnqueueArgs {
+            kind: DevqlTaskKindArg::Sync,
+            full,
+            paths,
+            repair,
+            validate,
+            backfill: None,
+            status,
+            require_daemon,
+        }),
+    })
+}
+
+fn queued_sync_task_payload(task_id: &str, mode: &str, paths: Option<Vec<&str>>) -> serde_json::Value {
+    json!({
+        "taskId": task_id,
+        "repoId": "repo-1",
+        "repoName": "demo",
+        "repoIdentity": "local/demo",
+        "kind": "SYNC",
+        "source": "manual_cli",
+        "status": "QUEUED",
+        "submittedAtUnix": 1,
+        "startedAtUnix": null,
+        "updatedAtUnix": 1,
+        "completedAtUnix": null,
+        "queuePosition": 1,
+        "tasksAhead": 0,
+        "error": null,
+        "syncSpec": {
+            "mode": mode,
+            "paths": paths.unwrap_or_default(),
+        },
+        "ingestSpec": null,
+        "syncProgress": {
+            "phase": "queued",
+            "currentPath": null,
+            "pathsTotal": 0,
+            "pathsCompleted": 0,
+            "pathsRemaining": 0,
+            "pathsUnchanged": 0,
+            "pathsAdded": 0,
+            "pathsChanged": 0,
+            "pathsRemoved": 0,
+            "cacheHits": 0,
+            "cacheMisses": 0,
+            "parseErrors": 0
+        },
+        "ingestProgress": null,
+        "syncResult": null,
+        "ingestResult": null
+    })
+}
+
+fn queued_ingest_task_payload(task_id: &str, backfill: Option<usize>) -> serde_json::Value {
+    json!({
+        "taskId": task_id,
+        "repoId": "repo-1",
+        "repoName": "demo",
+        "repoIdentity": "local/demo",
+        "kind": "INGEST",
+        "source": "manual_cli",
+        "status": "QUEUED",
+        "submittedAtUnix": 1,
+        "startedAtUnix": null,
+        "updatedAtUnix": 1,
+        "completedAtUnix": null,
+        "queuePosition": 1,
+        "tasksAhead": 0,
+        "error": null,
+        "syncSpec": null,
+        "ingestSpec": {
+            "backfill": backfill,
+        },
+        "syncProgress": null,
+        "ingestProgress": null,
+        "syncResult": null,
+        "ingestResult": null
+    })
+}
+
 fn test_daemon_state_root(repo_root: &Path) -> PathBuf {
     repo_root
         .parent()
@@ -150,51 +255,72 @@ fn write_current_runtime_state(repo_root: &Path) {
 }
 
 #[test]
-fn devql_cli_parses_ingest_defaults() {
-    let parsed =
-        Cli::try_parse_from(["bitloops", "devql", "ingest"]).expect("devql ingest should parse");
+fn devql_cli_parses_ingest_enqueue_defaults() {
+    let parsed = Cli::try_parse_from(["bitloops", "devql", "tasks", "enqueue", "--kind", "ingest"])
+        .expect("devql task ingest enqueue should parse");
 
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Ingest(ingest)) = args.command else {
-        panic!("expected devql ingest command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(enqueue) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
     };
 
-    assert!(!ingest.require_daemon);
+    assert!(matches!(enqueue.kind, DevqlTaskKindArg::Ingest));
+    assert!(!enqueue.require_daemon);
 }
 
 #[test]
-fn devql_cli_parses_ingest_require_daemon_flag() {
-    let parsed = Cli::try_parse_from(["bitloops", "devql", "ingest", "--require-daemon"])
-        .expect("devql ingest --require-daemon should parse");
-
-    let Some(Commands::Devql(args)) = parsed.command else {
-        panic!("expected devql command");
-    };
-    let Some(DevqlCommand::Ingest(ingest)) = args.command else {
-        panic!("expected devql ingest command");
-    };
-
-    assert!(ingest.require_daemon);
-}
-
-#[test]
-fn devql_cli_parses_sync_modes() {
+fn devql_cli_parses_ingest_enqueue_require_daemon_flag() {
     let parsed = Cli::try_parse_from([
         "bitloops",
         "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
+        "ingest",
+        "--require-daemon",
+    ])
+    .expect("devql task ingest enqueue --require-daemon should parse");
+
+    let Some(Commands::Devql(args)) = parsed.command else {
+        panic!("expected devql command");
+    };
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(enqueue) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
+    };
+
+    assert!(enqueue.require_daemon);
+}
+
+#[test]
+fn devql_cli_parses_sync_enqueue_modes() {
+    let parsed = Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
         "sync",
         "--paths",
         "src/lib.rs,src/main.rs",
     ])
-    .expect("devql sync with paths should parse");
+    .expect("devql task sync enqueue with paths should parse");
 
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Sync(sync)) = args.command else {
-        panic!("expected devql sync command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(sync) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
     };
 
     assert!(!sync.full);
@@ -207,13 +333,24 @@ fn devql_cli_parses_sync_modes() {
     assert!(!sync.status);
     assert!(!sync.require_daemon);
 
-    let parsed = Cli::try_parse_from(["bitloops", "devql", "sync", "--repair"])
-        .expect("devql sync repair should parse");
+    let parsed = Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
+        "sync",
+        "--repair",
+    ])
+    .expect("devql task sync repair should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Sync(sync)) = args.command else {
-        panic!("expected devql sync command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(sync) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
     };
     assert!(!sync.full);
     assert_eq!(sync.paths, None);
@@ -222,13 +359,24 @@ fn devql_cli_parses_sync_modes() {
     assert!(!sync.status);
     assert!(!sync.require_daemon);
 
-    let parsed = Cli::try_parse_from(["bitloops", "devql", "sync", "--full"])
-        .expect("devql sync full should parse");
+    let parsed = Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
+        "sync",
+        "--full",
+    ])
+    .expect("devql task sync full should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Sync(sync)) = args.command else {
-        panic!("expected devql sync command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(sync) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
     };
     assert!(sync.full);
     assert_eq!(sync.paths, None);
@@ -237,13 +385,24 @@ fn devql_cli_parses_sync_modes() {
     assert!(!sync.status);
     assert!(!sync.require_daemon);
 
-    let parsed = Cli::try_parse_from(["bitloops", "devql", "sync", "--validate"])
-        .expect("devql sync validate should parse");
+    let parsed = Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
+        "sync",
+        "--validate",
+    ])
+    .expect("devql task sync validate should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Sync(sync)) = args.command else {
-        panic!("expected devql sync command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(sync) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
     };
     assert!(!sync.full);
     assert_eq!(sync.paths, None);
@@ -254,57 +413,94 @@ fn devql_cli_parses_sync_modes() {
 }
 
 #[test]
-fn devql_cli_parses_sync_status_flag() {
-    let parsed = Cli::try_parse_from(["bitloops", "devql", "sync", "--status"])
-        .expect("devql sync --status should parse");
+fn devql_cli_parses_sync_enqueue_status_flag() {
+    let parsed = Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
+        "sync",
+        "--status",
+    ])
+    .expect("devql task sync enqueue --status should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Sync(sync)) = args.command else {
-        panic!("expected devql sync command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(sync) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
     };
     assert!(sync.status);
     assert!(!sync.require_daemon);
 }
 
 #[test]
-fn devql_cli_parses_sync_require_daemon_flag() {
-    let parsed = Cli::try_parse_from(["bitloops", "devql", "sync", "--require-daemon"])
-        .expect("devql sync --require-daemon should parse");
+fn devql_cli_parses_sync_enqueue_require_daemon_flag() {
+    let parsed = Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
+        "sync",
+        "--require-daemon",
+    ])
+    .expect("devql task sync enqueue --require-daemon should parse");
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Sync(sync)) = args.command else {
-        panic!("expected devql sync command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
+    };
+    let DevqlTasksCommand::Enqueue(sync) = tasks.command else {
+        panic!("expected devql tasks enqueue command");
     };
     assert!(sync.require_daemon);
 }
 
 #[test]
-fn devql_cli_rejects_conflicting_sync_modes() {
+fn devql_cli_rejects_conflicting_sync_enqueue_modes() {
     let cases = vec![
         vec![
             "bitloops",
             "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
             "sync",
             "--full",
             "--paths",
             "src/lib.rs",
         ],
-        vec!["bitloops", "devql", "sync", "--full", "--repair"],
+        vec![
+            "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--full", "--repair",
+        ],
         vec![
             "bitloops",
             "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
             "sync",
             "--paths",
             "src/lib.rs",
             "--repair",
         ],
-        vec!["bitloops", "devql", "sync", "--validate", "--repair"],
-        vec!["bitloops", "devql", "sync", "--validate", "--full"],
+        vec![
+            "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--validate", "--repair",
+        ],
+        vec![
+            "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--validate", "--full",
+        ],
         vec![
             "bitloops",
             "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
             "sync",
             "--validate",
             "--paths",
@@ -313,6 +509,9 @@ fn devql_cli_rejects_conflicting_sync_modes() {
         vec![
             "bitloops",
             "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
             "sync",
             "--full",
             "--paths",
@@ -1007,7 +1206,7 @@ fn devql_run_init_requires_running_daemon() {
 }
 
 #[test]
-fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
+fn devql_run_ingest_enqueue_executes_graphql_mutation_with_expected_input() {
     let repo = seed_devql_cli_repo();
     let _guard = enter_process_state(Some(repo.path()), &[]);
     let captured = Rc::new(RefCell::new(None::<(String, serde_json::Value)>));
@@ -1023,18 +1222,9 @@ fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
                           variables: &serde_json::Value| {
                         *captured.borrow_mut() = Some((query.to_string(), variables.clone()));
                         Ok(json!({
-                            "ingest": {
-                                "success": true,
-                                "commitsProcessed": 2,
-                                "checkpointCompanionsProcessed": 1,
-                                "eventsInserted": 3,
-                                "artefactsUpserted": 5,
-                                "semanticFeatureRowsUpserted": 0,
-                                "semanticFeatureRowsSkipped": 0,
-                                "symbolEmbeddingRowsUpserted": 0,
-                                "symbolEmbeddingRowsSkipped": 0,
-                                "symbolCloneEdgesUpserted": 0,
-                                "symbolCloneSourcesScored": 0
+                            "enqueueTask": {
+                                "merged": false,
+                                "task": queued_ingest_task_payload("ingest-task-1", None)
                             }
                         }))
                     }
@@ -1042,11 +1232,9 @@ fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
                 || {
                     test_runtime()
                         .block_on(run(DevqlArgs {
-                            command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                                require_daemon: false,
-                            })),
+                            command: Some(ingest_enqueue_command(false)),
                         }))
-                        .expect("devql ingest should succeed");
+                        .expect("devql ingest enqueue should succeed");
                 },
             );
         },
@@ -1056,12 +1244,12 @@ fn devql_run_ingest_executes_graphql_mutation_with_expected_input() {
         .borrow_mut()
         .take()
         .expect("graphql mutation should be captured");
-    assert!(query.contains("ingest"));
-    assert_eq!(variables, json!({}));
+    assert!(query.contains("enqueueTask"));
+    assert_eq!(variables["input"]["kind"], json!("INGEST"));
 }
 
 #[test]
-fn devql_run_ingest_requires_current_daemon_before_graphql_mutation() {
+fn devql_run_ingest_enqueue_requires_current_daemon_before_graphql_mutation() {
     let repo = seed_devql_cli_repo();
     let _guard = enter_process_state(Some(repo.path()), &[]);
     let bootstrap_count = Rc::new(RefCell::new(0usize));
@@ -1087,18 +1275,9 @@ fn devql_run_ingest_requires_current_daemon_before_graphql_mutation() {
                         *query_count.borrow_mut() += 1;
                         *ingested.borrow_mut() = Some((query.to_string(), variables.clone()));
                         Ok(json!({
-                            "ingest": {
-                                "success": true,
-                                "commitsProcessed": 0,
-                                "checkpointCompanionsProcessed": 0,
-                                "eventsInserted": 0,
-                                "artefactsUpserted": 0,
-                                "semanticFeatureRowsUpserted": 0,
-                                "semanticFeatureRowsSkipped": 0,
-                                "symbolEmbeddingRowsUpserted": 0,
-                                "symbolEmbeddingRowsSkipped": 0,
-                                "symbolCloneEdgesUpserted": 0,
-                                "symbolCloneSourcesScored": 0
+                            "enqueueTask": {
+                                "merged": false,
+                                "task": queued_ingest_task_payload("ingest-task-2", None)
                             }
                         }))
                     }
@@ -1106,11 +1285,9 @@ fn devql_run_ingest_requires_current_daemon_before_graphql_mutation() {
                 || {
                     test_runtime()
                         .block_on(run(DevqlArgs {
-                            command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                                require_daemon: false,
-                            })),
+                            command: Some(ingest_enqueue_command(false)),
                         }))
-                        .expect("devql ingest should succeed");
+                        .expect("devql ingest enqueue should succeed");
                 },
             );
         },
@@ -1122,8 +1299,8 @@ fn devql_run_ingest_requires_current_daemon_before_graphql_mutation() {
         .borrow_mut()
         .take()
         .expect("graphql mutation should be captured");
-    assert!(query.contains("ingest"));
-    assert_eq!(variables, json!({}));
+    assert!(query.contains("enqueueTask"));
+    assert_eq!(variables["input"]["kind"], json!("INGEST"));
 }
 
 #[test]
@@ -1143,11 +1320,9 @@ fn devql_run_ingest_require_daemon_fails_without_bootstrap() {
             || {
                 let err = test_runtime()
                     .block_on(run(DevqlArgs {
-                        command: Some(DevqlCommand::Ingest(DevqlIngestArgs {
-                            require_daemon: true,
-                        })),
+                        command: Some(ingest_enqueue_command(true)),
                     }))
-                    .expect_err("devql ingest --require-daemon should fail without a daemon");
+                    .expect_err("devql task ingest enqueue --require-daemon should fail without a daemon");
 
                 assert!(
                     err.to_string().contains("Bitloops daemon is not running"),
@@ -1165,7 +1340,7 @@ fn devql_run_ingest_require_daemon_fails_without_bootstrap() {
 }
 
 #[test]
-fn devql_run_ingest_stays_local_when_enrichment_is_disabled() {
+fn devql_run_ingest_enqueues_via_graphql_even_when_enrichment_is_disabled() {
     let repo = seed_devql_cli_repo();
     let daemon_state_root = test_daemon_state_root(repo.path());
     fs::write(
@@ -1214,32 +1389,25 @@ embedding_mode = "off"
                 let graphql_calls = Rc::clone(&graphql_calls);
                 move |_repo_root: &std::path::Path, _query: &str, _variables: &serde_json::Value| {
                     *graphql_calls.borrow_mut() += 1;
-                    panic!("graphql should not be used when enrichment is disabled");
+                    Ok(json!({
+                        "enqueueTask": {
+                            "merged": false,
+                            "task": queued_ingest_task_payload("ingest-task-3", None)
+                        }
+                    }))
                 }
             },
             || {
                 test_runtime()
                     .block_on(run(DevqlArgs {
-                        command: Some(DevqlCommand::Ingest(DevqlIngestArgs::default())),
+                        command: Some(ingest_enqueue_command(false)),
                     }))
-                    .expect("local deterministic ingest should succeed");
+                    .expect("daemon task ingest should succeed");
             },
         );
     });
 
-    assert_eq!(*graphql_calls.borrow(), 0);
-    with_isolated_daemon_state(repo.path(), || {
-        let err = test_runtime()
-            .block_on(run(DevqlArgs {
-                command: Some(DevqlCommand::Ingest(DevqlIngestArgs::default())),
-            }))
-            .expect_err("deterministic-only ingest should require a current daemon");
-        assert!(
-            format!("{err:#}").contains("bitloops init")
-                || format!("{err:#}").contains("daemon restart"),
-            "unexpected error: {err:#}"
-        );
-    });
+    assert_eq!(*graphql_calls.borrow(), 1);
 }
 
 #[test]
@@ -1259,37 +1427,9 @@ fn devql_run_sync_executes_graphql_mutation() {
                           variables: &serde_json::Value| {
                         *captured.borrow_mut() = Some((query.to_string(), variables.clone()));
                         Ok(json!({
-                            "enqueueSync": {
+                            "enqueueTask": {
                                 "merged": false,
-                                "task": {
-                                    "taskId": "sync-task-1",
-                                    "repoId": "repo-1",
-                                    "repoName": "demo",
-                                    "repoIdentity": "local/demo",
-                                    "source": "manual_cli",
-                                    "mode": "full",
-                                    "status": "queued",
-                                    "phase": "queued",
-                                    "submittedAtUnix": 1,
-                                    "startedAtUnix": null,
-                                    "updatedAtUnix": 1,
-                                    "completedAtUnix": null,
-                                    "queuePosition": 1,
-                                    "tasksAhead": 0,
-                                    "currentPath": null,
-                                    "pathsTotal": 0,
-                                    "pathsCompleted": 0,
-                                    "pathsRemaining": 0,
-                                    "pathsUnchanged": 0,
-                                    "pathsAdded": 0,
-                                    "pathsChanged": 0,
-                                    "pathsRemoved": 0,
-                                    "cacheHits": 0,
-                                    "cacheMisses": 0,
-                                    "parseErrors": 0,
-                                    "error": null,
-                                    "summary": null
-                                }
+                                "task": queued_sync_task_payload("sync-task-1", "full", None)
                             }
                         }))
                     }
@@ -1297,14 +1437,9 @@ fn devql_run_sync_executes_graphql_mutation() {
                 || {
                     test_runtime()
                         .block_on(run(DevqlArgs {
-                            command: Some(DevqlCommand::Sync(DevqlSyncArgs {
-                                full: true,
-                                paths: None,
-                                repair: false,
-                                validate: false,
-                                status: false,
-                                require_daemon: false,
-                            })),
+                            command: Some(sync_enqueue_command(
+                                true, None, false, false, false, false,
+                            )),
                         }))
                         .expect("devql sync should succeed");
                 },
@@ -1317,10 +1452,11 @@ fn devql_run_sync_executes_graphql_mutation() {
         .take()
         .expect("graphql mutation should be captured");
     assert!(
-        query.contains("enqueueSync"),
-        "expected enqueueSync mutation in query"
+        query.contains("enqueueTask"),
+        "expected enqueueTask mutation in query"
     );
-    assert_eq!(variables["input"]["full"], json!(true));
+    assert_eq!(variables["input"]["kind"], json!("SYNC"));
+    assert_eq!(variables["input"]["sync"]["full"], json!(true));
 }
 
 #[test]
@@ -1340,37 +1476,13 @@ fn devql_run_sync_passes_paths_to_graphql_mutation() {
                           variables: &serde_json::Value| {
                         *captured.borrow_mut() = Some((query.to_string(), variables.clone()));
                         Ok(json!({
-                            "enqueueSync": {
+                            "enqueueTask": {
                                 "merged": false,
-                                "task": {
-                                    "taskId": "sync-task-2",
-                                    "repoId": "repo-1",
-                                    "repoName": "demo",
-                                    "repoIdentity": "local/demo",
-                                    "source": "manual_cli",
-                                    "mode": "paths",
-                                    "status": "queued",
-                                    "phase": "queued",
-                                    "submittedAtUnix": 1,
-                                    "startedAtUnix": null,
-                                    "updatedAtUnix": 1,
-                                    "completedAtUnix": null,
-                                    "queuePosition": 1,
-                                    "tasksAhead": 0,
-                                    "currentPath": null,
-                                    "pathsTotal": 0,
-                                    "pathsCompleted": 0,
-                                    "pathsRemaining": 0,
-                                    "pathsUnchanged": 0,
-                                    "pathsAdded": 0,
-                                    "pathsChanged": 0,
-                                    "pathsRemoved": 0,
-                                    "cacheHits": 0,
-                                    "cacheMisses": 0,
-                                    "parseErrors": 0,
-                                    "error": null,
-                                    "summary": null
-                                }
+                                "task": queued_sync_task_payload(
+                                    "sync-task-2",
+                                    "paths",
+                                    Some(vec!["src/lib.rs", "src/main.rs"]),
+                                )
                             }
                         }))
                     }
@@ -1378,17 +1490,14 @@ fn devql_run_sync_passes_paths_to_graphql_mutation() {
                 || {
                     test_runtime()
                         .block_on(run(DevqlArgs {
-                            command: Some(DevqlCommand::Sync(DevqlSyncArgs {
-                                full: false,
-                                paths: Some(vec![
-                                    "src/lib.rs".to_string(),
-                                    "src/main.rs".to_string(),
-                                ]),
-                                repair: false,
-                                validate: false,
-                                status: false,
-                                require_daemon: false,
-                            })),
+                            command: Some(sync_enqueue_command(
+                                false,
+                                Some(vec!["src/lib.rs".to_string(), "src/main.rs".to_string()]),
+                                false,
+                                false,
+                                false,
+                                false,
+                            )),
                         }))
                         .expect("devql sync with paths should succeed");
                 },
@@ -1401,7 +1510,7 @@ fn devql_run_sync_passes_paths_to_graphql_mutation() {
         .take()
         .expect("graphql mutation should be captured");
     assert_eq!(
-        variables["input"]["paths"],
+        variables["input"]["sync"]["paths"],
         json!(["src/lib.rs", "src/main.rs"])
     );
 }
@@ -1424,51 +1533,18 @@ fn devql_run_sync_ensures_daemon_available() {
             with_graphql_executor_hook(
                 |_repo_root: &std::path::Path, _query: &str, _variables: &serde_json::Value| {
                     Ok(json!({
-                        "enqueueSync": {
+                        "enqueueTask": {
                             "merged": false,
-                            "task": {
-                                "taskId": "sync-task-3",
-                                "repoId": "repo-1",
-                                "repoName": "demo",
-                                "repoIdentity": "local/demo",
-                                "source": "manual_cli",
-                                "mode": "auto",
-                                "status": "queued",
-                                "phase": "queued",
-                                "submittedAtUnix": 1,
-                                "startedAtUnix": null,
-                                "updatedAtUnix": 1,
-                                "completedAtUnix": null,
-                                "queuePosition": 1,
-                                "tasksAhead": 0,
-                                "currentPath": null,
-                                "pathsTotal": 0,
-                                "pathsCompleted": 0,
-                                "pathsRemaining": 0,
-                                "pathsUnchanged": 0,
-                                "pathsAdded": 0,
-                                "pathsChanged": 0,
-                                "pathsRemoved": 0,
-                                "cacheHits": 0,
-                                "cacheMisses": 0,
-                                "parseErrors": 0,
-                                "error": null,
-                                "summary": null
-                            }
+                            "task": queued_sync_task_payload("sync-task-3", "auto", None)
                         }
                     }))
                 },
                 || {
                     test_runtime()
                         .block_on(run(DevqlArgs {
-                            command: Some(DevqlCommand::Sync(DevqlSyncArgs {
-                                full: false,
-                                paths: None,
-                                repair: false,
-                                validate: false,
-                                status: false,
-                                require_daemon: false,
-                            })),
+                            command: Some(sync_enqueue_command(
+                                false, None, false, false, false, false,
+                            )),
                         }))
                         .expect("devql sync should succeed");
                 },
@@ -1500,14 +1576,9 @@ fn devql_run_sync_require_daemon_fails_without_bootstrap() {
             || {
                 let err = test_runtime()
                     .block_on(run(DevqlArgs {
-                        command: Some(DevqlCommand::Sync(DevqlSyncArgs {
-                            full: false,
-                            paths: None,
-                            repair: false,
-                            validate: false,
-                            status: false,
-                            require_daemon: true,
-                        })),
+                        command: Some(sync_enqueue_command(
+                            false, None, false, false, false, true,
+                        )),
                     }))
                     .expect_err("devql sync --require-daemon should fail without a daemon");
 

--- a/bitloops/src/cli/init.rs
+++ b/bitloops/src/cli/init.rs
@@ -221,18 +221,17 @@ async fn run_with_io_async_for_project_root(
         if should_sync {
             writeln!(out, "Starting initial DevQL sync...")?;
             out.flush()?;
-            let (task, _merged) = crate::cli::devql::graphql::enqueue_sync_via_graphql(
+            let (task, _merged) = crate::cli::devql::graphql::enqueue_sync_task_via_graphql(
                 &scope, false, None, false, false, "init", false,
             )
             .await?;
-            if let Some(summary) =
-                crate::cli::devql::graphql::watch_sync_task_via_graphql(&scope, task.clone())
-                    .await?
+            if let Some(task) =
+                crate::cli::devql::graphql::watch_task_via_graphql(&scope, task.clone()).await?
             {
                 writeln!(
                     out,
                     "{}",
-                    crate::cli::devql::format_sync_completion_summary(&summary)
+                    crate::cli::devql::format_task_completion_summary(&task)
                 )?;
             }
         }
@@ -243,12 +242,21 @@ async fn run_with_io_async_for_project_root(
                 writeln!(out, "Starting initial DevQL ingest...")?;
             }
             out.flush()?;
-            crate::cli::devql::graphql::run_ingest_via_graphql(
+            let (task, _merged) = crate::cli::devql::graphql::enqueue_ingest_task_via_graphql(
                 &scope,
                 Some(args.backfill.unwrap_or(DEFAULT_INIT_INGEST_BACKFILL)),
                 false,
             )
             .await?;
+            if let Some(task) =
+                crate::cli::devql::graphql::watch_task_via_graphql(&scope, task).await?
+            {
+                writeln!(
+                    out,
+                    "{}",
+                    crate::cli::devql::format_task_completion_summary(&task)
+                )?;
+            }
         }
     }
     if defer_embeddings_install_until_after_sync {

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -1028,85 +1028,118 @@ fn run_init_with_install_default_daemon_defers_embeddings_until_after_sync_and_i
                                     {
                                         let events = std::rc::Rc::clone(&events);
                                         move |_repo_root, query, variables| {
-                                            if query.contains("enqueueSync") {
+                                            if query.contains("enqueueTask")
+                                                && variables["input"]["kind"] == "SYNC"
+                                            {
                                                 events.borrow_mut().push("sync");
                                                 assert_eq!(
                                                     variables,
                                                     &serde_json::json!({
                                                         "input": {
-                                                            "full": false,
-                                                            "paths": serde_json::Value::Null,
-                                                            "repair": false,
-                                                            "validate": false,
-                                                            "source": "init"
+                                                            "kind": "SYNC",
+                                                            "sync": {
+                                                                "full": false,
+                                                                "paths": serde_json::Value::Null,
+                                                                "repair": false,
+                                                                "validate": false,
+                                                                "source": "init"
+                                                            }
                                                         }
                                                     })
                                                 );
                                                 return Ok(serde_json::json!({
-                                                    "enqueueSync": {
+                                                    "enqueueTask": {
                                                         "merged": false,
                                                         "task": {
                                                             "taskId": "sync-task-1",
                                                             "repoId": "repo-1",
                                                             "repoName": "demo",
                                                             "repoIdentity": "local/demo",
+                                                            "kind": "SYNC",
                                                             "source": "init",
-                                                            "mode": "auto",
-                                                            "status": "queued",
-                                                            "phase": "queued",
+                                                            "status": "QUEUED",
                                                             "submittedAtUnix": 1,
                                                             "startedAtUnix": null,
                                                             "updatedAtUnix": 1,
                                                             "completedAtUnix": null,
                                                             "queuePosition": 1,
                                                             "tasksAhead": 0,
-                                                            "currentPath": null,
-                                                            "pathsTotal": 0,
-                                                            "pathsCompleted": 0,
-                                                            "pathsRemaining": 0,
-                                                            "pathsUnchanged": 0,
-                                                            "pathsAdded": 0,
-                                                            "pathsChanged": 0,
-                                                            "pathsRemoved": 0,
-                                                            "cacheHits": 0,
-                                                            "cacheMisses": 0,
-                                                            "parseErrors": 0,
                                                             "error": null,
-                                                            "summary": null
+                                                            "syncSpec": {
+                                                                "mode": "auto",
+                                                                "paths": []
+                                                            },
+                                                            "ingestSpec": null,
+                                                            "syncProgress": {
+                                                                "phase": "queued",
+                                                                "currentPath": null,
+                                                                "pathsTotal": 0,
+                                                                "pathsCompleted": 0,
+                                                                "pathsRemaining": 0,
+                                                                "pathsUnchanged": 0,
+                                                                "pathsAdded": 0,
+                                                                "pathsChanged": 0,
+                                                                "pathsRemoved": 0,
+                                                                "cacheHits": 0,
+                                                                "cacheMisses": 0,
+                                                                "parseErrors": 0
+                                                            },
+                                                            "ingestProgress": null,
+                                                            "syncResult": null,
+                                                            "ingestResult": null
                                                         }
                                                     }
                                                 }));
                                             }
 
-                                            if query.contains("syncTask") {
+                                            if query.contains("task(") || query.contains("query Task") {
                                                 return Ok(serde_json::json!({
-                                                    "syncTask": null
+                                                    "task": null
                                                 }));
                                             }
 
-                                            if query.contains("ingest") {
+                                            if query.contains("enqueueTask")
+                                                && variables["input"]["kind"] == "INGEST"
+                                            {
                                                 events.borrow_mut().push("ingest");
                                                 assert_eq!(
                                                     variables,
                                                     &serde_json::json!({
                                                         "input": {
-                                                            "backfill": 50
+                                                            "kind": "INGEST",
+                                                            "ingest": {
+                                                                "backfill": 50
+                                                            }
                                                         }
                                                     })
                                                 );
                                                 return Ok(serde_json::json!({
-                                                    "ingest": {
-                                                        "success": true,
-                                                        "commitsProcessed": 1,
-                                                        "checkpointCompanionsProcessed": 0,
-                                                        "eventsInserted": 0,
-                                                        "artefactsUpserted": 1,
-                                                        "semanticFeatureRowsUpserted": 0,
-                                                        "semanticFeatureRowsSkipped": 0,
-                                                        "symbolEmbeddingRowsUpserted": 0,
-                                                        "symbolEmbeddingRowsSkipped": 0,
-                                                        "symbolCloneEdgesUpserted": 0,
-                                                        "symbolCloneSourcesScored": 0
+                                                    "enqueueTask": {
+                                                        "merged": false,
+                                                        "task": {
+                                                            "taskId": "ingest-task-1",
+                                                            "repoId": "repo-1",
+                                                            "repoName": "demo",
+                                                            "repoIdentity": "local/demo",
+                                                            "kind": "INGEST",
+                                                            "source": "manual_cli",
+                                                            "status": "QUEUED",
+                                                            "submittedAtUnix": 1,
+                                                            "startedAtUnix": null,
+                                                            "updatedAtUnix": 1,
+                                                            "completedAtUnix": null,
+                                                            "queuePosition": 1,
+                                                            "tasksAhead": 0,
+                                                            "error": null,
+                                                            "syncSpec": null,
+                                                            "ingestSpec": {
+                                                                "backfill": 50
+                                                            },
+                                                            "syncProgress": null,
+                                                            "ingestProgress": null,
+                                                            "syncResult": null,
+                                                            "ingestResult": null
+                                                        }
                                                     }
                                                 }));
                                             }
@@ -1311,34 +1344,61 @@ fn run_init_triggers_repo_scoped_ingest_when_enabled() {
                                     .unwrap_or_else(|_| actual_repo_root.to_path_buf());
                                 assert_eq!(actual_repo_root, expected_repo_root);
 
-                                if query.contains("enqueueSync") {
+                                if query.contains("enqueueTask")
+                                    && variables["input"]["kind"] == "SYNC"
+                                {
                                     panic!("init should not enqueue sync when sync=false");
                                 }
 
-                                if query.contains("ingest") {
+                                if query.contains("enqueueTask")
+                                    && variables["input"]["kind"] == "INGEST"
+                                {
                                     *saw_ingest.borrow_mut() = true;
                                     assert_eq!(
                                         variables,
                                         &serde_json::json!({
                                             "input": {
-                                                "backfill": 50
+                                                "kind": "INGEST",
+                                                "ingest": {
+                                                    "backfill": 50
+                                                }
                                             }
                                         })
                                     );
                                     return Ok(serde_json::json!({
-                                        "ingest": {
-                                            "success": true,
-                                            "commitsProcessed": 1,
-                                            "checkpointCompanionsProcessed": 0,
-                                            "eventsInserted": 0,
-                                            "artefactsUpserted": 1,
-                                            "semanticFeatureRowsUpserted": 0,
-                                            "semanticFeatureRowsSkipped": 0,
-                                            "symbolEmbeddingRowsUpserted": 0,
-                                            "symbolEmbeddingRowsSkipped": 0,
-                                            "symbolCloneEdgesUpserted": 0,
-                                            "symbolCloneSourcesScored": 0
+                                        "enqueueTask": {
+                                            "merged": false,
+                                            "task": {
+                                                "taskId": "ingest-task-2",
+                                                "repoId": "repo-1",
+                                                "repoName": "demo",
+                                                "repoIdentity": "local/demo",
+                                                "kind": "INGEST",
+                                                "source": "manual_cli",
+                                                "status": "QUEUED",
+                                                "submittedAtUnix": 1,
+                                                "startedAtUnix": null,
+                                                "updatedAtUnix": 1,
+                                                "completedAtUnix": null,
+                                                "queuePosition": 1,
+                                                "tasksAhead": 0,
+                                                "error": null,
+                                                "syncSpec": null,
+                                                "ingestSpec": {
+                                                    "backfill": 50
+                                                },
+                                                "syncProgress": null,
+                                                "ingestProgress": null,
+                                                "syncResult": null,
+                                                "ingestResult": null
+                                            }
                                         }
+                                    }));
+                                }
+
+                                if query.contains("task(") || query.contains("query Task") {
+                                    return Ok(serde_json::json!({
+                                        "task": null
                                     }));
                                 }
 
@@ -1426,34 +1486,63 @@ fn run_init_uses_explicit_backfill_for_repo_scoped_ingest() {
                                             .unwrap_or_else(|_| actual_repo_root.to_path_buf());
                                         assert_eq!(actual_repo_root, expected_repo_root);
 
-                                        if query.contains("enqueueSync") {
+                                        if query.contains("enqueueTask")
+                                            && variables["input"]["kind"] == "SYNC"
+                                        {
                                             panic!("init should not enqueue sync when sync=false");
                                         }
 
-                                        if query.contains("ingest") {
+                                        if query.contains("enqueueTask")
+                                            && variables["input"]["kind"] == "INGEST"
+                                        {
                                             *saw_ingest.borrow_mut() = true;
                                             assert_eq!(
                                                 variables,
                                                 &serde_json::json!({
                                                     "input": {
-                                                        "backfill": 10
+                                                        "kind": "INGEST",
+                                                        "ingest": {
+                                                            "backfill": 10
+                                                        }
                                                     }
                                                 })
                                             );
                                             return Ok(serde_json::json!({
-                                                "ingest": {
-                                                    "success": true,
-                                                    "commitsProcessed": 1,
-                                                    "checkpointCompanionsProcessed": 0,
-                                                    "eventsInserted": 0,
-                                                    "artefactsUpserted": 1,
-                                                    "semanticFeatureRowsUpserted": 0,
-                                                    "semanticFeatureRowsSkipped": 0,
-                                                    "symbolEmbeddingRowsUpserted": 0,
-                                                    "symbolEmbeddingRowsSkipped": 0,
-                                                    "symbolCloneEdgesUpserted": 0,
-                                                    "symbolCloneSourcesScored": 0
+                                                "enqueueTask": {
+                                                    "merged": false,
+                                                    "task": {
+                                                        "taskId": "ingest-task-3",
+                                                        "repoId": "repo-1",
+                                                        "repoName": "demo",
+                                                        "repoIdentity": "local/demo",
+                                                        "kind": "INGEST",
+                                                        "source": "manual_cli",
+                                                        "status": "QUEUED",
+                                                        "submittedAtUnix": 1,
+                                                        "startedAtUnix": null,
+                                                        "updatedAtUnix": 1,
+                                                        "completedAtUnix": null,
+                                                        "queuePosition": 1,
+                                                        "tasksAhead": 0,
+                                                        "error": null,
+                                                        "syncSpec": null,
+                                                        "ingestSpec": {
+                                                            "backfill": 10
+                                                        },
+                                                        "syncProgress": null,
+                                                        "ingestProgress": null,
+                                                        "syncResult": null,
+                                                        "ingestResult": null
+                                                    }
                                                 }
+                                            }));
+                                        }
+
+                                        if query.contains("task(")
+                                            || query.contains("query Task")
+                                        {
+                                            return Ok(serde_json::json!({
+                                                "task": null
                                             }));
                                         }
 

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -1197,7 +1197,9 @@ fn run_init_with_install_default_daemon_defers_embeddings_until_after_sync_and_i
                                                 }));
                                             }
 
-                                            if query.contains("task(") || query.contains("query Task") {
+                                            if query.contains("task(")
+                                                || query.contains("query Task")
+                                            {
                                                 return Ok(serde_json::json!({
                                                     "task": null
                                                 }));

--- a/bitloops/src/cli/root/telemetry_actions.rs
+++ b/bitloops/src/cli/root/telemetry_actions.rs
@@ -477,36 +477,7 @@ fn devql_action(
         crate::cli::devql::DevqlCommand::Init(_) => {
             Some(new_action("bitloops devql init", HashMap::new()))
         }
-        crate::cli::devql::DevqlCommand::Ingest(_) => {
-            Some(new_action("bitloops devql ingest", HashMap::new()))
-        }
-        crate::cli::devql::DevqlCommand::Sync(args) => {
-            let mut props = HashMap::new();
-            let mut flags = Vec::new();
-            if args.status {
-                flags.push("status");
-            }
-            insert_flags(&mut props, flags);
-            let sync_mode = if args.full {
-                "full"
-            } else if args.paths.is_some() {
-                "paths"
-            } else if args.repair {
-                "repair"
-            } else if args.validate {
-                "validate"
-            } else {
-                "incremental"
-            };
-            insert_string_property(&mut props, "sync_mode", sync_mode);
-            insert_bool_property(&mut props, "status_follow", args.status);
-            insert_optional_count_property(
-                &mut props,
-                "paths_count",
-                args.paths.as_ref().map(Vec::len),
-            );
-            Some(new_action("bitloops devql sync", props))
-        }
+        crate::cli::devql::DevqlCommand::Tasks(args) => devql_tasks_action(args),
         crate::cli::devql::DevqlCommand::Projection(args) => match &args.command {
             crate::cli::devql::DevqlProjectionCommand::CheckpointFileSnapshots(args) => {
                 let mut props = HashMap::new();
@@ -648,6 +619,101 @@ fn devql_action(
     }
 }
 
+fn devql_tasks_action(
+    args: &crate::cli::devql::DevqlTasksArgs,
+) -> Option<crate::telemetry::analytics::ActionDescriptor> {
+    match &args.command {
+        crate::cli::devql::DevqlTasksCommand::Enqueue(args) => {
+            let mut props = HashMap::new();
+            let mut flags = Vec::new();
+            if args.status {
+                flags.push("status");
+            }
+            if args.require_daemon {
+                flags.push("require_daemon");
+            }
+            insert_flags(&mut props, flags);
+            insert_string_property(
+                &mut props,
+                "task_kind",
+                match args.kind {
+                    crate::cli::devql::DevqlTaskKindArg::Sync => "sync",
+                    crate::cli::devql::DevqlTaskKindArg::Ingest => "ingest",
+                },
+            );
+            if matches!(args.kind, crate::cli::devql::DevqlTaskKindArg::Sync) {
+                let sync_mode = if args.full {
+                    "full"
+                } else if args.paths.is_some() {
+                    "paths"
+                } else if args.repair {
+                    "repair"
+                } else if args.validate {
+                    "validate"
+                } else {
+                    "incremental"
+                };
+                insert_string_property(&mut props, "sync_mode", sync_mode);
+                insert_optional_count_property(
+                    &mut props,
+                    "paths_count",
+                    args.paths.as_ref().map(Vec::len),
+                );
+            }
+            insert_optional_count_property(&mut props, "backfill", args.backfill);
+            insert_bool_property(&mut props, "status_follow", args.status);
+            Some(new_action("bitloops devql tasks enqueue", props))
+        }
+        crate::cli::devql::DevqlTasksCommand::Watch(args) => {
+            let mut props = HashMap::new();
+            insert_bool_property(&mut props, "require_daemon", args.require_daemon);
+            Some(new_action("bitloops devql tasks watch", props))
+        }
+        crate::cli::devql::DevqlTasksCommand::Status(_) => {
+            Some(new_action("bitloops devql tasks status", HashMap::new()))
+        }
+        crate::cli::devql::DevqlTasksCommand::List(args) => {
+            let mut props = HashMap::new();
+            insert_optional_count_property(&mut props, "limit", args.limit);
+            if let Some(kind) = args.kind {
+                insert_string_property(
+                    &mut props,
+                    "task_kind",
+                    match kind {
+                        crate::cli::devql::DevqlTaskKindArg::Sync => "sync",
+                        crate::cli::devql::DevqlTaskKindArg::Ingest => "ingest",
+                    },
+                );
+            }
+            if let Some(status) = args.status {
+                insert_string_property(
+                    &mut props,
+                    "task_status",
+                    match status {
+                        crate::cli::devql::DevqlTaskStatusArg::Queued => "queued",
+                        crate::cli::devql::DevqlTaskStatusArg::Running => "running",
+                        crate::cli::devql::DevqlTaskStatusArg::Completed => "completed",
+                        crate::cli::devql::DevqlTaskStatusArg::Failed => "failed",
+                        crate::cli::devql::DevqlTaskStatusArg::Cancelled => "cancelled",
+                    },
+                );
+            }
+            Some(new_action("bitloops devql tasks list", props))
+        }
+        crate::cli::devql::DevqlTasksCommand::Pause(args) => {
+            let mut props = HashMap::new();
+            insert_bool_property(&mut props, "has_reason", args.reason.is_some());
+            Some(new_action("bitloops devql tasks pause", props))
+        }
+        crate::cli::devql::DevqlTasksCommand::Resume(_) => {
+            Some(new_action("bitloops devql tasks resume", HashMap::new()))
+        }
+        crate::cli::devql::DevqlTasksCommand::Cancel(_) => {
+            Some(new_action("bitloops devql tasks cancel", HashMap::new()))
+        }
+    }
+}
+
 fn embeddings_action(
     args: &crate::cli::embeddings::EmbeddingsArgs,
 ) -> Option<crate::telemetry::analytics::ActionDescriptor> {
@@ -708,20 +774,31 @@ mod telemetry_actions_unit_tests {
     }
 
     #[test]
-    fn telemetry_action_for_devql_ingest_has_no_legacy_checkpoint_limit_property() {
-        let cli = crate::cli::Cli::try_parse_from(["bitloops", "devql", "ingest"])
-            .expect("devql ingest should parse");
+    fn telemetry_action_for_devql_tasks_enqueue_ingest_has_no_legacy_checkpoint_limit_property() {
+        let cli = crate::cli::Cli::try_parse_from([
+            "bitloops",
+            "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
+            "ingest",
+        ])
+        .expect("devql task enqueue should parse");
         let action = telemetry_action_for_command(
             cli.command
                 .as_ref()
-                .expect("devql ingest should produce a subcommand"),
+                .expect("devql task enqueue should produce a subcommand"),
         )
-        .expect("devql ingest telemetry action should be emitted");
+        .expect("devql task enqueue telemetry action should be emitted");
 
-        assert_eq!(action.event, "bitloops devql ingest");
+        assert_eq!(action.event, "bitloops devql tasks enqueue");
+        assert_eq!(
+            action.properties.get("task_kind").and_then(Value::as_str),
+            Some("ingest")
+        );
         assert!(
-            action.properties.is_empty(),
-            "devql ingest no longer accepts legacy checkpoint limit flags"
+            !action.properties.contains_key("max_checkpoints"),
+            "devql task enqueue should not emit the removed max_checkpoints property"
         );
     }
 }

--- a/bitloops/src/cli/root/telemetry_actions.rs
+++ b/bitloops/src/cli/root/telemetry_actions.rs
@@ -776,12 +776,7 @@ mod telemetry_actions_unit_tests {
     #[test]
     fn telemetry_action_for_devql_tasks_enqueue_ingest_has_no_legacy_checkpoint_limit_property() {
         let cli = crate::cli::Cli::try_parse_from([
-            "bitloops",
-            "devql",
-            "tasks",
-            "enqueue",
-            "--kind",
-            "ingest",
+            "bitloops", "devql", "tasks", "enqueue", "--kind", "ingest",
         ])
         .expect("devql task enqueue should parse");
         let action = telemetry_action_for_command(

--- a/bitloops/src/cli/root_test.rs
+++ b/bitloops/src/cli/root_test.rs
@@ -791,13 +791,27 @@ fn TestTelemetryAction_DaemonStartCanonicalCommandUsesSameEventName() {
 
 #[test]
 #[allow(non_snake_case)]
-fn TestTelemetryAction_DevqlSyncTracksSafeProperties() {
-    let parsed = Cli::try_parse_from(["bitloops", "devql", "sync", "--paths", "a,b", "--status"])
-        .expect("devql sync should parse");
+fn TestTelemetryAction_DevqlTasksEnqueueSyncTracksSafeProperties() {
+    let parsed = Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "tasks",
+        "enqueue",
+        "--kind",
+        "sync",
+        "--paths",
+        "a,b",
+        "--status",
+    ])
+    .expect("devql tasks enqueue should parse");
     let command = parsed.command.as_ref().expect("command");
     let action = telemetry_action_for_command(command).expect("telemetry action");
 
-    assert_eq!(action.event, "bitloops devql sync");
+    assert_eq!(action.event, "bitloops devql tasks enqueue");
+    assert_eq!(
+        action.properties.get("task_kind").and_then(Value::as_str),
+        Some("sync")
+    );
     assert_eq!(
         action.properties.get("sync_mode").and_then(Value::as_str),
         Some("paths")

--- a/bitloops/src/cli/root_test.rs
+++ b/bitloops/src/cli/root_test.rs
@@ -797,15 +797,7 @@ fn TestTelemetryAction_DaemonStartCanonicalCommandUsesSameEventName() {
 #[allow(non_snake_case)]
 fn TestTelemetryAction_DevqlTasksEnqueueSyncTracksSafeProperties() {
     let parsed = Cli::try_parse_from([
-        "bitloops",
-        "devql",
-        "tasks",
-        "enqueue",
-        "--kind",
-        "sync",
-        "--paths",
-        "a,b",
-        "--status",
+        "bitloops", "devql", "tasks", "enqueue", "--kind", "sync", "--paths", "a,b", "--status",
     ])
     .expect("devql tasks enqueue should parse");
     let command = parsed.command.as_ref().expect("command");

--- a/bitloops/src/cli/status.rs
+++ b/bitloops/src/cli/status.rs
@@ -189,7 +189,40 @@ fn truncate_prompt(input: &str, max_chars: usize) -> String {
 
 pub async fn run(args: StatusArgs) -> Result<()> {
     let mut out = std::io::stdout();
-    run_status(&mut out, args.detailed)
+    run_status(&mut out, args.detailed)?;
+
+    let start = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    if find_repo_root(&start).is_ok()
+        && let Ok(scope) = crate::devql_transport::discover_slim_cli_repo_scope(Some(&start))
+        && let Ok(status) = crate::cli::devql::graphql::task_queue_status_via_graphql(&scope).await
+    {
+        writeln!(out)?;
+        writeln!(out, "DevQL Task Queue:")?;
+        writeln!(
+            out,
+            "  state: {}",
+            if status.paused { "paused" } else { "running" }
+        )?;
+        writeln!(out, "  queued: {}", status.queued_tasks)?;
+        writeln!(out, "  running: {}", status.running_tasks)?;
+        writeln!(out, "  failed: {}", status.failed_tasks)?;
+        for counts in status.by_kind {
+            writeln!(
+                out,
+                "  {}: queued={} running={} failed={} completed_recent={}",
+                counts.kind.to_ascii_lowercase(),
+                counts.queued_tasks,
+                counts.running_tasks,
+                counts.failed_tasks,
+                counts.completed_recent_tasks
+            )?;
+        }
+        if let Some(reason) = status.paused_reason {
+            writeln!(out, "  pause reason: {reason}")?;
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/bitloops/src/daemon.rs
+++ b/bitloops/src/daemon.rs
@@ -73,9 +73,9 @@ pub use self::types::{
     DevqlTaskKind, DevqlTaskKindCounts, DevqlTaskProgress, DevqlTaskQueueState,
     DevqlTaskQueueStatus, DevqlTaskRecord, DevqlTaskResult, DevqlTaskSource, DevqlTaskSpec,
     DevqlTaskStatus, EnrichmentQueueMode, EnrichmentQueueState, EnrichmentQueueStatus,
-    IngestTaskSpec, InternalDaemonProcessArgs, InternalDaemonSupervisorArgs,
-    RepoTaskControlState, ResolvedDaemonConfig, ServiceManagerKind, SupervisorRuntimeState,
-    SupervisorServiceMetadata, SyncTaskMode, SyncTaskSpec,
+    IngestTaskSpec, InternalDaemonProcessArgs, InternalDaemonSupervisorArgs, RepoTaskControlState,
+    ResolvedDaemonConfig, ServiceManagerKind, SupervisorRuntimeState, SupervisorServiceMetadata,
+    SyncTaskMode, SyncTaskSpec,
 };
 pub(crate) use self::types::{
     ENRICHMENT_STATE_FILE_NAME, SUPERVISOR_RUNTIME_STATE_FILE_NAME, SYNC_STATE_FILE_NAME,
@@ -345,10 +345,7 @@ pub fn enqueue_ingest_for_config(
     )
 }
 
-pub fn pause_devql_tasks(
-    repo_id: &str,
-    reason: Option<String>,
-) -> Result<DevqlTaskControlResult> {
+pub fn pause_devql_tasks(repo_id: &str, reason: Option<String>) -> Result<DevqlTaskControlResult> {
     DevqlTaskCoordinator::shared().pause_repo(repo_id, reason)
 }
 

--- a/bitloops/src/daemon.rs
+++ b/bitloops/src/daemon.rs
@@ -50,8 +50,8 @@ mod state_store;
 mod supervisor_api;
 #[path = "daemon/supervisor_client.rs"]
 mod supervisor_client;
-#[path = "daemon/sync.rs"]
-mod sync;
+#[path = "daemon/tasks.rs"]
+mod tasks;
 #[path = "daemon/types.rs"]
 mod types;
 
@@ -65,15 +65,17 @@ pub use self::enrichment::EnrichmentCoordinator;
 pub use self::enrichment::EnrichmentJobTarget;
 pub(crate) use self::enrichment::EnrichmentQueueState as PersistedEnrichmentQueueState;
 pub use self::logger::{ProcessLogContext, daemon_log_file_path, init_process_logger};
-pub use self::sync::{SyncCoordinator, SyncEnqueueResult};
+pub use self::tasks::{DevqlTaskCoordinator, DevqlTaskEnqueueResult};
 pub use self::types::{
     CapabilityEventQueueState, CapabilityEventQueueStatus, CapabilityEventRunRecord,
     CapabilityEventRunStatus, DaemonHealthSummary, DaemonMode, DaemonProcessModeArg,
-    DaemonRuntimeState, DaemonServiceMetadata, DaemonStatusReport, EnrichmentQueueMode,
-    EnrichmentQueueState, EnrichmentQueueStatus, InternalDaemonProcessArgs,
-    InternalDaemonSupervisorArgs, ResolvedDaemonConfig, ServiceManagerKind, SupervisorRuntimeState,
-    SupervisorServiceMetadata, SyncQueueState, SyncQueueStatus, SyncTaskMode, SyncTaskRecord,
-    SyncTaskSource, SyncTaskStatus,
+    DaemonRuntimeState, DaemonServiceMetadata, DaemonStatusReport, DevqlTaskControlResult,
+    DevqlTaskKind, DevqlTaskKindCounts, DevqlTaskProgress, DevqlTaskQueueState,
+    DevqlTaskQueueStatus, DevqlTaskRecord, DevqlTaskResult, DevqlTaskSource, DevqlTaskSpec,
+    DevqlTaskStatus, EnrichmentQueueMode, EnrichmentQueueState, EnrichmentQueueStatus,
+    IngestTaskSpec, InternalDaemonProcessArgs, InternalDaemonSupervisorArgs,
+    RepoTaskControlState, ResolvedDaemonConfig, ServiceManagerKind, SupervisorRuntimeState,
+    SupervisorServiceMetadata, SyncTaskMode, SyncTaskSpec,
 };
 pub(crate) use self::types::{
     ENRICHMENT_STATE_FILE_NAME, SUPERVISOR_RUNTIME_STATE_FILE_NAME, SYNC_STATE_FILE_NAME,
@@ -277,33 +279,85 @@ pub fn shared_capability_event_coordinator() -> Arc<CapabilityEventCoordinator> 
     CapabilityEventCoordinator::shared()
 }
 
-pub fn shared_sync_coordinator() -> Arc<SyncCoordinator> {
-    SyncCoordinator::shared()
+pub fn shared_devql_task_coordinator() -> Arc<DevqlTaskCoordinator> {
+    DevqlTaskCoordinator::shared()
 }
 
-pub(crate) fn activate_sync_worker(subscription_hub: Arc<crate::graphql::SubscriptionHub>) {
+pub(crate) fn activate_task_worker(subscription_hub: Arc<crate::graphql::SubscriptionHub>) {
     CapabilityEventCoordinator::shared().activate_worker();
-    SyncCoordinator::shared().activate_worker(Some(subscription_hub));
+    DevqlTaskCoordinator::shared().activate_worker(Some(subscription_hub));
 }
 
-pub fn sync_status(repo_id: Option<&str>) -> Result<SyncQueueStatus> {
-    SyncCoordinator::shared().snapshot(repo_id)
+pub fn devql_task_status(repo_id: Option<&str>) -> Result<DevqlTaskQueueStatus> {
+    DevqlTaskCoordinator::shared().snapshot(repo_id)
 }
 
-pub fn sync_task(task_id: &str) -> Result<Option<SyncTaskRecord>> {
-    SyncCoordinator::shared().task(task_id)
+pub fn devql_task(task_id: &str) -> Result<Option<DevqlTaskRecord>> {
+    DevqlTaskCoordinator::shared().task(task_id)
 }
 
-pub fn sync_tasks(repo_id: Option<&str>, limit: Option<usize>) -> Result<Vec<SyncTaskRecord>> {
-    SyncCoordinator::shared().tasks(repo_id, limit)
+pub fn devql_tasks(
+    repo_id: Option<&str>,
+    kind: Option<DevqlTaskKind>,
+    status: Option<DevqlTaskStatus>,
+    limit: Option<usize>,
+) -> Result<Vec<DevqlTaskRecord>> {
+    DevqlTaskCoordinator::shared().tasks(repo_id, kind, status, limit)
+}
+
+pub fn enqueue_task_for_config(
+    cfg: &crate::host::devql::DevqlConfig,
+    source: DevqlTaskSource,
+    spec: DevqlTaskSpec,
+) -> Result<DevqlTaskEnqueueResult> {
+    DevqlTaskCoordinator::shared().enqueue(cfg, source, spec)
 }
 
 pub fn enqueue_sync_for_config(
     cfg: &crate::host::devql::DevqlConfig,
-    source: SyncTaskSource,
+    source: DevqlTaskSource,
     mode: crate::host::devql::SyncMode,
-) -> Result<SyncEnqueueResult> {
-    SyncCoordinator::shared().enqueue(cfg, source, mode)
+) -> Result<DevqlTaskEnqueueResult> {
+    enqueue_task_for_config(
+        cfg,
+        source,
+        DevqlTaskSpec::Sync(SyncTaskSpec {
+            mode: match mode {
+                crate::host::devql::SyncMode::Auto => SyncTaskMode::Auto,
+                crate::host::devql::SyncMode::Full => SyncTaskMode::Full,
+                crate::host::devql::SyncMode::Paths(paths) => SyncTaskMode::Paths { paths },
+                crate::host::devql::SyncMode::Repair => SyncTaskMode::Repair,
+                crate::host::devql::SyncMode::Validate => SyncTaskMode::Validate,
+            },
+        }),
+    )
+}
+
+pub fn enqueue_ingest_for_config(
+    cfg: &crate::host::devql::DevqlConfig,
+    source: DevqlTaskSource,
+    backfill: Option<usize>,
+) -> Result<DevqlTaskEnqueueResult> {
+    enqueue_task_for_config(
+        cfg,
+        source,
+        DevqlTaskSpec::Ingest(IngestTaskSpec { backfill }),
+    )
+}
+
+pub fn pause_devql_tasks(
+    repo_id: &str,
+    reason: Option<String>,
+) -> Result<DevqlTaskControlResult> {
+    DevqlTaskCoordinator::shared().pause_repo(repo_id, reason)
+}
+
+pub fn resume_devql_tasks(repo_id: &str) -> Result<DevqlTaskControlResult> {
+    DevqlTaskCoordinator::shared().resume_repo(repo_id)
+}
+
+pub fn cancel_devql_task(task_id: &str) -> Result<DevqlTaskRecord> {
+    DevqlTaskCoordinator::shared().cancel_task(task_id)
 }
 
 pub async fn wait_until_ready(timeout: Duration) -> Result<DaemonRuntimeState> {

--- a/bitloops/src/daemon/capability_events.rs
+++ b/bitloops/src/daemon/capability_events.rs
@@ -220,6 +220,7 @@ pub(crate) fn build_sync_completed_runs(
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 pub(crate) fn test_shared_instance_at(db_path: PathBuf) -> Arc<CapabilityEventCoordinator> {
     CapabilityEventCoordinator::new_shared_instance(
         DaemonSqliteRuntimeStore::open_at(db_path)

--- a/bitloops/src/daemon/lifecycle.rs
+++ b/bitloops/src/daemon/lifecycle.rs
@@ -211,7 +211,7 @@ pub(super) async fn status() -> Result<DaemonStatusReport> {
         .and_then(|repo_root| crate::host::devql::resolve_repo_identity(&repo_root).ok())
         .map(|repo| repo.repo_id);
     let capability_events = super::capability_event_status(current_repo_id.as_deref()).ok();
-    let sync = super::sync_status(current_repo_id.as_deref()).ok();
+    let devql_tasks = super::devql_task_status(current_repo_id.as_deref()).ok();
 
     Ok(DaemonStatusReport {
         runtime,
@@ -220,7 +220,7 @@ pub(super) async fn status() -> Result<DaemonStatusReport> {
         health,
         capability_events,
         enrichment,
-        sync,
+        devql_tasks,
     })
 }
 

--- a/bitloops/src/daemon/tasks.rs
+++ b/bitloops/src/daemon/tasks.rs
@@ -1,0 +1,8 @@
+#[path = "tasks/coordinator.rs"]
+mod coordinator;
+#[path = "tasks/queue.rs"]
+mod queue;
+#[path = "tasks/state.rs"]
+mod state;
+
+pub use self::coordinator::{DevqlTaskCoordinator, DevqlTaskEnqueueResult};

--- a/bitloops/src/daemon/tasks/coordinator.rs
+++ b/bitloops/src/daemon/tasks/coordinator.rs
@@ -1,0 +1,857 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Instant;
+
+use anyhow::{Result, anyhow, bail};
+use tokio::sync::Notify;
+use tokio::time::{Duration, sleep};
+use uuid::Uuid;
+
+use crate::graphql::{Checkpoint, SubscriptionHub};
+use crate::host::capability_host::{SyncArtefactDiff, SyncCompletedPayload, SyncFileDiff};
+use crate::host::devql::{
+    DevqlConfig, IngestedCheckpointNotification, IngestionCounters, IngestionObserver,
+    IngestionProgressPhase, IngestionProgressUpdate, RepoIdentity, SyncObserver,
+    SyncProgressPhase, SyncProgressUpdate, SyncSummary,
+};
+#[cfg(test)]
+use crate::utils::paths::default_global_runtime_db_path;
+
+use super::super::types::{
+    DevqlTaskControlResult, DevqlTaskKind, DevqlTaskProgress, DevqlTaskQueueStatus,
+    DevqlTaskRecord, DevqlTaskResult, DevqlTaskSource, DevqlTaskSpec, DevqlTaskStatus,
+    RepoTaskControlState, SyncTaskMode, SyncTaskSpec, unix_timestamp_now,
+};
+use super::queue::{
+    changed_tasks, default_progress_for_spec, failed_progress, ingest_progress_from_summary,
+    merge_existing_task, next_runnable_task_indexes, project_status, prune_terminal_tasks,
+    recompute_queue_positions, sync_progress_from_summary, sync_task_mode_from_host,
+    sync_task_mode_to_host,
+};
+use crate::host::runtime_store::{DaemonSqliteRuntimeStore, PersistedDevqlTaskQueueState};
+
+const WORKER_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const PROGRESS_PERSIST_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone)]
+pub struct DevqlTaskEnqueueResult {
+    pub task: DevqlTaskRecord,
+    pub merged: bool,
+}
+
+#[derive(Debug)]
+pub struct DevqlTaskCoordinator {
+    pub(super) runtime_store: DaemonSqliteRuntimeStore,
+    pub(super) lock: Mutex<()>,
+    pub(super) notify: Notify,
+    pub(super) worker_started: AtomicBool,
+    pub(super) subscription_hub: Mutex<Option<Arc<SubscriptionHub>>>,
+}
+
+struct SyncCoordinatorObserver {
+    coordinator: Arc<DevqlTaskCoordinator>,
+    task_id: String,
+    progress_state: Mutex<ProgressPersistState<SyncProgressUpdate>>,
+}
+
+struct IngestCoordinatorObserver {
+    coordinator: Arc<DevqlTaskCoordinator>,
+    task_id: String,
+    repo_name: String,
+    progress_state: Mutex<ProgressPersistState<IngestionProgressUpdate>>,
+}
+
+#[derive(Debug)]
+struct ProgressPersistState<T> {
+    last_persisted: Option<T>,
+    last_persisted_at: Option<Instant>,
+}
+
+impl<T> Default for ProgressPersistState<T> {
+    fn default() -> Self {
+        Self {
+            last_persisted: None,
+            last_persisted_at: None,
+        }
+    }
+}
+
+struct WorkerStartedGuard {
+    coordinator: Arc<DevqlTaskCoordinator>,
+}
+
+impl Drop for WorkerStartedGuard {
+    fn drop(&mut self) {
+        self.coordinator
+            .worker_started
+            .store(false, Ordering::SeqCst);
+    }
+}
+
+impl SyncObserver for SyncCoordinatorObserver {
+    fn on_progress(&self, update: SyncProgressUpdate) {
+        match self.progress_state.lock() {
+            Ok(mut state) => {
+                let now = Instant::now();
+                if !should_persist_progress(
+                    state.last_persisted.as_ref(),
+                    &update,
+                    state.last_persisted_at,
+                    now,
+                ) {
+                    return;
+                }
+                state.last_persisted = Some(update.clone());
+                state.last_persisted_at = Some(now);
+            }
+            Err(_) => {
+                log::warn!(
+                    "failed to acquire sync progress throttle state for task `{}`",
+                    self.task_id
+                );
+            }
+        }
+
+        if let Err(err) = self
+            .coordinator
+            .update_task_progress(&self.task_id, DevqlTaskProgress::Sync(update))
+        {
+            log::warn!(
+                "failed to persist sync progress for task `{}`: {err:#}",
+                self.task_id
+            );
+        }
+    }
+}
+
+impl IngestionObserver for IngestCoordinatorObserver {
+    fn on_progress(&self, update: IngestionProgressUpdate) {
+        match self.progress_state.lock() {
+            Ok(mut state) => {
+                let now = Instant::now();
+                if !should_persist_progress(
+                    state.last_persisted.as_ref(),
+                    &update,
+                    state.last_persisted_at,
+                    now,
+                ) {
+                    return;
+                }
+                state.last_persisted = Some(update.clone());
+                state.last_persisted_at = Some(now);
+            }
+            Err(_) => {
+                log::warn!(
+                    "failed to acquire ingest progress throttle state for task `{}`",
+                    self.task_id
+                );
+            }
+        }
+
+        if let Err(err) = self
+            .coordinator
+            .update_task_progress(&self.task_id, DevqlTaskProgress::Ingest(update))
+        {
+            log::warn!(
+                "failed to persist ingest progress for task `{}`: {err:#}",
+                self.task_id
+            );
+        }
+    }
+
+    fn on_checkpoint_ingested(&self, checkpoint: IngestedCheckpointNotification) {
+        self.coordinator.publish_checkpoint(
+            self.repo_name.clone(),
+            Checkpoint::from_ingested(&checkpoint.checkpoint, checkpoint.commit_sha.as_deref()),
+        );
+    }
+}
+
+impl DevqlTaskCoordinator {
+    pub(crate) fn shared() -> Arc<Self> {
+        static INSTANCE: OnceLock<Mutex<Arc<DevqlTaskCoordinator>>> = OnceLock::new();
+        let slot = INSTANCE.get_or_init(|| {
+            let runtime_store = DaemonSqliteRuntimeStore::open()
+                .expect("opening daemon runtime store for DevQL tasks");
+            Mutex::new(Self::new_shared_instance(runtime_store))
+        });
+        let coordinator = slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        #[cfg(test)]
+        let mut coordinator = coordinator;
+
+        #[cfg(test)]
+        {
+            let runtime_db_path = default_global_runtime_db_path();
+            if coordinator.runtime_store.db_path() != runtime_db_path.as_path() {
+                let runtime_store = DaemonSqliteRuntimeStore::open_at(runtime_db_path)
+                    .expect("opening daemon runtime store for DevQL tasks");
+                *coordinator = Self::new_shared_instance(runtime_store);
+            }
+        }
+
+        Arc::clone(&coordinator)
+    }
+
+    fn new_shared_instance(runtime_store: DaemonSqliteRuntimeStore) -> Arc<Self> {
+        Arc::new(Self {
+            runtime_store,
+            lock: Mutex::new(()),
+            notify: Notify::new(),
+            worker_started: AtomicBool::new(false),
+            subscription_hub: Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn activate_worker(self: &Arc<Self>, hub: Option<Arc<SubscriptionHub>>) {
+        if let Some(hub) = hub {
+            self.register_subscription_hub(hub);
+        }
+        if self.worker_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        if let Err(err) = self.recover_running_tasks() {
+            log::warn!("failed to recover queued DevQL tasks: {err:#}");
+        }
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            self.worker_started.store(false, Ordering::SeqCst);
+            log::warn!("DevQL task worker activation requested without an active tokio runtime");
+            return;
+        };
+        let coordinator = Arc::clone(self);
+        handle.spawn(async move {
+            let _guard = WorkerStartedGuard {
+                coordinator: Arc::clone(&coordinator),
+            };
+            coordinator.run_loop().await;
+        });
+    }
+
+    pub(crate) fn register_subscription_hub(&self, hub: Arc<SubscriptionHub>) {
+        if let Ok(mut slot) = self.subscription_hub.lock() {
+            *slot = Some(hub);
+        }
+    }
+
+    pub(crate) fn enqueue(
+        &self,
+        cfg: &DevqlConfig,
+        source: DevqlTaskSource,
+        spec: DevqlTaskSpec,
+    ) -> Result<DevqlTaskEnqueueResult> {
+        let kind = task_kind_from_spec(&spec);
+        self.mutate_state(|state| {
+            if let Some(task) = merge_existing_task(state, cfg, source, kind, &spec) {
+                return Ok(DevqlTaskEnqueueResult { task, merged: true });
+            }
+
+            let now = unix_timestamp_now();
+            let task = DevqlTaskRecord {
+                task_id: format!("{kind}-task-{}", Uuid::new_v4()),
+                repo_id: cfg.repo.repo_id.clone(),
+                repo_name: cfg.repo.name.clone(),
+                repo_provider: cfg.repo.provider.clone(),
+                repo_organisation: cfg.repo.organization.clone(),
+                repo_identity: cfg.repo.identity.clone(),
+                daemon_config_root: cfg.daemon_config_root.clone(),
+                repo_root: cfg.repo_root.clone(),
+                kind,
+                source,
+                spec: spec.clone(),
+                status: DevqlTaskStatus::Queued,
+                submitted_at_unix: now,
+                started_at_unix: None,
+                updated_at_unix: now,
+                completed_at_unix: None,
+                queue_position: None,
+                tasks_ahead: None,
+                progress: default_progress_for_spec(&spec),
+                error: None,
+                result: None,
+            };
+            state.tasks.push(task.clone());
+            state.last_action = Some("enqueue".to_string());
+            Ok(DevqlTaskEnqueueResult {
+                task,
+                merged: false,
+            })
+        })
+    }
+
+    pub(crate) fn snapshot(&self, repo_id: Option<&str>) -> Result<DevqlTaskQueueStatus> {
+        let state = self.load_state()?;
+        let persisted = self.runtime_store.devql_task_state_exists()?;
+        Ok(project_status(&state, repo_id, persisted))
+    }
+
+    pub(crate) fn task(&self, task_id: &str) -> Result<Option<DevqlTaskRecord>> {
+        let state = self.load_state()?;
+        Ok(state.tasks.into_iter().find(|task| task.task_id == task_id))
+    }
+
+    pub(crate) fn tasks(
+        &self,
+        repo_id: Option<&str>,
+        kind: Option<DevqlTaskKind>,
+        status: Option<DevqlTaskStatus>,
+        limit: Option<usize>,
+    ) -> Result<Vec<DevqlTaskRecord>> {
+        let state = self.load_state()?;
+        let mut tasks = state
+            .tasks
+            .into_iter()
+            .filter(|task| repo_id.is_none_or(|repo_id| task.repo_id == repo_id))
+            .filter(|task| kind.is_none_or(|kind| task.kind == kind))
+            .filter(|task| status.is_none_or(|status| task.status == status))
+            .collect::<Vec<_>>();
+        tasks.sort_by(|left, right| {
+            right
+                .updated_at_unix
+                .cmp(&left.updated_at_unix)
+                .then_with(|| left.task_id.cmp(&right.task_id))
+        });
+        if let Some(limit) = limit {
+            tasks.truncate(limit);
+        }
+        Ok(tasks)
+    }
+
+    pub(crate) fn pause_repo(
+        &self,
+        repo_id: &str,
+        reason: Option<String>,
+    ) -> Result<DevqlTaskControlResult> {
+        let repo_id = repo_id.to_string();
+        self.mutate_state(|state| {
+            let control = state
+                .repo_controls
+                .entry(repo_id.clone())
+                .or_insert_with(|| RepoTaskControlState {
+                    repo_id: repo_id.clone(),
+                    paused: false,
+                    paused_reason: None,
+                    updated_at_unix: 0,
+                });
+            control.paused = true;
+            control.paused_reason = reason.clone();
+            control.updated_at_unix = unix_timestamp_now();
+            state.last_action = Some("paused".to_string());
+            Ok(DevqlTaskControlResult {
+                message: format!("paused DevQL task queue for {repo_id}"),
+                control: control.clone(),
+            })
+        })
+    }
+
+    pub(crate) fn resume_repo(&self, repo_id: &str) -> Result<DevqlTaskControlResult> {
+        let repo_id = repo_id.to_string();
+        self.mutate_state(|state| {
+            let control = state
+                .repo_controls
+                .entry(repo_id.clone())
+                .or_insert_with(|| RepoTaskControlState {
+                    repo_id: repo_id.clone(),
+                    paused: false,
+                    paused_reason: None,
+                    updated_at_unix: 0,
+                });
+            control.paused = false;
+            control.paused_reason = None;
+            control.updated_at_unix = unix_timestamp_now();
+            state.last_action = Some("resumed".to_string());
+            Ok(DevqlTaskControlResult {
+                message: format!("resumed DevQL task queue for {repo_id}"),
+                control: control.clone(),
+            })
+        })
+    }
+
+    pub(crate) fn cancel_task(&self, task_id: &str) -> Result<DevqlTaskRecord> {
+        let task_id = task_id.to_string();
+        self.mutate_state(|state| {
+            let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
+                bail!("unknown task `{task_id}`");
+            };
+            match task.status {
+                DevqlTaskStatus::Queued => {
+                    let now = unix_timestamp_now();
+                    task.status = DevqlTaskStatus::Cancelled;
+                    task.updated_at_unix = now;
+                    task.completed_at_unix = Some(now);
+                    task.error = None;
+                    task.result = None;
+                    state.last_action = Some("cancelled".to_string());
+                    Ok(task.clone())
+                }
+                DevqlTaskStatus::Running => {
+                    bail!("task `{task_id}` is already running and cannot be cancelled")
+                }
+                _ => bail!("task `{task_id}` is not queued and cannot be cancelled"),
+            }
+        })
+    }
+
+    async fn run_loop(self: Arc<Self>) {
+        loop {
+            match self.schedule_pending_tasks() {
+                Ok(true) => continue,
+                Ok(false) => {}
+                Err(err) => {
+                    log::warn!("daemon DevQL task worker error: {err:#}");
+                }
+            }
+            tokio::select! {
+                _ = self.notify.notified() => {},
+                _ = sleep(WORKER_POLL_INTERVAL) => {},
+            }
+        }
+    }
+
+    fn schedule_pending_tasks(self: &Arc<Self>) -> Result<bool> {
+        let tasks = self.mutate_state(|state| {
+            let indexes = next_runnable_task_indexes(state);
+            if indexes.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let now = unix_timestamp_now();
+            let mut scheduled = Vec::with_capacity(indexes.len());
+            for index in indexes {
+                let mut task = state.tasks[index].clone();
+                task.status = DevqlTaskStatus::Running;
+                task.started_at_unix = Some(task.started_at_unix.unwrap_or(now));
+                task.updated_at_unix = now;
+                task.error = None;
+                task.completed_at_unix = None;
+                task.result = None;
+                state.tasks[index] = task.clone();
+                scheduled.push(task);
+            }
+            state.last_action = Some("running".to_string());
+            Ok(scheduled)
+        })?;
+
+        if tasks.is_empty() {
+            return Ok(false);
+        }
+
+        for task in tasks {
+            let coordinator = Arc::clone(self);
+            tokio::spawn(async move {
+                if let Err(err) = coordinator.run_task(task).await {
+                    log::warn!("DevQL task execution failed: {err:#}");
+                }
+            });
+        }
+
+        Ok(true)
+    }
+
+    async fn run_task(self: Arc<Self>, task: DevqlTaskRecord) -> Result<()> {
+        match task.kind {
+            DevqlTaskKind::Sync => self.run_sync_task(task).await,
+            DevqlTaskKind::Ingest => self.run_ingest_task(task).await,
+        }
+    }
+
+    async fn run_sync_task(self: Arc<Self>, task: DevqlTaskRecord) -> Result<()> {
+        self.update_task_progress(
+            &task.task_id,
+            DevqlTaskProgress::Sync(SyncProgressUpdate {
+                phase: SyncProgressPhase::EnsuringSchema,
+                ..task
+                    .sync_progress()
+                    .cloned()
+                    .unwrap_or_else(SyncProgressUpdate::default)
+            }),
+        )?;
+
+        let repo = RepoIdentity {
+            repo_id: task.repo_id.clone(),
+            name: task.repo_name.clone(),
+            provider: task.repo_provider.clone(),
+            organization: task.repo_organisation.clone(),
+            identity: task.repo_identity.clone(),
+        };
+        let cfg = DevqlConfig::from_roots(
+            task.daemon_config_root.clone(),
+            task.repo_root.clone(),
+            repo,
+        )?;
+        let requested_mode = sync_task_mode_to_host(
+            &task
+                .sync_spec()
+                .map(|spec| &spec.mode)
+                .cloned()
+                .ok_or_else(|| anyhow!("sync task missing sync spec"))?,
+        );
+
+        let schema_outcome = match crate::host::devql::prepare_sync_execution_schema(
+            &cfg,
+            "queued DevQL sync",
+            &requested_mode,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                self.finish_task_failed(&task.task_id, err)?;
+                return Ok(());
+            }
+        };
+        let effective_mode = crate::host::devql::effective_sync_mode_after_schema_preparation(
+            requested_mode,
+            schema_outcome,
+        );
+        let effective_spec = sync_task_mode_from_host(&effective_mode);
+        if task.sync_spec().is_none_or(|spec| spec.mode != effective_spec) {
+            self.update_sync_mode(&task.task_id, effective_spec)?;
+        }
+
+        let observer = SyncCoordinatorObserver {
+            coordinator: Arc::clone(&self),
+            task_id: task.task_id.clone(),
+            progress_state: Mutex::new(ProgressPersistState::default()),
+        };
+
+        let host = match crate::host::devql::build_capability_host(&cfg.repo_root, cfg.repo.clone())
+        {
+            Ok(host) => Some(host),
+            Err(err) => {
+                log::warn!(
+                    "failed to build capability host for sync event dispatch (task_id={}): {err:#}",
+                    task.task_id
+                );
+                None
+            }
+        };
+
+        match crate::host::devql::run_sync_with_summary_and_observer_and_diffs(
+            &cfg,
+            effective_mode,
+            Some(&observer),
+        )
+        .await
+        {
+            Ok((summary, file_diff, artefact_diff)) => {
+                if let Some(host) = host.as_ref() {
+                    let capability_event_coordinator =
+                        crate::daemon::shared_capability_event_coordinator();
+                    capability_event_coordinator.activate_worker();
+                    if let Err(err) = enqueue_sync_completed_runs(
+                        capability_event_coordinator.as_ref(),
+                        host,
+                        &cfg,
+                        &summary,
+                        file_diff,
+                        artefact_diff,
+                    ) {
+                        log::warn!(
+                            "failed to enqueue sync capability event runs (task_id={}): {err:#}",
+                            task.task_id
+                        );
+                    }
+                }
+                self.finish_sync_task_completed(&task.task_id, summary)?
+            }
+            Err(err) => self.finish_task_failed(&task.task_id, err)?,
+        }
+
+        Ok(())
+    }
+
+    async fn run_ingest_task(self: Arc<Self>, task: DevqlTaskRecord) -> Result<()> {
+        let repo = RepoIdentity {
+            repo_id: task.repo_id.clone(),
+            name: task.repo_name.clone(),
+            provider: task.repo_provider.clone(),
+            organization: task.repo_organisation.clone(),
+            identity: task.repo_identity.clone(),
+        };
+        let cfg = DevqlConfig::from_roots(
+            task.daemon_config_root.clone(),
+            task.repo_root.clone(),
+            repo,
+        )?;
+        let observer = IngestCoordinatorObserver {
+            coordinator: Arc::clone(&self),
+            task_id: task.task_id.clone(),
+            repo_name: task.repo_name.clone(),
+            progress_state: Mutex::new(ProgressPersistState::default()),
+        };
+        let backfill = task.ingest_spec().and_then(|spec| spec.backfill);
+
+        let result = match backfill {
+            Some(backfill) => {
+                crate::host::devql::execute_ingest_with_backfill_window(
+                    &cfg,
+                    false,
+                    backfill,
+                    Some(&observer),
+                    Some(crate::daemon::shared_enrichment_coordinator()),
+                )
+                .await
+            }
+            None => {
+                crate::host::devql::execute_ingest_with_observer(
+                    &cfg,
+                    false,
+                    0,
+                    Some(&observer),
+                    Some(crate::daemon::shared_enrichment_coordinator()),
+                )
+                .await
+            }
+        };
+
+        match result {
+            Ok(summary) => self.finish_ingest_task_completed(&task.task_id, summary)?,
+            Err(err) => self.finish_task_failed(&task.task_id, err)?,
+        }
+        Ok(())
+    }
+
+    fn update_sync_mode(&self, task_id: &str, mode: SyncTaskMode) -> Result<()> {
+        let task_id = task_id.to_string();
+        self.mutate_state(|state| {
+            let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
+                return Ok(());
+            };
+            if let Some(spec) = sync_spec_from_task_spec_mut(&mut task.spec) {
+                spec.mode = mode;
+            }
+            task.updated_at_unix = unix_timestamp_now();
+            state.last_action = Some("mode_updated".to_string());
+            Ok(())
+        })
+        .map(|_: ()| ())
+    }
+
+    pub(super) fn recover_running_tasks(&self) -> Result<()> {
+        self.mutate_state(|state| {
+            for task in &mut state.tasks {
+                if task.status == DevqlTaskStatus::Running {
+                    task.status = DevqlTaskStatus::Queued;
+                    task.progress = default_progress_for_spec(&task.spec);
+                    task.error = None;
+                    task.result = None;
+                    task.started_at_unix = None;
+                    task.completed_at_unix = None;
+                    task.updated_at_unix = unix_timestamp_now();
+                }
+            }
+            state.last_action = Some("recovered_running_tasks".to_string());
+            Ok(())
+        })
+        .map(|_: ()| ())
+    }
+
+    fn update_task_progress(&self, task_id: &str, update: DevqlTaskProgress) -> Result<()> {
+        let task_id = task_id.to_string();
+        self.mutate_state(|state| {
+            let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
+                return Ok(());
+            };
+            task.progress = update.clone();
+            task.updated_at_unix = unix_timestamp_now();
+            state.last_action = Some(progress_action(&update));
+            Ok(())
+        })
+        .map(|_: ()| ())
+    }
+
+    fn finish_sync_task_completed(&self, task_id: &str, summary: SyncSummary) -> Result<()> {
+        let task_id = task_id.to_string();
+        self.mutate_state(|state| {
+            let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
+                return Ok(());
+            };
+            let now = unix_timestamp_now();
+            task.status = DevqlTaskStatus::Completed;
+            task.updated_at_unix = now;
+            task.completed_at_unix = Some(now);
+            task.error = None;
+            task.result = Some(DevqlTaskResult::Sync(summary.clone()));
+            task.progress = DevqlTaskProgress::Sync(sync_progress_from_summary(&summary));
+            state.last_action = Some("completed".to_string());
+            Ok(())
+        })
+        .map(|_: ()| ())
+    }
+
+    fn finish_ingest_task_completed(&self, task_id: &str, summary: IngestionCounters) -> Result<()> {
+        let task_id = task_id.to_string();
+        self.mutate_state(|state| {
+            let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
+                return Ok(());
+            };
+            let now = unix_timestamp_now();
+            task.status = DevqlTaskStatus::Completed;
+            task.updated_at_unix = now;
+            task.completed_at_unix = Some(now);
+            task.error = None;
+            task.result = Some(DevqlTaskResult::Ingest(summary.clone()));
+            task.progress = DevqlTaskProgress::Ingest(ingest_progress_from_summary(&summary));
+            state.last_action = Some("completed".to_string());
+            Ok(())
+        })
+        .map(|_: ()| ())
+    }
+
+    fn finish_task_failed(&self, task_id: &str, err: anyhow::Error) -> Result<()> {
+        let task_id = task_id.to_string();
+        let error = format!("{err:#}");
+        self.mutate_state(|state| {
+            let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
+                return Ok(());
+            };
+            let now = unix_timestamp_now();
+            task.status = DevqlTaskStatus::Failed;
+            task.updated_at_unix = now;
+            task.completed_at_unix = Some(now);
+            task.error = Some(error.clone());
+            task.result = None;
+            task.progress = failed_progress(&task.progress);
+            state.last_action = Some("failed".to_string());
+            Ok(())
+        })
+        .map(|_: ()| ())
+    }
+
+    fn load_state(&self) -> Result<PersistedDevqlTaskQueueState> {
+        Ok(self
+            .runtime_store
+            .load_devql_task_queue_state()?
+            .unwrap_or_else(PersistedDevqlTaskQueueState::default))
+    }
+
+    fn mutate_state<T>(
+        &self,
+        mutate: impl FnOnce(&mut PersistedDevqlTaskQueueState) -> Result<T>,
+    ) -> Result<T> {
+        let guard = self
+            .lock
+            .lock()
+            .map_err(|_| anyhow!("DevQL task coordinator lock poisoned"))?;
+        let (result, tasks_to_publish) = self.runtime_store.mutate_devql_task_queue_state(|state| {
+            let previous_tasks = state.tasks.clone();
+            let result = mutate(state)?;
+            let tasks_to_publish = Self::save_state(state, &previous_tasks)?;
+            Ok((result, tasks_to_publish))
+        })?;
+        drop(guard);
+        self.publish_tasks(tasks_to_publish);
+        self.notify.notify_waiters();
+        Ok(result)
+    }
+
+    fn save_state(
+        state: &mut PersistedDevqlTaskQueueState,
+        previous_tasks: &[DevqlTaskRecord],
+    ) -> Result<Vec<DevqlTaskRecord>> {
+        state.version = 1;
+        state.updated_at_unix = unix_timestamp_now();
+        recompute_queue_positions(&mut state.tasks);
+        prune_terminal_tasks(&mut state.tasks);
+        Ok(changed_tasks(previous_tasks, &state.tasks))
+    }
+
+    fn publish_tasks(&self, tasks: Vec<DevqlTaskRecord>) {
+        let Some(hub) = self
+            .subscription_hub
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone())
+        else {
+            return;
+        };
+        for task in tasks {
+            hub.publish_task(task);
+        }
+    }
+
+    fn publish_checkpoint(&self, repo_name: String, checkpoint: Checkpoint) {
+        let Some(hub) = self
+            .subscription_hub
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone())
+        else {
+            return;
+        };
+        hub.publish_checkpoint(repo_name, checkpoint);
+    }
+}
+
+fn task_kind_from_spec(spec: &DevqlTaskSpec) -> DevqlTaskKind {
+    match spec {
+        DevqlTaskSpec::Sync(_) => DevqlTaskKind::Sync,
+        DevqlTaskSpec::Ingest(_) => DevqlTaskKind::Ingest,
+    }
+}
+
+fn progress_action(update: &DevqlTaskProgress) -> String {
+    match update {
+        DevqlTaskProgress::Sync(update) => update.phase.as_str().to_string(),
+        DevqlTaskProgress::Ingest(update) => match update.phase {
+            IngestionProgressPhase::Initializing => "initializing".to_string(),
+            IngestionProgressPhase::Extracting => "extracting".to_string(),
+            IngestionProgressPhase::Persisting => "persisting".to_string(),
+            IngestionProgressPhase::Complete => "complete".to_string(),
+            IngestionProgressPhase::Failed => "failed".to_string(),
+        },
+    }
+}
+
+fn enqueue_sync_completed_runs(
+    coordinator: &crate::daemon::CapabilityEventCoordinator,
+    host: &crate::host::capability_host::DevqlCapabilityHost,
+    cfg: &DevqlConfig,
+    summary: &SyncSummary,
+    file_diff: SyncFileDiff,
+    artefact_diff: SyncArtefactDiff,
+) -> Result<usize> {
+    if !summary.success || summary.mode == "validate" {
+        return Ok(0);
+    }
+
+    let payload = SyncCompletedPayload {
+        repo_id: cfg.repo.repo_id.clone(),
+        repo_root: cfg.repo_root.clone(),
+        active_branch: summary.active_branch.clone(),
+        head_commit_sha: summary.head_commit_sha.clone(),
+        sync_mode: summary.mode.clone(),
+        sync_completed_at: chrono::Utc::now().to_rfc3339(),
+        files: file_diff,
+        artefacts: artefact_diff,
+    };
+    let runs = crate::daemon::capability_events::build_sync_completed_runs(host, &payload)?;
+    if runs.is_empty() {
+        return Ok(0);
+    }
+    let run_count = runs.len();
+    coordinator.enqueue_runs(runs)?;
+    Ok(run_count)
+}
+
+fn should_persist_progress<T: PartialEq>(
+    previous: Option<&T>,
+    update: &T,
+    last_persisted_at: Option<Instant>,
+    now: Instant,
+) -> bool {
+    let Some(previous) = previous else {
+        return true;
+    };
+
+    let interval_elapsed = last_persisted_at
+        .is_none_or(|timestamp| now.duration_since(timestamp) >= PROGRESS_PERSIST_INTERVAL);
+    interval_elapsed && previous != update
+}
+
+fn sync_spec_from_task_spec_mut(spec: &mut DevqlTaskSpec) -> Option<&mut SyncTaskSpec> {
+    match spec {
+        DevqlTaskSpec::Sync(spec) => Some(spec),
+        DevqlTaskSpec::Ingest(_) => None,
+    }
+}

--- a/bitloops/src/daemon/tasks/coordinator.rs
+++ b/bitloops/src/daemon/tasks/coordinator.rs
@@ -11,8 +11,8 @@ use crate::graphql::{Checkpoint, SubscriptionHub};
 use crate::host::capability_host::{SyncArtefactDiff, SyncCompletedPayload, SyncFileDiff};
 use crate::host::devql::{
     DevqlConfig, IngestedCheckpointNotification, IngestionCounters, IngestionObserver,
-    IngestionProgressPhase, IngestionProgressUpdate, RepoIdentity, SyncObserver,
-    SyncProgressPhase, SyncProgressUpdate, SyncSummary,
+    IngestionProgressPhase, IngestionProgressUpdate, RepoIdentity, SyncObserver, SyncProgressPhase,
+    SyncProgressUpdate, SyncSummary,
 };
 #[cfg(test)]
 use crate::utils::paths::default_global_runtime_db_path;
@@ -504,7 +504,10 @@ impl DevqlTaskCoordinator {
             schema_outcome,
         );
         let effective_spec = sync_task_mode_from_host(&effective_mode);
-        if task.sync_spec().is_none_or(|spec| spec.mode != effective_spec) {
+        if task
+            .sync_spec()
+            .is_none_or(|spec| spec.mode != effective_spec)
+        {
             self.update_sync_mode(&task.task_id, effective_spec)?;
         }
 
@@ -671,7 +674,7 @@ impl DevqlTaskCoordinator {
             task.updated_at_unix = now;
             task.completed_at_unix = Some(now);
             task.error = None;
-            task.result = Some(DevqlTaskResult::Sync(summary.clone()));
+            task.result = Some(DevqlTaskResult::Sync(Box::new(summary.clone())));
             task.progress = DevqlTaskProgress::Sync(sync_progress_from_summary(&summary));
             state.last_action = Some("completed".to_string());
             Ok(())
@@ -679,7 +682,11 @@ impl DevqlTaskCoordinator {
         .map(|_: ()| ())
     }
 
-    fn finish_ingest_task_completed(&self, task_id: &str, summary: IngestionCounters) -> Result<()> {
+    fn finish_ingest_task_completed(
+        &self,
+        task_id: &str,
+        summary: IngestionCounters,
+    ) -> Result<()> {
         let task_id = task_id.to_string();
         self.mutate_state(|state| {
             let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
@@ -733,12 +740,13 @@ impl DevqlTaskCoordinator {
             .lock
             .lock()
             .map_err(|_| anyhow!("DevQL task coordinator lock poisoned"))?;
-        let (result, tasks_to_publish) = self.runtime_store.mutate_devql_task_queue_state(|state| {
-            let previous_tasks = state.tasks.clone();
-            let result = mutate(state)?;
-            let tasks_to_publish = Self::save_state(state, &previous_tasks)?;
-            Ok((result, tasks_to_publish))
-        })?;
+        let (result, tasks_to_publish) =
+            self.runtime_store.mutate_devql_task_queue_state(|state| {
+                let previous_tasks = state.tasks.clone();
+                let result = mutate(state)?;
+                let tasks_to_publish = Self::save_state(state, &previous_tasks)?;
+                Ok((result, tasks_to_publish))
+            })?;
         drop(guard);
         self.publish_tasks(tasks_to_publish);
         self.notify.notify_waiters();

--- a/bitloops/src/daemon/tasks/queue.rs
+++ b/bitloops/src/daemon/tasks/queue.rs
@@ -1,0 +1,489 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::host::devql::{
+    DevqlConfig, IngestionCounters, IngestionProgressPhase, IngestionProgressUpdate, SyncMode,
+    SyncProgressPhase, SyncProgressUpdate, SyncSummary,
+};
+
+use super::super::types::{
+    DevqlTaskKind, DevqlTaskKindCounts, DevqlTaskProgress, DevqlTaskQueueState,
+    DevqlTaskQueueStatus, DevqlTaskRecord, DevqlTaskSource, DevqlTaskSpec, DevqlTaskStatus,
+    SyncTaskMode, SyncTaskSpec, unix_timestamp_now,
+};
+use super::state::PersistedDevqlTaskQueueState;
+
+const MAX_TERMINAL_TASKS: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TaskLaneKey {
+    repo_id: String,
+    kind: DevqlTaskKind,
+}
+
+pub(super) fn changed_tasks(
+    previous: &[DevqlTaskRecord],
+    current: &[DevqlTaskRecord],
+) -> Vec<DevqlTaskRecord> {
+    let previous_by_id = previous
+        .iter()
+        .map(|task| (task.task_id.as_str(), task))
+        .collect::<HashMap<_, _>>();
+    current
+        .iter()
+        .filter(|task| {
+            previous_by_id
+                .get(task.task_id.as_str())
+                .is_none_or(|previous| *previous != *task)
+        })
+        .cloned()
+        .collect()
+}
+
+pub(super) fn merge_existing_task(
+    state: &mut PersistedDevqlTaskQueueState,
+    cfg: &DevqlConfig,
+    _source: DevqlTaskSource,
+    kind: DevqlTaskKind,
+    spec: &DevqlTaskSpec,
+) -> Option<DevqlTaskRecord> {
+    if kind == DevqlTaskKind::Ingest {
+        if let Some(existing) = state.tasks.iter_mut().find(|task| {
+            task.repo_id == cfg.repo.repo_id
+                && task.kind == DevqlTaskKind::Ingest
+                && matches!(task.status, DevqlTaskStatus::Queued | DevqlTaskStatus::Running)
+                && task.spec == *spec
+        }) {
+            existing.updated_at_unix = unix_timestamp_now();
+            existing.error = None;
+            return Some(existing.clone());
+        }
+        return None;
+    }
+
+    let mode = sync_spec_from_task_spec(spec).map(|spec| &spec.mode)?;
+    if *mode != SyncTaskMode::Validate
+        && let Some(existing) = state.tasks.iter_mut().find(|task| {
+            task.repo_id == cfg.repo.repo_id
+                && task.kind == DevqlTaskKind::Sync
+                && matches!(task.status, DevqlTaskStatus::Queued | DevqlTaskStatus::Running)
+                && sync_spec_from_task_spec(&task.spec).is_some_and(|existing_spec| match (
+                    &existing_spec.mode,
+                    mode,
+                ) {
+                    (SyncTaskMode::Repair, _) => true,
+                    (existing_mode, incoming_mode)
+                        if is_full_like(existing_mode) && is_weaker_than_repair(incoming_mode) =>
+                    {
+                        true
+                    }
+                    _ => false,
+                })
+        })
+    {
+        existing.updated_at_unix = unix_timestamp_now();
+        existing.error = None;
+        return Some(existing.clone());
+    }
+
+    if let SyncTaskMode::Paths { paths } = mode
+        && let Some(existing) = state.tasks.iter_mut().find(|task| {
+            task.repo_id == cfg.repo.repo_id
+                && task.kind == DevqlTaskKind::Sync
+                && task.status == DevqlTaskStatus::Queued
+                && sync_spec_from_task_spec(&task.spec)
+                    .is_some_and(|existing| matches!(existing.mode, SyncTaskMode::Paths { .. }))
+        })
+    {
+        if let Some(SyncTaskSpec {
+            mode: SyncTaskMode::Paths {
+                paths: existing_paths,
+            },
+        }) = sync_spec_from_task_spec_mut(&mut existing.spec)
+        {
+            existing_paths.extend(paths.iter().cloned());
+            existing_paths.sort();
+            existing_paths.dedup();
+        }
+        existing.updated_at_unix = unix_timestamp_now();
+        existing.error = None;
+        return Some(existing.clone());
+    }
+
+    None
+}
+
+pub(super) fn next_runnable_task_indexes(state: &PersistedDevqlTaskQueueState) -> Vec<usize> {
+    let paused_repo_ids = state
+        .repo_controls
+        .iter()
+        .filter(|(_, control)| control.paused)
+        .map(|(repo_id, _)| repo_id.as_str())
+        .collect::<HashSet<_>>();
+    let running_lanes = state
+        .tasks
+        .iter()
+        .filter(|task| task.status == DevqlTaskStatus::Running)
+        .map(task_lane)
+        .collect::<HashSet<_>>();
+
+    let mut selected = HashMap::<TaskLaneKey, (usize, (u8, u64, usize))>::new();
+    for (index, task) in state.tasks.iter().enumerate() {
+        if task.status != DevqlTaskStatus::Queued || paused_repo_ids.contains(task.repo_id.as_str())
+        {
+            continue;
+        }
+        let lane = task_lane(task);
+        if running_lanes.contains(&lane) {
+            continue;
+        }
+        let key = pending_sort_key(index, task);
+        selected
+            .entry(lane)
+            .and_modify(|(existing_index, existing_key)| {
+                if key < *existing_key {
+                    *existing_index = index;
+                    *existing_key = key;
+                }
+            })
+            .or_insert((index, key));
+    }
+
+    let mut selected = selected.into_values().collect::<Vec<_>>();
+    selected.sort_by(|(_, left), (_, right)| left.cmp(right));
+    selected.into_iter().map(|(index, _)| index).collect()
+}
+
+fn pending_sort_key(index: usize, task: &DevqlTaskRecord) -> (u8, u64, usize) {
+    (
+        if task.kind == DevqlTaskKind::Sync
+            && task
+                .sync_spec()
+                .is_some_and(|spec| matches!(spec.mode, SyncTaskMode::Validate))
+        {
+            1
+        } else {
+            0
+        },
+        task.submitted_at_unix,
+        index,
+    )
+}
+
+pub(super) fn recompute_queue_positions(tasks: &mut [DevqlTaskRecord]) {
+    for task in tasks.iter_mut() {
+        task.queue_position = None;
+        task.tasks_ahead = None;
+    }
+
+    let lanes = tasks
+        .iter()
+        .filter(|task| matches!(task.status, DevqlTaskStatus::Running | DevqlTaskStatus::Queued))
+        .map(task_lane)
+        .collect::<HashSet<_>>();
+
+    for lane in lanes {
+        let mut order = tasks
+            .iter()
+            .enumerate()
+            .filter(|(_, task)| {
+                task.repo_id == lane.repo_id
+                    && task.kind == lane.kind
+                    && matches!(task.status, DevqlTaskStatus::Running | DevqlTaskStatus::Queued)
+            })
+            .map(|(index, task)| {
+                (
+                    index,
+                    task.status == DevqlTaskStatus::Running,
+                    pending_sort_key(index, task),
+                )
+            })
+            .collect::<Vec<_>>();
+        order.sort_by(|(_, left_running, left_key), (_, right_running, right_key)| {
+            left_running
+                .cmp(right_running)
+                .reverse()
+                .then_with(|| left_key.cmp(right_key))
+        });
+
+        for (index, (task_index, _, _)) in order.into_iter().enumerate() {
+            let position = (index as u64) + 1;
+            tasks[task_index].queue_position = Some(position);
+            tasks[task_index].tasks_ahead = Some(position.saturating_sub(1));
+        }
+    }
+}
+
+pub(super) fn prune_terminal_tasks(tasks: &mut Vec<DevqlTaskRecord>) {
+    let mut terminal = tasks
+        .iter()
+        .filter(|task| {
+            matches!(
+                task.status,
+                DevqlTaskStatus::Completed | DevqlTaskStatus::Failed | DevqlTaskStatus::Cancelled
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    terminal.sort_by(|left, right| right.updated_at_unix.cmp(&left.updated_at_unix));
+    terminal.truncate(MAX_TERMINAL_TASKS);
+
+    let terminal_ids = terminal
+        .into_iter()
+        .map(|task| task.task_id)
+        .collect::<HashSet<_>>();
+    tasks.retain(|task| {
+        !matches!(
+            task.status,
+            DevqlTaskStatus::Completed | DevqlTaskStatus::Failed | DevqlTaskStatus::Cancelled
+        ) || terminal_ids.contains(&task.task_id)
+    });
+}
+
+pub(super) fn project_status(
+    state: &PersistedDevqlTaskQueueState,
+    repo_id: Option<&str>,
+    persisted: bool,
+) -> DevqlTaskQueueStatus {
+    let queued_tasks = state
+        .tasks
+        .iter()
+        .filter(|task| task.status == DevqlTaskStatus::Queued)
+        .count() as u64;
+    let running_tasks = state
+        .tasks
+        .iter()
+        .filter(|task| task.status == DevqlTaskStatus::Running)
+        .count() as u64;
+    let failed_tasks = state
+        .tasks
+        .iter()
+        .filter(|task| task.status == DevqlTaskStatus::Failed)
+        .count() as u64;
+    let completed_recent_tasks = state
+        .tasks
+        .iter()
+        .filter(|task| task.status == DevqlTaskStatus::Completed)
+        .count() as u64;
+
+    DevqlTaskQueueStatus {
+        state: DevqlTaskQueueState {
+            version: state.version,
+            queued_tasks,
+            running_tasks,
+            failed_tasks,
+            completed_recent_tasks,
+            by_kind: counts_by_kind(&state.tasks),
+            last_action: state.last_action.clone(),
+            last_updated_unix: state.updated_at_unix,
+        },
+        persisted,
+        current_repo_tasks: repo_id
+            .map(|repo_id| select_repo_tasks(&state.tasks, repo_id))
+            .unwrap_or_default(),
+        current_repo_control: repo_id.and_then(|repo_id| state.repo_controls.get(repo_id).cloned()),
+    }
+}
+
+fn counts_by_kind(tasks: &[DevqlTaskRecord]) -> Vec<DevqlTaskKindCounts> {
+    let mut counts = HashMap::<DevqlTaskKind, DevqlTaskKindCounts>::new();
+    for kind in [DevqlTaskKind::Sync, DevqlTaskKind::Ingest] {
+        counts.insert(
+            kind,
+            DevqlTaskKindCounts {
+                kind,
+                queued_tasks: 0,
+                running_tasks: 0,
+                failed_tasks: 0,
+                completed_recent_tasks: 0,
+            },
+        );
+    }
+
+    for task in tasks {
+        let entry = counts.get_mut(&task.kind).expect("kind counts initialised");
+        match task.status {
+            DevqlTaskStatus::Queued => entry.queued_tasks += 1,
+            DevqlTaskStatus::Running => entry.running_tasks += 1,
+            DevqlTaskStatus::Failed => entry.failed_tasks += 1,
+            DevqlTaskStatus::Completed => entry.completed_recent_tasks += 1,
+            DevqlTaskStatus::Cancelled => {}
+        }
+    }
+
+    let mut counts = counts.into_values().collect::<Vec<_>>();
+    counts.sort_by_key(|entry| entry.kind);
+    counts
+}
+
+fn select_repo_tasks(tasks: &[DevqlTaskRecord], repo_id: &str) -> Vec<DevqlTaskRecord> {
+    [DevqlTaskKind::Sync, DevqlTaskKind::Ingest]
+        .into_iter()
+        .filter_map(|kind| select_repo_task(tasks, repo_id, kind))
+        .collect()
+}
+
+fn select_repo_task(
+    tasks: &[DevqlTaskRecord],
+    repo_id: &str,
+    kind: DevqlTaskKind,
+) -> Option<DevqlTaskRecord> {
+    tasks
+        .iter()
+        .filter(|task| {
+            task.repo_id == repo_id && task.kind == kind && task.status == DevqlTaskStatus::Running
+        })
+        .max_by_key(|task| task.updated_at_unix)
+        .cloned()
+        .or_else(|| {
+            tasks
+                .iter()
+                .filter(|task| {
+                    task.repo_id == repo_id
+                        && task.kind == kind
+                        && task.status == DevqlTaskStatus::Queued
+                })
+                .min_by_key(|task| task.queue_position.unwrap_or(u64::MAX))
+                .cloned()
+        })
+        .or_else(|| {
+            tasks
+                .iter()
+                .filter(|task| task.repo_id == repo_id && task.kind == kind)
+                .max_by_key(|task| task.updated_at_unix)
+                .cloned()
+        })
+}
+
+pub(super) fn sync_task_mode_from_host(mode: &SyncMode) -> SyncTaskMode {
+    match mode {
+        SyncMode::Auto => SyncTaskMode::Auto,
+        SyncMode::Full => SyncTaskMode::Full,
+        SyncMode::Paths(paths) => SyncTaskMode::Paths {
+            paths: normalize_paths(paths),
+        },
+        SyncMode::Repair => SyncTaskMode::Repair,
+        SyncMode::Validate => SyncTaskMode::Validate,
+    }
+}
+
+pub(super) fn sync_task_mode_to_host(mode: &SyncTaskMode) -> SyncMode {
+    match mode {
+        SyncTaskMode::Auto => SyncMode::Auto,
+        SyncTaskMode::Full => SyncMode::Full,
+        SyncTaskMode::Paths { paths } => SyncMode::Paths(paths.clone()),
+        SyncTaskMode::Repair => SyncMode::Repair,
+        SyncTaskMode::Validate => SyncMode::Validate,
+    }
+}
+
+pub(super) fn sync_progress_from_summary(summary: &SyncSummary) -> SyncProgressUpdate {
+    let total = summary.paths_unchanged
+        + summary.paths_added
+        + summary.paths_changed
+        + summary.paths_removed;
+    SyncProgressUpdate {
+        phase: SyncProgressPhase::Complete,
+        current_path: None,
+        paths_total: total,
+        paths_completed: total,
+        paths_remaining: 0,
+        paths_unchanged: summary.paths_unchanged,
+        paths_added: summary.paths_added,
+        paths_changed: summary.paths_changed,
+        paths_removed: summary.paths_removed,
+        cache_hits: summary.cache_hits,
+        cache_misses: summary.cache_misses,
+        parse_errors: summary.parse_errors,
+    }
+}
+
+pub(super) fn ingest_progress_from_summary(summary: &IngestionCounters) -> IngestionProgressUpdate {
+    IngestionProgressUpdate {
+        phase: IngestionProgressPhase::Complete,
+        commits_total: summary.commits_processed,
+        commits_processed: summary.commits_processed,
+        current_checkpoint_id: None,
+        current_commit_sha: None,
+        counters: summary.clone(),
+    }
+}
+
+pub(super) fn default_progress_for_spec(spec: &DevqlTaskSpec) -> DevqlTaskProgress {
+    match spec {
+        DevqlTaskSpec::Sync(_) => DevqlTaskProgress::Sync(SyncProgressUpdate::default()),
+        DevqlTaskSpec::Ingest(_) => DevqlTaskProgress::Ingest(IngestionProgressUpdate {
+            phase: IngestionProgressPhase::Initializing,
+            commits_total: 0,
+            commits_processed: 0,
+            current_checkpoint_id: None,
+            current_commit_sha: None,
+            counters: IngestionCounters::default(),
+        }),
+    }
+}
+
+pub(super) fn failed_progress(progress: &DevqlTaskProgress) -> DevqlTaskProgress {
+    match progress {
+        DevqlTaskProgress::Sync(progress) => {
+            let mut progress = progress.clone();
+            progress.phase = SyncProgressPhase::Failed;
+            DevqlTaskProgress::Sync(progress)
+        }
+        DevqlTaskProgress::Ingest(progress) => {
+            let mut progress = progress.clone();
+            progress.phase = IngestionProgressPhase::Failed;
+            DevqlTaskProgress::Ingest(progress)
+        }
+    }
+}
+
+pub(super) fn sync_spec_from_task_spec(spec: &DevqlTaskSpec) -> Option<&SyncTaskSpec> {
+    match spec {
+        DevqlTaskSpec::Sync(spec) => Some(spec),
+        DevqlTaskSpec::Ingest(_) => None,
+    }
+}
+
+fn sync_spec_from_task_spec_mut(spec: &mut DevqlTaskSpec) -> Option<&mut SyncTaskSpec> {
+    match spec {
+        DevqlTaskSpec::Sync(spec) => Some(spec),
+        DevqlTaskSpec::Ingest(_) => None,
+    }
+}
+
+fn normalize_paths(paths: &[String]) -> Vec<String> {
+    let mut paths = paths
+        .iter()
+        .map(|path| normalize_repo_path(path))
+        .filter(|path| !path.is_empty())
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn normalize_repo_path(path: &str) -> String {
+    let mut normalized = path.trim().replace('\\', "/");
+    while normalized.starts_with("./") {
+        normalized = normalized[2..].to_string();
+    }
+    normalized.trim_start_matches('/').to_string()
+}
+
+fn is_full_like(mode: &SyncTaskMode) -> bool {
+    matches!(mode, SyncTaskMode::Auto | SyncTaskMode::Full)
+}
+
+fn is_weaker_than_repair(mode: &SyncTaskMode) -> bool {
+    matches!(
+        mode,
+        SyncTaskMode::Auto | SyncTaskMode::Full | SyncTaskMode::Paths { .. }
+    )
+}
+
+fn task_lane(task: &DevqlTaskRecord) -> TaskLaneKey {
+    TaskLaneKey {
+        repo_id: task.repo_id.clone(),
+        kind: task.kind,
+    }
+}

--- a/bitloops/src/daemon/tasks/queue.rs
+++ b/bitloops/src/daemon/tasks/queue.rs
@@ -50,7 +50,10 @@ pub(super) fn merge_existing_task(
         if let Some(existing) = state.tasks.iter_mut().find(|task| {
             task.repo_id == cfg.repo.repo_id
                 && task.kind == DevqlTaskKind::Ingest
-                && matches!(task.status, DevqlTaskStatus::Queued | DevqlTaskStatus::Running)
+                && matches!(
+                    task.status,
+                    DevqlTaskStatus::Queued | DevqlTaskStatus::Running
+                )
                 && task.spec == *spec
         }) {
             existing.updated_at_unix = unix_timestamp_now();
@@ -65,18 +68,21 @@ pub(super) fn merge_existing_task(
         && let Some(existing) = state.tasks.iter_mut().find(|task| {
             task.repo_id == cfg.repo.repo_id
                 && task.kind == DevqlTaskKind::Sync
-                && matches!(task.status, DevqlTaskStatus::Queued | DevqlTaskStatus::Running)
-                && sync_spec_from_task_spec(&task.spec).is_some_and(|existing_spec| match (
-                    &existing_spec.mode,
-                    mode,
-                ) {
-                    (SyncTaskMode::Repair, _) => true,
-                    (existing_mode, incoming_mode)
-                        if is_full_like(existing_mode) && is_weaker_than_repair(incoming_mode) =>
-                    {
-                        true
+                && matches!(
+                    task.status,
+                    DevqlTaskStatus::Queued | DevqlTaskStatus::Running
+                )
+                && sync_spec_from_task_spec(&task.spec).is_some_and(|existing_spec| {
+                    match (&existing_spec.mode, mode) {
+                        (SyncTaskMode::Repair, _) => true,
+                        (existing_mode, incoming_mode)
+                            if is_full_like(existing_mode)
+                                && is_weaker_than_repair(incoming_mode) =>
+                        {
+                            true
+                        }
+                        _ => false,
                     }
-                    _ => false,
                 })
         })
     {
@@ -177,7 +183,12 @@ pub(super) fn recompute_queue_positions(tasks: &mut [DevqlTaskRecord]) {
 
     let lanes = tasks
         .iter()
-        .filter(|task| matches!(task.status, DevqlTaskStatus::Running | DevqlTaskStatus::Queued))
+        .filter(|task| {
+            matches!(
+                task.status,
+                DevqlTaskStatus::Running | DevqlTaskStatus::Queued
+            )
+        })
         .map(task_lane)
         .collect::<HashSet<_>>();
 
@@ -188,7 +199,10 @@ pub(super) fn recompute_queue_positions(tasks: &mut [DevqlTaskRecord]) {
             .filter(|(_, task)| {
                 task.repo_id == lane.repo_id
                     && task.kind == lane.kind
-                    && matches!(task.status, DevqlTaskStatus::Running | DevqlTaskStatus::Queued)
+                    && matches!(
+                        task.status,
+                        DevqlTaskStatus::Running | DevqlTaskStatus::Queued
+                    )
             })
             .map(|(index, task)| {
                 (
@@ -198,12 +212,14 @@ pub(super) fn recompute_queue_positions(tasks: &mut [DevqlTaskRecord]) {
                 )
             })
             .collect::<Vec<_>>();
-        order.sort_by(|(_, left_running, left_key), (_, right_running, right_key)| {
-            left_running
-                .cmp(right_running)
-                .reverse()
-                .then_with(|| left_key.cmp(right_key))
-        });
+        order.sort_by(
+            |(_, left_running, left_key), (_, right_running, right_key)| {
+                left_running
+                    .cmp(right_running)
+                    .reverse()
+                    .then_with(|| left_key.cmp(right_key))
+            },
+        );
 
         for (index, (task_index, _, _)) in order.into_iter().enumerate() {
             let position = (index as u64) + 1;

--- a/bitloops/src/daemon/tasks/state.rs
+++ b/bitloops/src/daemon/tasks/state.rs
@@ -1,0 +1,2 @@
+pub(super) type PersistedDevqlTaskQueueState =
+    crate::host::runtime_store::PersistedDevqlTaskQueueState;

--- a/bitloops/src/daemon/types.rs
+++ b/bitloops/src/daemon/types.rs
@@ -371,9 +371,25 @@ pub struct CapabilityEventQueueStatus {
     pub current_repo_run: Option<CapabilityEventRunRecord>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum DevqlTaskKind {
+    Sync,
+    Ingest,
+}
+
+impl fmt::Display for DevqlTaskKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sync => write!(f, "sync"),
+            Self::Ingest => write!(f, "ingest"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum SyncTaskSource {
+pub enum DevqlTaskSource {
     Init,
     ManualCli,
     Watcher,
@@ -382,7 +398,7 @@ pub enum SyncTaskSource {
     PostCheckout,
 }
 
-impl fmt::Display for SyncTaskSource {
+impl fmt::Display for DevqlTaskSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Init => write!(f, "init"),
@@ -419,7 +435,7 @@ impl fmt::Display for SyncTaskMode {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum SyncTaskStatus {
+pub enum DevqlTaskStatus {
     Queued,
     Running,
     Completed,
@@ -427,7 +443,7 @@ pub enum SyncTaskStatus {
     Cancelled,
 }
 
-impl fmt::Display for SyncTaskStatus {
+impl fmt::Display for DevqlTaskStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Queued => write!(f, "queued"),
@@ -440,7 +456,38 @@ impl fmt::Display for SyncTaskStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SyncTaskRecord {
+pub struct SyncTaskSpec {
+    pub mode: SyncTaskMode,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IngestTaskSpec {
+    pub backfill: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum DevqlTaskSpec {
+    Sync(SyncTaskSpec),
+    Ingest(IngestTaskSpec),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum DevqlTaskProgress {
+    Sync(crate::host::devql::SyncProgressUpdate),
+    Ingest(crate::host::devql::IngestionProgressUpdate),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum DevqlTaskResult {
+    Sync(crate::host::devql::SyncSummary),
+    Ingest(crate::host::devql::IngestionCounters),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DevqlTaskRecord {
     pub task_id: String,
     pub repo_id: String,
     pub repo_name: String,
@@ -450,47 +497,109 @@ pub struct SyncTaskRecord {
     #[serde(alias = "config_root", default)]
     pub daemon_config_root: PathBuf,
     pub repo_root: PathBuf,
-    pub source: SyncTaskSource,
-    pub mode: SyncTaskMode,
-    pub status: SyncTaskStatus,
+    pub kind: DevqlTaskKind,
+    pub source: DevqlTaskSource,
+    pub spec: DevqlTaskSpec,
+    pub status: DevqlTaskStatus,
     pub submitted_at_unix: u64,
     pub started_at_unix: Option<u64>,
     pub updated_at_unix: u64,
     pub completed_at_unix: Option<u64>,
     pub queue_position: Option<u64>,
     pub tasks_ahead: Option<u64>,
-    pub progress: crate::host::devql::SyncProgressUpdate,
+    pub progress: DevqlTaskProgress,
     pub error: Option<String>,
-    pub summary: Option<crate::host::devql::SyncSummary>,
+    pub result: Option<DevqlTaskResult>,
 }
 
-impl SyncTaskRecord {
+impl DevqlTaskRecord {
     pub fn normalise_legacy_values(&mut self) {
         if self.daemon_config_root.as_os_str().is_empty() {
             self.daemon_config_root = self.repo_root.clone();
         }
     }
+
+    pub fn sync_spec(&self) -> Option<&SyncTaskSpec> {
+        match &self.spec {
+            DevqlTaskSpec::Sync(spec) => Some(spec),
+            DevqlTaskSpec::Ingest(_) => None,
+        }
+    }
+
+    pub fn ingest_spec(&self) -> Option<&IngestTaskSpec> {
+        match &self.spec {
+            DevqlTaskSpec::Sync(_) => None,
+            DevqlTaskSpec::Ingest(spec) => Some(spec),
+        }
+    }
+
+    pub fn sync_progress(&self) -> Option<&crate::host::devql::SyncProgressUpdate> {
+        match &self.progress {
+            DevqlTaskProgress::Sync(progress) => Some(progress),
+            DevqlTaskProgress::Ingest(_) => None,
+        }
+    }
+
+    pub fn ingest_progress(&self) -> Option<&crate::host::devql::IngestionProgressUpdate> {
+        match &self.progress {
+            DevqlTaskProgress::Sync(_) => None,
+            DevqlTaskProgress::Ingest(progress) => Some(progress),
+        }
+    }
+
+    pub fn sync_result(&self) -> Option<&crate::host::devql::SyncSummary> {
+        match &self.result {
+            Some(DevqlTaskResult::Sync(result)) => Some(result),
+            _ => None,
+        }
+    }
+
+    pub fn ingest_result(&self) -> Option<&crate::host::devql::IngestionCounters> {
+        match &self.result {
+            Some(DevqlTaskResult::Ingest(result)) => Some(result),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SyncQueueState {
-    pub version: u8,
-    pub pending_tasks: u64,
+pub struct RepoTaskControlState {
+    pub repo_id: String,
+    pub paused: bool,
+    pub paused_reason: Option<String>,
+    pub updated_at_unix: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DevqlTaskKindCounts {
+    pub kind: DevqlTaskKind,
+    pub queued_tasks: u64,
     pub running_tasks: u64,
     pub failed_tasks: u64,
     pub completed_recent_tasks: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DevqlTaskQueueState {
+    pub version: u8,
+    pub queued_tasks: u64,
+    pub running_tasks: u64,
+    pub failed_tasks: u64,
+    pub completed_recent_tasks: u64,
+    pub by_kind: Vec<DevqlTaskKindCounts>,
     pub last_action: Option<String>,
     pub last_updated_unix: u64,
 }
 
-impl Default for SyncQueueState {
+impl Default for DevqlTaskQueueState {
     fn default() -> Self {
         Self {
             version: 1,
-            pending_tasks: 0,
+            queued_tasks: 0,
             running_tasks: 0,
             failed_tasks: 0,
             completed_recent_tasks: 0,
+            by_kind: default_devql_task_kind_counts(),
             last_action: Some("initialized".to_string()),
             last_updated_unix: 0,
         }
@@ -498,10 +607,36 @@ impl Default for SyncQueueState {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct SyncQueueStatus {
-    pub state: SyncQueueState,
+pub struct DevqlTaskQueueStatus {
+    pub state: DevqlTaskQueueState,
     pub persisted: bool,
-    pub current_repo_task: Option<SyncTaskRecord>,
+    pub current_repo_tasks: Vec<DevqlTaskRecord>,
+    pub current_repo_control: Option<RepoTaskControlState>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DevqlTaskControlResult {
+    pub message: String,
+    pub control: RepoTaskControlState,
+}
+
+fn default_devql_task_kind_counts() -> Vec<DevqlTaskKindCounts> {
+    vec![
+        DevqlTaskKindCounts {
+            kind: DevqlTaskKind::Sync,
+            queued_tasks: 0,
+            running_tasks: 0,
+            failed_tasks: 0,
+            completed_recent_tasks: 0,
+        },
+        DevqlTaskKindCounts {
+            kind: DevqlTaskKind::Ingest,
+            queued_tasks: 0,
+            running_tasks: 0,
+            failed_tasks: 0,
+            completed_recent_tasks: 0,
+        },
+    ]
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -512,7 +647,7 @@ pub struct DaemonStatusReport {
     pub health: Option<DaemonHealthSummary>,
     pub capability_events: Option<CapabilityEventQueueStatus>,
     pub enrichment: Option<EnrichmentQueueStatus>,
-    pub sync: Option<SyncQueueStatus>,
+    pub devql_tasks: Option<DevqlTaskQueueStatus>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/bitloops/src/daemon/types.rs
+++ b/bitloops/src/daemon/types.rs
@@ -482,7 +482,7 @@ pub enum DevqlTaskProgress {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum DevqlTaskResult {
-    Sync(crate::host::devql::SyncSummary),
+    Sync(Box<crate::host::devql::SyncSummary>),
     Ingest(crate::host::devql::IngestionCounters),
 }
 
@@ -549,7 +549,7 @@ impl DevqlTaskRecord {
 
     pub fn sync_result(&self) -> Option<&crate::host::devql::SyncSummary> {
         match &self.result {
-            Some(DevqlTaskResult::Sync(result)) => Some(result),
+            Some(DevqlTaskResult::Sync(result)) => Some(result.as_ref()),
             _ => None,
         }
     }

--- a/bitloops/src/graphql.rs
+++ b/bitloops/src/graphql.rs
@@ -15,8 +15,8 @@ pub(crate) use context::DevqlGraphqlContext;
 pub(crate) use error::{backend_error, bad_cursor_error, bad_user_input_error};
 pub(crate) use scope::{ResolvedTemporalScope, ResolverScope, TemporalAccessMode};
 pub(crate) use subscriptions::SubscriptionHub;
-pub(crate) use types::{ArtefactFilterInput, CanonicalKind};
 pub(crate) use types::Checkpoint;
+pub(crate) use types::{ArtefactFilterInput, CanonicalKind};
 
 #[cfg(test)]
 pub(crate) use types::DateTimeScalar;
@@ -562,15 +562,8 @@ fn extract_operation_name(query: &str) -> Option<&str> {
 
 fn graphql_operation_family(name: &str) -> Option<String> {
     match name {
-        "InitSchema"
-        | "EnqueueTask"
-        | "Task"
-        | "Tasks"
-        | "TaskQueue"
-        | "PauseTaskQueue"
-        | "ResumeTaskQueue"
-        | "CancelTask"
-        | "TaskProgress" => Some(name.to_string()),
+        "InitSchema" | "EnqueueTask" | "Task" | "Tasks" | "TaskQueue" | "PauseTaskQueue"
+        | "ResumeTaskQueue" | "CancelTask" | "TaskProgress" => Some(name.to_string()),
         _ => None,
     }
 }
@@ -717,7 +710,9 @@ mod analytics_signature_tests {
 
     #[test]
     fn graphql_request_signature_whitelists_known_operation_names() {
-        let request = Request::new("mutation EnqueueTask($input: EnqueueTaskInput!) { enqueueTask(input: $input) { merged } }");
+        let request = Request::new(
+            "mutation EnqueueTask($input: EnqueueTaskInput!) { enqueueTask(input: $input) { merged } }",
+        );
         let signature = graphql_request_signature(&request);
 
         assert_eq!(signature.0, "mutation");

--- a/bitloops/src/graphql.rs
+++ b/bitloops/src/graphql.rs
@@ -16,15 +16,12 @@ pub(crate) use error::{backend_error, bad_cursor_error, bad_user_input_error};
 pub(crate) use scope::{ResolvedTemporalScope, ResolverScope, TemporalAccessMode};
 pub(crate) use subscriptions::SubscriptionHub;
 pub(crate) use types::{ArtefactFilterInput, CanonicalKind};
+pub(crate) use types::Checkpoint;
 
 #[cfg(test)]
 pub(crate) use types::DateTimeScalar;
 #[cfg(test)]
 pub(crate) use types::artefact::LineRangeInput;
-#[cfg(test)]
-pub(crate) use types::ingestion::IngestionPhase;
-#[cfg(test)]
-pub(crate) use types::{Checkpoint, IngestionProgressEvent};
 
 use self::loaders::LoaderRegistryExtension;
 use self::mutation_root::MutationRoot;
@@ -446,9 +443,15 @@ fn extract_operation_name(query: &str) -> Option<&str> {
 
 fn graphql_operation_family(name: &str) -> Option<String> {
     match name {
-        "InitSchema" | "Ingest" | "EnqueueSync" | "SyncTask" | "SyncProgress" => {
-            Some(name.to_string())
-        }
+        "InitSchema"
+        | "EnqueueTask"
+        | "Task"
+        | "Tasks"
+        | "TaskQueue"
+        | "PauseTaskQueue"
+        | "ResumeTaskQueue"
+        | "CancelTask"
+        | "TaskProgress" => Some(name.to_string()),
         _ => None,
     }
 }
@@ -569,13 +572,11 @@ mod analytics_signature_tests {
 
     #[test]
     fn graphql_request_signature_whitelists_known_operation_names() {
-        let request = Request::new(
-            "mutation EnqueueSync($input: EnqueueSyncInput!) { enqueueSync(input: $input) { merged } }",
-        );
+        let request = Request::new("mutation EnqueueTask($input: EnqueueTaskInput!) { enqueueTask(input: $input) { merged } }");
         let signature = graphql_request_signature(&request);
 
         assert_eq!(signature.0, "mutation");
-        assert_eq!(signature.1, "EnqueueSync");
+        assert_eq!(signature.1, "EnqueueTask");
     }
 
     #[test]

--- a/bitloops/src/graphql/context.rs
+++ b/bitloops/src/graphql/context.rs
@@ -174,10 +174,6 @@ impl DevqlGraphqlContext {
         Ok(Arc::clone(capability_host))
     }
 
-    pub(crate) fn repo_name(&self) -> &str {
-        self.repo_identity.name.as_str()
-    }
-
     pub(crate) fn require_slim_request_scope(&self) -> Result<()> {
         if self.schema_mode == DevqlSchemaMode::Slim && !self.request_scope_present {
             return Err(anyhow!(

--- a/bitloops/src/graphql/mutation_root.rs
+++ b/bitloops/src/graphql/mutation_root.rs
@@ -622,7 +622,9 @@ impl MutationRoot {
     }
 }
 
-fn parse_task_source(raw: Option<&str>) -> std::result::Result<crate::daemon::DevqlTaskSource, String> {
+fn parse_task_source(
+    raw: Option<&str>,
+) -> std::result::Result<crate::daemon::DevqlTaskSource, String> {
     match raw.map(str::trim).filter(|value| !value.is_empty()) {
         None => Ok(crate::daemon::DevqlTaskSource::ManualCli),
         Some("init") => Ok(crate::daemon::DevqlTaskSource::Init),
@@ -630,9 +632,7 @@ fn parse_task_source(raw: Option<&str>) -> std::result::Result<crate::daemon::De
             Ok(crate::daemon::DevqlTaskSource::ManualCli)
         }
         Some("watcher") => Ok(crate::daemon::DevqlTaskSource::Watcher),
-        Some("post_commit") | Some("post-commit") => {
-            Ok(crate::daemon::DevqlTaskSource::PostCommit)
-        }
+        Some("post_commit") | Some("post-commit") => Ok(crate::daemon::DevqlTaskSource::PostCommit),
         Some("post_merge") | Some("post-merge") => Ok(crate::daemon::DevqlTaskSource::PostMerge),
         Some("post_checkout") | Some("post-checkout") => {
             Ok(crate::daemon::DevqlTaskSource::PostCheckout)
@@ -683,9 +683,7 @@ fn resolve_enqueue_task_input(
                         crate::host::devql::SyncMode::Paths(paths) => {
                             crate::daemon::SyncTaskMode::Paths { paths }
                         }
-                        crate::host::devql::SyncMode::Repair => {
-                            crate::daemon::SyncTaskMode::Repair
-                        }
+                        crate::host::devql::SyncMode::Repair => crate::daemon::SyncTaskMode::Repair,
                         crate::host::devql::SyncMode::Validate => {
                             crate::daemon::SyncTaskMode::Validate
                         }

--- a/bitloops/src/graphql/mutation_root.rs
+++ b/bitloops/src/graphql/mutation_root.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 use super::{
     DevqlGraphqlContext,
     types::{
-        Checkpoint, DateTimeScalar, IngestionProgressEvent, KnowledgeItem, KnowledgeRelation,
-        SyncTaskObject,
+        DateTimeScalar, KnowledgeItem, KnowledgeRelation, TaskKind, TaskObject,
+        TaskQueueControlResultObject,
     },
 };
 
@@ -41,7 +41,7 @@ pub struct RefreshKnowledgeInput {
 }
 
 #[derive(Debug, Clone, InputObject)]
-pub struct EnqueueSyncInput {
+pub struct EnqueueSyncTaskInput {
     #[graphql(default = false)]
     pub full: bool,
     #[graphql(default)]
@@ -55,9 +55,18 @@ pub struct EnqueueSyncInput {
 }
 
 #[derive(Debug, Clone, InputObject)]
-pub struct IngestInput {
+pub struct EnqueueIngestTaskInput {
     #[graphql(default)]
     pub backfill: Option<i32>,
+}
+
+#[derive(Debug, Clone, InputObject)]
+pub struct EnqueueTaskInput {
+    pub kind: TaskKind,
+    #[graphql(default)]
+    pub sync: Option<EnqueueSyncTaskInput>,
+    #[graphql(default)]
+    pub ingest: Option<EnqueueIngestTaskInput>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, SimpleObject)]
@@ -142,8 +151,8 @@ pub struct SyncResult {
 }
 
 #[derive(Debug, Clone, SimpleObject)]
-pub struct EnqueueSyncResult {
-    pub task: SyncTaskObject,
+pub struct EnqueueTaskResult {
+    pub task: TaskObject,
     pub merged: bool,
 }
 
@@ -334,91 +343,119 @@ impl MutationRoot {
         Ok(summary.into())
     }
 
-    async fn ingest(&self, ctx: &Context<'_>, input: Option<IngestInput>) -> Result<IngestResult> {
-        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
-        context
-            .require_repo_write_scope()
-            .map_err(|err| operation_error("BAD_USER_INPUT", "validation", "ingest", err))?;
-        let cfg = context
-            .devql_config()
-            .map_err(|err| operation_error("BACKEND_ERROR", "configuration", "ingest", err))?;
-        crate::daemon::require_current_repo_runtime(cfg.repo_root.as_path(), "GraphQL ingest")
-            .map_err(|err| operation_error("BACKEND_ERROR", "configuration", "ingest", err))?;
-        let observer = GraphqlIngestionObserver::new(context);
-        let backfill = match input.and_then(|input| input.backfill) {
-            Some(backfill) if backfill <= 0 => {
-                return Err(operation_error(
-                    "BAD_USER_INPUT",
-                    "validation",
-                    "ingest",
-                    "`backfill` must be greater than zero",
-                ));
-            }
-            Some(backfill) => Some(usize::try_from(backfill).map_err(|_| {
-                operation_error(
-                    "BAD_USER_INPUT",
-                    "validation",
-                    "ingest",
-                    "`backfill` must be greater than zero",
-                )
-            })?),
-            None => None,
-        };
-        let summary = if let Some(backfill) = backfill {
-            crate::host::devql::execute_ingest_with_backfill_window(
-                &cfg,
-                false,
-                backfill,
-                Some(&observer),
-                Some(crate::daemon::shared_enrichment_coordinator()),
-            )
-            .await
-        } else {
-            crate::host::devql::execute_ingest_with_observer(
-                &cfg,
-                false,
-                0,
-                Some(&observer),
-                Some(crate::daemon::shared_enrichment_coordinator()),
-            )
-            .await
-        }
-        .map_err(|err| operation_error("BACKEND_ERROR", "ingestion", "ingest", err))?;
-        Ok(summary.into())
-    }
-
-    #[graphql(name = "enqueueSync")]
-    async fn enqueue_sync(
+    #[graphql(name = "enqueueTask")]
+    async fn enqueue_task(
         &self,
         ctx: &Context<'_>,
-        input: EnqueueSyncInput,
-    ) -> Result<EnqueueSyncResult> {
+        input: EnqueueTaskInput,
+    ) -> Result<EnqueueTaskResult> {
         let context = ctx.data_unchecked::<DevqlGraphqlContext>();
         context
             .require_repo_write_scope()
-            .map_err(|err| operation_error("BAD_USER_INPUT", "validation", "enqueueSync", err))?;
+            .map_err(|err| operation_error("BAD_USER_INPUT", "validation", "enqueueTask", err))?;
         let cfg = context
             .devql_config()
-            .map_err(|err| operation_error("BACKEND_ERROR", "configuration", "enqueueSync", err))?;
+            .map_err(|err| operation_error("BACKEND_ERROR", "configuration", "enqueueTask", err))?;
+        let (source, spec) = resolve_enqueue_task_input(input, "enqueueTask")?;
 
-        let EnqueueSyncInput {
-            full,
-            paths,
-            repair,
-            validate,
-            source,
-        } = input;
-        let mode = resolve_sync_mode_input(full, paths, repair, validate, "enqueueSync")?;
-        let source = parse_sync_source(source.as_deref())
-            .map_err(|err| operation_error("BAD_USER_INPUT", "validation", "enqueueSync", err))?;
-
-        crate::daemon::shared_sync_coordinator().register_subscription_hub(context.subscriptions());
-        let queued = crate::daemon::enqueue_sync_for_config(&cfg, source, mode)
-            .map_err(|err| operation_error("BACKEND_ERROR", "sync", "enqueueSync", err))?;
-        Ok(EnqueueSyncResult {
+        crate::daemon::shared_devql_task_coordinator()
+            .register_subscription_hub(context.subscriptions());
+        let queued = crate::daemon::enqueue_task_for_config(&cfg, source, spec)
+            .map_err(|err| operation_error("BACKEND_ERROR", "task", "enqueueTask", err))?;
+        Ok(EnqueueTaskResult {
             task: queued.task.into(),
             merged: queued.merged,
         })
+    }
+
+    #[graphql(name = "pauseTaskQueue")]
+    async fn pause_task_queue(
+        &self,
+        ctx: &Context<'_>,
+        reason: Option<String>,
+    ) -> Result<TaskQueueControlResultObject> {
+        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
+        context.require_repo_write_scope().map_err(|err| {
+            operation_error("BAD_USER_INPUT", "validation", "pauseTaskQueue", err)
+        })?;
+        let cfg = context.devql_config().map_err(|err| {
+            operation_error("BACKEND_ERROR", "configuration", "pauseTaskQueue", err)
+        })?;
+        let reason = normalise_optional_input(reason, "reason", "pauseTaskQueue")?;
+        crate::daemon::pause_devql_tasks(cfg.repo.repo_id.as_str(), reason)
+            .map(Into::into)
+            .map_err(|err| operation_error("BACKEND_ERROR", "task", "pauseTaskQueue", err))
+    }
+
+    #[graphql(name = "resumeTaskQueue")]
+    async fn resume_task_queue(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "repoId")] repo_id: Option<String>,
+    ) -> Result<TaskQueueControlResultObject> {
+        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
+        context.require_repo_write_scope().map_err(|err| {
+            operation_error("BAD_USER_INPUT", "validation", "resumeTaskQueue", err)
+        })?;
+        let cfg = context.devql_config().map_err(|err| {
+            operation_error("BACKEND_ERROR", "configuration", "resumeTaskQueue", err)
+        })?;
+        let requested_repo_id = repo_id
+            .map(|value| require_non_empty_input(value, "repoId", "resumeTaskQueue"))
+            .transpose()?;
+        if let Some(requested_repo_id) = requested_repo_id
+            && requested_repo_id != cfg.repo.repo_id
+        {
+            return Err(operation_error(
+                "BAD_USER_INPUT",
+                "validation",
+                "resumeTaskQueue",
+                format!(
+                    "repoId `{requested_repo_id}` does not match the current repository `{}`",
+                    cfg.repo.repo_id
+                ),
+            ));
+        }
+
+        crate::daemon::resume_devql_tasks(cfg.repo.repo_id.as_str())
+            .map(Into::into)
+            .map_err(|err| operation_error("BACKEND_ERROR", "task", "resumeTaskQueue", err))
+    }
+
+    #[graphql(name = "cancelTask")]
+    async fn cancel_task(&self, ctx: &Context<'_>, id: String) -> Result<TaskObject> {
+        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
+        context
+            .require_repo_write_scope()
+            .map_err(|err| operation_error("BAD_USER_INPUT", "validation", "cancelTask", err))?;
+        let cfg = context
+            .devql_config()
+            .map_err(|err| operation_error("BACKEND_ERROR", "configuration", "cancelTask", err))?;
+        let task = crate::daemon::devql_task(id.as_str())
+            .map_err(|err| operation_error("BACKEND_ERROR", "task", "cancelTask", err))?
+            .ok_or_else(|| {
+                operation_error(
+                    "BAD_USER_INPUT",
+                    "validation",
+                    "cancelTask",
+                    format!("unknown task `{id}`"),
+                )
+            })?;
+        if task.repo_id != cfg.repo.repo_id {
+            return Err(operation_error(
+                "BAD_USER_INPUT",
+                "validation",
+                "cancelTask",
+                format!(
+                    "task `{id}` belongs to repository `{}` and is outside the current repo scope",
+                    task.repo_id
+                ),
+            ));
+        }
+
+        crate::daemon::cancel_devql_task(id.as_str())
+            .map(Into::into)
+            .map_err(|err| operation_error("BACKEND_ERROR", "task", "cancelTask", err))
     }
 
     async fn add_knowledge(
@@ -585,24 +622,118 @@ impl MutationRoot {
     }
 }
 
-fn parse_sync_source(
-    raw: Option<&str>,
-) -> std::result::Result<crate::daemon::SyncTaskSource, String> {
+fn parse_task_source(raw: Option<&str>) -> std::result::Result<crate::daemon::DevqlTaskSource, String> {
     match raw.map(str::trim).filter(|value| !value.is_empty()) {
-        None => Ok(crate::daemon::SyncTaskSource::ManualCli),
-        Some("init") => Ok(crate::daemon::SyncTaskSource::Init),
+        None => Ok(crate::daemon::DevqlTaskSource::ManualCli),
+        Some("init") => Ok(crate::daemon::DevqlTaskSource::Init),
         Some("manual_cli") | Some("manual-cli") | Some("manual") => {
-            Ok(crate::daemon::SyncTaskSource::ManualCli)
+            Ok(crate::daemon::DevqlTaskSource::ManualCli)
         }
-        Some("watcher") => Ok(crate::daemon::SyncTaskSource::Watcher),
-        Some("post_commit") | Some("post-commit") => Ok(crate::daemon::SyncTaskSource::PostCommit),
-        Some("post_merge") | Some("post-merge") => Ok(crate::daemon::SyncTaskSource::PostMerge),
+        Some("watcher") => Ok(crate::daemon::DevqlTaskSource::Watcher),
+        Some("post_commit") | Some("post-commit") => {
+            Ok(crate::daemon::DevqlTaskSource::PostCommit)
+        }
+        Some("post_merge") | Some("post-merge") => Ok(crate::daemon::DevqlTaskSource::PostMerge),
         Some("post_checkout") | Some("post-checkout") => {
-            Ok(crate::daemon::SyncTaskSource::PostCheckout)
+            Ok(crate::daemon::DevqlTaskSource::PostCheckout)
         }
         Some(other) => Err(format!(
-            "unsupported sync source `{other}`; expected one of: init, manual_cli, watcher, post_commit, post_merge, post_checkout"
+            "unsupported task source `{other}`; expected one of: init, manual_cli, watcher, post_commit, post_merge, post_checkout"
         )),
+    }
+}
+
+fn resolve_enqueue_task_input(
+    input: EnqueueTaskInput,
+    operation: &'static str,
+) -> Result<(crate::daemon::DevqlTaskSource, crate::daemon::DevqlTaskSpec)> {
+    match input.kind {
+        TaskKind::Sync => {
+            let sync = input.sync.ok_or_else(|| {
+                operation_error(
+                    "BAD_USER_INPUT",
+                    "validation",
+                    operation,
+                    "`sync` input is required when kind is SYNC",
+                )
+            })?;
+            if input.ingest.is_some() {
+                return Err(operation_error(
+                    "BAD_USER_INPUT",
+                    "validation",
+                    operation,
+                    "`ingest` must not be provided when kind is SYNC",
+                ));
+            }
+            let mode = resolve_sync_mode_input(
+                sync.full,
+                sync.paths,
+                sync.repair,
+                sync.validate,
+                operation,
+            )?;
+            let source = parse_task_source(sync.source.as_deref())
+                .map_err(|err| operation_error("BAD_USER_INPUT", "validation", operation, err))?;
+            Ok((
+                source,
+                crate::daemon::DevqlTaskSpec::Sync(crate::daemon::SyncTaskSpec {
+                    mode: match mode {
+                        crate::host::devql::SyncMode::Auto => crate::daemon::SyncTaskMode::Auto,
+                        crate::host::devql::SyncMode::Full => crate::daemon::SyncTaskMode::Full,
+                        crate::host::devql::SyncMode::Paths(paths) => {
+                            crate::daemon::SyncTaskMode::Paths { paths }
+                        }
+                        crate::host::devql::SyncMode::Repair => {
+                            crate::daemon::SyncTaskMode::Repair
+                        }
+                        crate::host::devql::SyncMode::Validate => {
+                            crate::daemon::SyncTaskMode::Validate
+                        }
+                    },
+                }),
+            ))
+        }
+        TaskKind::Ingest => {
+            let ingest = input.ingest.ok_or_else(|| {
+                operation_error(
+                    "BAD_USER_INPUT",
+                    "validation",
+                    operation,
+                    "`ingest` input is required when kind is INGEST",
+                )
+            })?;
+            if input.sync.is_some() {
+                return Err(operation_error(
+                    "BAD_USER_INPUT",
+                    "validation",
+                    operation,
+                    "`sync` must not be provided when kind is INGEST",
+                ));
+            }
+            let backfill = match ingest.backfill {
+                Some(backfill) if backfill <= 0 => {
+                    return Err(operation_error(
+                        "BAD_USER_INPUT",
+                        "validation",
+                        operation,
+                        "`backfill` must be greater than zero",
+                    ));
+                }
+                Some(backfill) => Some(usize::try_from(backfill).map_err(|_| {
+                    operation_error(
+                        "BAD_USER_INPUT",
+                        "validation",
+                        operation,
+                        "`backfill` must be greater than zero",
+                    )
+                })?),
+                None => None,
+            };
+            Ok((
+                crate::daemon::DevqlTaskSource::ManualCli,
+                crate::daemon::DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec { backfill }),
+            ))
+        }
     }
 }
 
@@ -777,39 +908,6 @@ fn operation_error(
 
 fn to_graphql_count(value: usize) -> i32 {
     i32::try_from(value).unwrap_or(i32::MAX)
-}
-
-struct GraphqlIngestionObserver {
-    repo_name: String,
-    context: DevqlGraphqlContext,
-}
-
-impl GraphqlIngestionObserver {
-    fn new(context: &DevqlGraphqlContext) -> Self {
-        Self {
-            repo_name: context.repo_name().to_string(),
-            context: context.clone(),
-        }
-    }
-}
-
-impl crate::host::devql::IngestionObserver for GraphqlIngestionObserver {
-    fn on_progress(&self, update: crate::host::devql::IngestionProgressUpdate) {
-        self.context
-            .subscriptions()
-            .publish_progress(self.repo_name.clone(), IngestionProgressEvent::from(update));
-    }
-
-    fn on_checkpoint_ingested(
-        &self,
-        checkpoint: crate::host::devql::IngestedCheckpointNotification,
-    ) {
-        self.context.subscriptions().publish_checkpoint(
-            self.repo_name.clone(),
-            Checkpoint::from_ingested(&checkpoint.checkpoint, checkpoint.commit_sha.as_deref())
-                .with_scope(self.context.slim_root_scope()),
-        );
-    }
 }
 
 #[cfg(test)]

--- a/bitloops/src/graphql/mutation_root/tests.rs
+++ b/bitloops/src/graphql/mutation_root/tests.rs
@@ -1,49 +1,49 @@
 use super::*;
 
 #[test]
-fn parse_sync_source_accepts_default_and_aliases() {
+fn parse_task_source_accepts_default_and_aliases() {
     assert_eq!(
-        parse_sync_source(None).expect("default source"),
-        crate::daemon::SyncTaskSource::ManualCli
+        parse_task_source(None).expect("default source"),
+        crate::daemon::DevqlTaskSource::ManualCli
     );
     assert_eq!(
-        parse_sync_source(Some("   ")).expect("blank source"),
-        crate::daemon::SyncTaskSource::ManualCli
+        parse_task_source(Some("   ")).expect("blank source"),
+        crate::daemon::DevqlTaskSource::ManualCli
     );
     assert_eq!(
-        parse_sync_source(Some("manual")).expect("manual alias"),
-        crate::daemon::SyncTaskSource::ManualCli
+        parse_task_source(Some("manual")).expect("manual alias"),
+        crate::daemon::DevqlTaskSource::ManualCli
     );
     assert_eq!(
-        parse_sync_source(Some("manual-cli")).expect("manual-cli alias"),
-        crate::daemon::SyncTaskSource::ManualCli
+        parse_task_source(Some("manual-cli")).expect("manual-cli alias"),
+        crate::daemon::DevqlTaskSource::ManualCli
     );
     assert_eq!(
-        parse_sync_source(Some("init")).expect("init source"),
-        crate::daemon::SyncTaskSource::Init
+        parse_task_source(Some("init")).expect("init source"),
+        crate::daemon::DevqlTaskSource::Init
     );
     assert_eq!(
-        parse_sync_source(Some("watcher")).expect("watcher source"),
-        crate::daemon::SyncTaskSource::Watcher
+        parse_task_source(Some("watcher")).expect("watcher source"),
+        crate::daemon::DevqlTaskSource::Watcher
     );
     assert_eq!(
-        parse_sync_source(Some("post-commit")).expect("post-commit source"),
-        crate::daemon::SyncTaskSource::PostCommit
+        parse_task_source(Some("post-commit")).expect("post-commit source"),
+        crate::daemon::DevqlTaskSource::PostCommit
     );
     assert_eq!(
-        parse_sync_source(Some("post_merge")).expect("post_merge source"),
-        crate::daemon::SyncTaskSource::PostMerge
+        parse_task_source(Some("post_merge")).expect("post_merge source"),
+        crate::daemon::DevqlTaskSource::PostMerge
     );
     assert_eq!(
-        parse_sync_source(Some("post_checkout")).expect("post_checkout source"),
-        crate::daemon::SyncTaskSource::PostCheckout
+        parse_task_source(Some("post_checkout")).expect("post_checkout source"),
+        crate::daemon::DevqlTaskSource::PostCheckout
     );
 }
 
 #[test]
-fn parse_sync_source_rejects_unknown_values() {
-    let err = parse_sync_source(Some("cronjob")).expect_err("unknown source should fail");
-    assert!(err.contains("unsupported sync source `cronjob`"));
+fn parse_task_source_rejects_unknown_values() {
+    let err = parse_task_source(Some("cronjob")).expect_err("unknown source should fail");
+    assert!(err.contains("unsupported task source `cronjob`"));
     assert!(err.contains("manual_cli"));
 }
 
@@ -60,7 +60,7 @@ fn resolve_sync_mode_input_rejects_conflicting_selectors() {
         Some(vec!["src/lib.rs".to_string()]),
         false,
         false,
-        "enqueueSync",
+        "enqueueTask",
     )
     .expect_err("conflicting selectors should fail");
     assert!(

--- a/bitloops/src/graphql/query_root.rs
+++ b/bitloops/src/graphql/query_root.rs
@@ -1,6 +1,8 @@
 use super::backend_error;
 use super::context::DevqlGraphqlContext;
-use super::types::{HealthStatus, Repository, TaskKind, TaskObject, TaskQueueStatusObject, TaskStatus};
+use super::types::{
+    HealthStatus, Repository, TaskKind, TaskObject, TaskQueueStatusObject, TaskStatus,
+};
 use async_graphql::{Context, Object, Result};
 
 #[derive(Default)]
@@ -44,8 +46,8 @@ impl QueryRoot {
             status.map(Into::into),
             limit,
         )
-            .map(|tasks| tasks.into_iter().map(Into::into).collect())
-            .map_err(|err| backend_error(format!("failed to list tasks: {err:#}")))
+        .map(|tasks| tasks.into_iter().map(Into::into).collect())
+        .map_err(|err| backend_error(format!("failed to list tasks: {err:#}")))
     }
 
     #[graphql(name = "taskQueue")]

--- a/bitloops/src/graphql/query_root.rs
+++ b/bitloops/src/graphql/query_root.rs
@@ -1,6 +1,6 @@
 use super::backend_error;
 use super::context::DevqlGraphqlContext;
-use super::types::{HealthStatus, Repository, SyncTaskObject};
+use super::types::{HealthStatus, Repository, TaskKind, TaskObject, TaskQueueStatusObject, TaskStatus};
 use async_graphql::{Context, Object, Result};
 
 #[derive(Default)]
@@ -21,25 +21,41 @@ impl QueryRoot {
             .map_err(|err| backend_error(format!("failed to resolve repository: {err:#}")))
     }
 
-    #[graphql(name = "syncTask")]
-    async fn sync_task(&self, _ctx: &Context<'_>, id: String) -> Result<Option<SyncTaskObject>> {
-        crate::daemon::sync_task(id.as_str())
+    async fn task(&self, _ctx: &Context<'_>, id: String) -> Result<Option<TaskObject>> {
+        crate::daemon::devql_task(id.as_str())
             .map(|task| task.map(Into::into))
-            .map_err(|err| backend_error(format!("failed to load sync task: {err:#}")))
+            .map_err(|err| backend_error(format!("failed to load task: {err:#}")))
     }
 
-    #[graphql(name = "syncTasks")]
-    async fn sync_tasks(
+    async fn tasks(
         &self,
         _ctx: &Context<'_>,
         #[graphql(name = "repoId")] repo_id: Option<String>,
+        kind: Option<TaskKind>,
+        status: Option<TaskStatus>,
         limit: Option<i32>,
-    ) -> Result<Vec<SyncTaskObject>> {
+    ) -> Result<Vec<TaskObject>> {
         let limit = limit
             .map(|limit| usize::try_from(limit.max(0)).unwrap_or(usize::MAX))
             .or(Some(25));
-        crate::daemon::sync_tasks(repo_id.as_deref(), limit)
+        crate::daemon::devql_tasks(
+            repo_id.as_deref(),
+            kind.map(Into::into),
+            status.map(Into::into),
+            limit,
+        )
             .map(|tasks| tasks.into_iter().map(Into::into).collect())
-            .map_err(|err| backend_error(format!("failed to list sync tasks: {err:#}")))
+            .map_err(|err| backend_error(format!("failed to list tasks: {err:#}")))
+    }
+
+    #[graphql(name = "taskQueue")]
+    async fn task_queue(
+        &self,
+        _ctx: &Context<'_>,
+        #[graphql(name = "repoId")] repo_id: Option<String>,
+    ) -> Result<TaskQueueStatusObject> {
+        crate::daemon::devql_task_status(repo_id.as_deref())
+            .map(Into::into)
+            .map_err(|err| backend_error(format!("failed to load task queue status: {err:#}")))
     }
 }

--- a/bitloops/src/graphql/slim_query_root.rs
+++ b/bitloops/src/graphql/slim_query_root.rs
@@ -277,8 +277,8 @@ impl SlimQueryRoot {
             status.map(Into::into),
             limit,
         )
-            .map(|tasks| tasks.into_iter().map(Into::into).collect())
-            .map_err(|err| backend_error(format!("failed to list tasks: {err:#}")))
+        .map(|tasks| tasks.into_iter().map(Into::into).collect())
+        .map_err(|err| backend_error(format!("failed to list tasks: {err:#}")))
     }
 
     #[graphql(name = "taskQueue")]

--- a/bitloops/src/graphql/slim_query_root.rs
+++ b/bitloops/src/graphql/slim_query_root.rs
@@ -12,8 +12,9 @@ use super::types::{
     CloneConnection, CloneEdge, CloneSummary, ClonesFilterInput, CommitConnection, CommitEdge,
     ConnectionPagination, DateTimeScalar, DependencyConnectionEdge, DependencyEdgeConnection,
     DepsFilterInput, FileContext, HealthStatus, KnowledgeItemConnection, KnowledgeItemEdge,
-    KnowledgeProvider, SyncTaskObject, TelemetryEventConnection, TelemetryEventEdge, TemporalScope,
-    TestHarnessCommitSummary, TestHarnessCoverageResult, TestHarnessTestsResult, paginate_items,
+    KnowledgeProvider, TaskKind, TaskObject, TaskQueueStatusObject, TaskStatus,
+    TelemetryEventConnection, TelemetryEventEdge, TemporalScope, TestHarnessCommitSummary,
+    TestHarnessCoverageResult, TestHarnessTestsResult, paginate_items,
 };
 
 #[derive(Default)]
@@ -240,8 +241,7 @@ impl SlimQueryRoot {
             .map_err(|err| backend_error(format!("failed to query repository users: {err:#}")))
     }
 
-    #[graphql(name = "syncTask")]
-    async fn sync_task(&self, ctx: &Context<'_>, id: String) -> Result<Option<SyncTaskObject>> {
+    async fn task(&self, ctx: &Context<'_>, id: String) -> Result<Option<TaskObject>> {
         let context = ctx.data_unchecked::<DevqlGraphqlContext>();
         context
             .require_slim_request_scope()
@@ -249,17 +249,18 @@ impl SlimQueryRoot {
         let repo_id = context
             .repo_id_for_scope(&context.slim_root_scope())
             .map_err(|err| backend_error(format!("failed to resolve repository scope: {err:#}")))?;
-        let task = crate::daemon::sync_task(id.as_str())
-            .map_err(|err| backend_error(format!("failed to load sync task: {err:#}")))?;
+        let task = crate::daemon::devql_task(id.as_str())
+            .map_err(|err| backend_error(format!("failed to load task: {err:#}")))?;
         Ok(task.filter(|task| task.repo_id == repo_id).map(Into::into))
     }
 
-    #[graphql(name = "syncTasks")]
-    async fn sync_tasks(
+    async fn tasks(
         &self,
         ctx: &Context<'_>,
+        kind: Option<TaskKind>,
+        status: Option<TaskStatus>,
         limit: Option<i32>,
-    ) -> Result<Vec<SyncTaskObject>> {
+    ) -> Result<Vec<TaskObject>> {
         let context = ctx.data_unchecked::<DevqlGraphqlContext>();
         context
             .require_slim_request_scope()
@@ -270,9 +271,28 @@ impl SlimQueryRoot {
         let limit = limit
             .map(|limit| usize::try_from(limit.max(0)).unwrap_or(usize::MAX))
             .or(Some(25));
-        crate::daemon::sync_tasks(Some(repo_id.as_str()), limit)
+        crate::daemon::devql_tasks(
+            Some(repo_id.as_str()),
+            kind.map(Into::into),
+            status.map(Into::into),
+            limit,
+        )
             .map(|tasks| tasks.into_iter().map(Into::into).collect())
-            .map_err(|err| backend_error(format!("failed to list sync tasks: {err:#}")))
+            .map_err(|err| backend_error(format!("failed to list tasks: {err:#}")))
+    }
+
+    #[graphql(name = "taskQueue")]
+    async fn task_queue(&self, ctx: &Context<'_>) -> Result<TaskQueueStatusObject> {
+        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
+        context
+            .require_slim_request_scope()
+            .map_err(|err| bad_user_input_error(err.to_string()))?;
+        let repo_id = context
+            .repo_id_for_scope(&context.slim_root_scope())
+            .map_err(|err| backend_error(format!("failed to resolve repository scope: {err:#}")))?;
+        crate::daemon::devql_task_status(Some(repo_id.as_str()))
+            .map(Into::into)
+            .map_err(|err| backend_error(format!("failed to load task queue status: {err:#}")))
     }
 
     async fn agents(&self, ctx: &Context<'_>) -> Result<Vec<String>> {

--- a/bitloops/src/graphql/slim_subscription_root.rs
+++ b/bitloops/src/graphql/slim_subscription_root.rs
@@ -4,14 +4,13 @@ use async_graphql::futures_util::{Stream, stream};
 use async_graphql::{Context, Subscription};
 
 use super::context::DevqlGraphqlContext;
-use super::types::{Checkpoint, IngestionProgressEvent, SyncProgressEvent};
+use super::types::{Checkpoint, TaskProgressEvent};
 
 #[derive(Default)]
 pub struct SlimSubscriptionRoot;
 
 type CheckpointStream = Pin<Box<dyn Stream<Item = Checkpoint> + Send>>;
-type IngestionProgressStream = Pin<Box<dyn Stream<Item = IngestionProgressEvent> + Send>>;
-type SyncProgressStream = Pin<Box<dyn Stream<Item = SyncProgressEvent> + Send>>;
+type TaskProgressStream = Pin<Box<dyn Stream<Item = TaskProgressEvent> + Send>>;
 
 #[Subscription]
 impl SlimSubscriptionRoot {
@@ -40,38 +39,13 @@ impl SlimSubscriptionRoot {
         ))
     }
 
-    async fn ingestion_progress(&self, ctx: &Context<'_>) -> IngestionProgressStream {
-        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
-        let receiver = context.subscriptions().subscribe_progress();
-        let repo_name = context.repo_name_for_scope(&context.slim_root_scope()).ok();
-
-        Box::pin(stream::unfold(
-            (receiver, repo_name),
-            |(mut receiver, repo_name)| async move {
-                let repo_name = repo_name.clone()?;
-                loop {
-                    match receiver.recv().await {
-                        Ok(event) => {
-                            if event.repo_name != repo_name {
-                                continue;
-                            }
-                            return Some((event.event, (receiver, Some(repo_name))));
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
-                    }
-                }
-            },
-        ))
-    }
-
-    async fn sync_progress(
+    async fn task_progress(
         &self,
         ctx: &Context<'_>,
         #[graphql(name = "taskId")] task_id: String,
-    ) -> SyncProgressStream {
+    ) -> TaskProgressStream {
         let context = ctx.data_unchecked::<DevqlGraphqlContext>();
-        let receiver = context.subscriptions().subscribe_sync_progress();
+        let receiver = context.subscriptions().subscribe_task_progress();
 
         Box::pin(stream::unfold(
             (receiver, task_id),
@@ -85,7 +59,7 @@ impl SlimSubscriptionRoot {
                             return Some((event.task.into(), (receiver, task_id)));
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                            if let Ok(Some(task)) = crate::daemon::sync_task(task_id.as_str()) {
+                            if let Ok(Some(task)) = crate::daemon::devql_task(task_id.as_str()) {
                                 return Some((task.into(), (receiver, task_id)));
                             }
                             continue;

--- a/bitloops/src/graphql/subscription_root.rs
+++ b/bitloops/src/graphql/subscription_root.rs
@@ -4,14 +4,13 @@ use async_graphql::futures_util::{Stream, stream};
 use async_graphql::{Context, Subscription};
 
 use super::context::DevqlGraphqlContext;
-use super::types::{Checkpoint, IngestionProgressEvent, SyncProgressEvent};
+use super::types::{Checkpoint, TaskProgressEvent};
 
 #[derive(Default)]
 pub struct SubscriptionRoot;
 
 type CheckpointStream = Pin<Box<dyn Stream<Item = Checkpoint> + Send>>;
-type IngestionProgressStream = Pin<Box<dyn Stream<Item = IngestionProgressEvent> + Send>>;
-type SyncProgressStream = Pin<Box<dyn Stream<Item = SyncProgressEvent> + Send>>;
+type TaskProgressStream = Pin<Box<dyn Stream<Item = TaskProgressEvent> + Send>>;
 
 #[Subscription]
 impl SubscriptionRoot {
@@ -46,44 +45,13 @@ impl SubscriptionRoot {
         ))
     }
 
-    async fn ingestion_progress(
-        &self,
-        ctx: &Context<'_>,
-        #[graphql(name = "repoName")] repo_name: String,
-    ) -> IngestionProgressStream {
-        let context = ctx.data_unchecked::<DevqlGraphqlContext>();
-        let receiver = context.subscriptions().subscribe_progress();
-
-        Box::pin(stream::unfold(
-            (receiver, repo_name),
-            |(mut receiver, repo_name)| async move {
-                loop {
-                    match receiver.recv().await {
-                        Ok(event) => {
-                            let event_repo_name = event.repo_name;
-                            let progress = event.event;
-                            if event_repo_name != repo_name {
-                                continue;
-                            }
-                            return Some((progress, (receiver, repo_name)));
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                            continue;
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
-                    }
-                }
-            },
-        ))
-    }
-
-    async fn sync_progress(
+    async fn task_progress(
         &self,
         ctx: &Context<'_>,
         #[graphql(name = "taskId")] task_id: String,
-    ) -> SyncProgressStream {
+    ) -> TaskProgressStream {
         let context = ctx.data_unchecked::<DevqlGraphqlContext>();
-        let receiver = context.subscriptions().subscribe_sync_progress();
+        let receiver = context.subscriptions().subscribe_task_progress();
 
         Box::pin(stream::unfold(
             (receiver, task_id),
@@ -97,7 +65,7 @@ impl SubscriptionRoot {
                             return Some((event.task.into(), (receiver, task_id)));
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                            if let Ok(Some(task)) = crate::daemon::sync_task(task_id.as_str()) {
+                            if let Ok(Some(task)) = crate::daemon::devql_task(task_id.as_str()) {
                                 return Some((task.into(), (receiver, task_id)));
                             }
                             continue;

--- a/bitloops/src/graphql/subscriptions.rs
+++ b/bitloops/src/graphql/subscriptions.rs
@@ -59,6 +59,8 @@ impl SubscriptionHub {
 
     pub(crate) fn publish_task(&self, task: DevqlTaskRecord) {
         let task_id = task.task_id.clone();
-        let _ = self.task_progress.send(TaskProgressMessage { task_id, task });
+        let _ = self
+            .task_progress
+            .send(TaskProgressMessage { task_id, task });
     }
 }

--- a/bitloops/src/graphql/subscriptions.rs
+++ b/bitloops/src/graphql/subscriptions.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use tokio::sync::broadcast;
 
-use super::types::{Checkpoint, IngestionProgressEvent};
-use crate::daemon::SyncTaskRecord;
+use super::types::Checkpoint;
+use crate::daemon::DevqlTaskRecord;
 
 const SUBSCRIPTION_CHANNEL_CAPACITY: usize = 128;
 
@@ -14,33 +14,24 @@ pub(crate) struct CheckpointIngestedEvent {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct IngestionProgressMessage {
-    pub(crate) repo_name: String,
-    pub(crate) event: IngestionProgressEvent,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct SyncTaskMessage {
+pub(crate) struct TaskProgressMessage {
     pub(crate) task_id: String,
-    pub(crate) task: SyncTaskRecord,
+    pub(crate) task: DevqlTaskRecord,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct SubscriptionHub {
     checkpoint_ingested: broadcast::Sender<CheckpointIngestedEvent>,
-    ingestion_progress: broadcast::Sender<IngestionProgressMessage>,
-    sync_progress: broadcast::Sender<SyncTaskMessage>,
+    task_progress: broadcast::Sender<TaskProgressMessage>,
 }
 
 impl Default for SubscriptionHub {
     fn default() -> Self {
         let (checkpoint_ingested, _) = broadcast::channel(SUBSCRIPTION_CHANNEL_CAPACITY);
-        let (ingestion_progress, _) = broadcast::channel(SUBSCRIPTION_CHANNEL_CAPACITY);
-        let (sync_progress, _) = broadcast::channel(SUBSCRIPTION_CHANNEL_CAPACITY);
+        let (task_progress, _) = broadcast::channel(SUBSCRIPTION_CHANNEL_CAPACITY);
         Self {
             checkpoint_ingested,
-            ingestion_progress,
-            sync_progress,
+            task_progress,
         }
     }
 }
@@ -54,12 +45,8 @@ impl SubscriptionHub {
         self.checkpoint_ingested.subscribe()
     }
 
-    pub(crate) fn subscribe_progress(&self) -> broadcast::Receiver<IngestionProgressMessage> {
-        self.ingestion_progress.subscribe()
-    }
-
-    pub(crate) fn subscribe_sync_progress(&self) -> broadcast::Receiver<SyncTaskMessage> {
-        self.sync_progress.subscribe()
+    pub(crate) fn subscribe_task_progress(&self) -> broadcast::Receiver<TaskProgressMessage> {
+        self.task_progress.subscribe()
     }
 
     pub(crate) fn publish_checkpoint(&self, repo_name: impl Into<String>, checkpoint: Checkpoint) {
@@ -70,19 +57,8 @@ impl SubscriptionHub {
         });
     }
 
-    pub(crate) fn publish_progress(
-        &self,
-        repo_name: impl Into<String>,
-        event: IngestionProgressEvent,
-    ) {
-        let repo_name = repo_name.into();
-        let _ = self
-            .ingestion_progress
-            .send(IngestionProgressMessage { repo_name, event });
-    }
-
-    pub(crate) fn publish_sync_task(&self, task: SyncTaskRecord) {
+    pub(crate) fn publish_task(&self, task: DevqlTaskRecord) {
         let task_id = task.task_id.clone();
-        let _ = self.sync_progress.send(SyncTaskMessage { task_id, task });
+        let _ = self.task_progress.send(TaskProgressMessage { task_id, task });
     }
 }

--- a/bitloops/src/graphql/types.rs
+++ b/bitloops/src/graphql/types.rs
@@ -46,7 +46,10 @@ pub use knowledge::{
 pub use project::Project;
 pub use repository::{Branch, Repository};
 pub use scalars::{DateTimeScalar, JsonScalar};
-pub use sync::{SyncProgressEvent, SyncTaskObject};
+pub use sync::{
+    TaskKind, TaskObject, TaskProgressEvent, TaskQueueControlResultObject, TaskQueueStatusObject,
+    TaskStatus,
+};
 pub use telemetry::TelemetryEvent;
 pub use temporal_scope::{AsOfInput, TemporalScope};
 pub use test_harness::{

--- a/bitloops/src/graphql/types/sync.rs
+++ b/bitloops/src/graphql/types/sync.rs
@@ -145,20 +145,22 @@ impl From<DevqlTaskRecord> for TaskObject {
         let ingest_spec = value.ingest_spec().map(|spec| IngestTaskSpecObject {
             backfill: spec.backfill.map(to_graphql_count),
         });
-        let sync_progress = value.sync_progress().map(|progress| SyncTaskProgressObject {
-            phase: progress.phase.as_str().to_string(),
-            current_path: progress.current_path.clone(),
-            paths_total: to_graphql_count(progress.paths_total),
-            paths_completed: to_graphql_count(progress.paths_completed),
-            paths_remaining: to_graphql_count(progress.paths_remaining),
-            paths_unchanged: to_graphql_count(progress.paths_unchanged),
-            paths_added: to_graphql_count(progress.paths_added),
-            paths_changed: to_graphql_count(progress.paths_changed),
-            paths_removed: to_graphql_count(progress.paths_removed),
-            cache_hits: to_graphql_count(progress.cache_hits),
-            cache_misses: to_graphql_count(progress.cache_misses),
-            parse_errors: to_graphql_count(progress.parse_errors),
-        });
+        let sync_progress = value
+            .sync_progress()
+            .map(|progress| SyncTaskProgressObject {
+                phase: progress.phase.as_str().to_string(),
+                current_path: progress.current_path.clone(),
+                paths_total: to_graphql_count(progress.paths_total),
+                paths_completed: to_graphql_count(progress.paths_completed),
+                paths_remaining: to_graphql_count(progress.paths_remaining),
+                paths_unchanged: to_graphql_count(progress.paths_unchanged),
+                paths_added: to_graphql_count(progress.paths_added),
+                paths_changed: to_graphql_count(progress.paths_changed),
+                paths_removed: to_graphql_count(progress.paths_removed),
+                cache_hits: to_graphql_count(progress.cache_hits),
+                cache_misses: to_graphql_count(progress.cache_misses),
+                parse_errors: to_graphql_count(progress.parse_errors),
+            });
         let ingest_progress = value.ingest_progress().cloned().map(Into::into);
         let sync_result = value.sync_result().cloned().map(Into::into);
         let ingest_result = value.ingest_result().cloned().map(Into::into);
@@ -259,7 +261,11 @@ impl From<DevqlTaskQueueStatus> for TaskQueueStatusObject {
                 .and_then(|control| control.paused_reason.clone()),
             last_action: value.state.last_action,
             last_updated_unix: value.state.last_updated_unix as i64,
-            current_repo_tasks: value.current_repo_tasks.into_iter().map(Into::into).collect(),
+            current_repo_tasks: value
+                .current_repo_tasks
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }

--- a/bitloops/src/graphql/types/sync.rs
+++ b/bitloops/src/graphql/types/sync.rs
@@ -1,24 +1,42 @@
-use async_graphql::SimpleObject;
+use async_graphql::{Enum, SimpleObject};
 
-use crate::daemon::SyncTaskRecord;
-use crate::graphql::mutation_root::SyncResult;
+use crate::daemon::{
+    DevqlTaskControlResult, DevqlTaskKindCounts, DevqlTaskQueueStatus, DevqlTaskRecord,
+    DevqlTaskStatus,
+};
+use crate::graphql::mutation_root::{IngestResult, SyncResult};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+pub enum TaskKind {
+    Sync,
+    Ingest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
+pub enum TaskStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
 
 #[derive(Debug, Clone, SimpleObject)]
-#[graphql(name = "SyncTask")]
-pub struct SyncTaskObject {
-    pub task_id: String,
-    pub repo_id: String,
-    pub repo_name: String,
-    pub repo_identity: String,
-    pub source: String,
+#[graphql(name = "SyncTaskSpec")]
+pub struct SyncTaskSpecObject {
     pub mode: String,
-    pub status: String,
-    pub submitted_at_unix: i64,
-    pub started_at_unix: Option<i64>,
-    pub updated_at_unix: i64,
-    pub completed_at_unix: Option<i64>,
-    pub queue_position: Option<i32>,
-    pub tasks_ahead: Option<i32>,
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "IngestTaskSpec")]
+pub struct IngestTaskSpecObject {
+    pub backfill: Option<i32>,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "SyncTaskProgress")]
+pub struct SyncTaskProgressObject {
     pub phase: String,
     pub current_path: Option<String>,
     pub paths_total: i32,
@@ -31,227 +49,233 @@ pub struct SyncTaskObject {
     pub cache_hits: i32,
     pub cache_misses: i32,
     pub parse_errors: i32,
-    pub error: Option<String>,
-    pub summary: Option<SyncResult>,
 }
 
 #[derive(Debug, Clone, SimpleObject)]
-#[graphql(name = "SyncProgressEvent")]
-pub struct SyncProgressEvent {
+#[graphql(name = "Task")]
+pub struct TaskObject {
     pub task_id: String,
     pub repo_id: String,
     pub repo_name: String,
     pub repo_identity: String,
+    pub kind: TaskKind,
     pub source: String,
-    pub mode: String,
-    pub status: String,
+    pub status: TaskStatus,
     pub submitted_at_unix: i64,
     pub started_at_unix: Option<i64>,
     pub updated_at_unix: i64,
     pub completed_at_unix: Option<i64>,
     pub queue_position: Option<i32>,
     pub tasks_ahead: Option<i32>,
-    pub phase: String,
-    pub current_path: Option<String>,
-    pub paths_total: i32,
-    pub paths_completed: i32,
-    pub paths_remaining: i32,
-    pub paths_unchanged: i32,
-    pub paths_added: i32,
-    pub paths_changed: i32,
-    pub paths_removed: i32,
-    pub cache_hits: i32,
-    pub cache_misses: i32,
-    pub parse_errors: i32,
     pub error: Option<String>,
-    pub summary: Option<SyncResult>,
+    pub sync_spec: Option<SyncTaskSpecObject>,
+    pub ingest_spec: Option<IngestTaskSpecObject>,
+    pub sync_progress: Option<SyncTaskProgressObject>,
+    pub ingest_progress: Option<super::IngestionProgressEvent>,
+    pub sync_result: Option<SyncResult>,
+    pub ingest_result: Option<IngestResult>,
 }
 
-impl From<SyncTaskRecord> for SyncTaskObject {
-    fn from(value: SyncTaskRecord) -> Self {
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "TaskProgressEvent")]
+pub struct TaskProgressEvent {
+    pub task: TaskObject,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "TaskKindCounts")]
+pub struct TaskKindCountsObject {
+    pub kind: TaskKind,
+    pub queued_tasks: i32,
+    pub running_tasks: i32,
+    pub failed_tasks: i32,
+    pub completed_recent_tasks: i32,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "TaskQueueStatus")]
+pub struct TaskQueueStatusObject {
+    pub persisted: bool,
+    pub queued_tasks: i32,
+    pub running_tasks: i32,
+    pub failed_tasks: i32,
+    pub completed_recent_tasks: i32,
+    pub by_kind: Vec<TaskKindCountsObject>,
+    pub paused: bool,
+    pub paused_reason: Option<String>,
+    pub last_action: Option<String>,
+    pub last_updated_unix: i64,
+    pub current_repo_tasks: Vec<TaskObject>,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+#[graphql(name = "TaskQueueControlResult")]
+pub struct TaskQueueControlResultObject {
+    pub message: String,
+    pub repo_id: String,
+    pub paused: bool,
+    pub paused_reason: Option<String>,
+    pub updated_at_unix: i64,
+}
+
+impl From<DevqlTaskRecord> for TaskObject {
+    fn from(value: DevqlTaskRecord) -> Self {
+        let sync_spec = value.sync_spec().map(|spec| match &spec.mode {
+            crate::daemon::SyncTaskMode::Auto => SyncTaskSpecObject {
+                mode: "auto".to_string(),
+                paths: Vec::new(),
+            },
+            crate::daemon::SyncTaskMode::Full => SyncTaskSpecObject {
+                mode: "full".to_string(),
+                paths: Vec::new(),
+            },
+            crate::daemon::SyncTaskMode::Paths { paths } => SyncTaskSpecObject {
+                mode: "paths".to_string(),
+                paths: paths.clone(),
+            },
+            crate::daemon::SyncTaskMode::Repair => SyncTaskSpecObject {
+                mode: "repair".to_string(),
+                paths: Vec::new(),
+            },
+            crate::daemon::SyncTaskMode::Validate => SyncTaskSpecObject {
+                mode: "validate".to_string(),
+                paths: Vec::new(),
+            },
+        });
+        let ingest_spec = value.ingest_spec().map(|spec| IngestTaskSpecObject {
+            backfill: spec.backfill.map(to_graphql_count),
+        });
+        let sync_progress = value.sync_progress().map(|progress| SyncTaskProgressObject {
+            phase: progress.phase.as_str().to_string(),
+            current_path: progress.current_path.clone(),
+            paths_total: to_graphql_count(progress.paths_total),
+            paths_completed: to_graphql_count(progress.paths_completed),
+            paths_remaining: to_graphql_count(progress.paths_remaining),
+            paths_unchanged: to_graphql_count(progress.paths_unchanged),
+            paths_added: to_graphql_count(progress.paths_added),
+            paths_changed: to_graphql_count(progress.paths_changed),
+            paths_removed: to_graphql_count(progress.paths_removed),
+            cache_hits: to_graphql_count(progress.cache_hits),
+            cache_misses: to_graphql_count(progress.cache_misses),
+            parse_errors: to_graphql_count(progress.parse_errors),
+        });
+        let ingest_progress = value.ingest_progress().cloned().map(Into::into);
+        let sync_result = value.sync_result().cloned().map(Into::into);
+        let ingest_result = value.ingest_result().cloned().map(Into::into);
+
         Self {
             task_id: value.task_id,
             repo_id: value.repo_id,
             repo_name: value.repo_name,
             repo_identity: value.repo_identity,
+            kind: match value.kind {
+                crate::daemon::DevqlTaskKind::Sync => TaskKind::Sync,
+                crate::daemon::DevqlTaskKind::Ingest => TaskKind::Ingest,
+            },
             source: value.source.to_string(),
-            mode: value.mode.to_string(),
-            status: value.status.to_string(),
+            status: match value.status {
+                DevqlTaskStatus::Queued => TaskStatus::Queued,
+                DevqlTaskStatus::Running => TaskStatus::Running,
+                DevqlTaskStatus::Completed => TaskStatus::Completed,
+                DevqlTaskStatus::Failed => TaskStatus::Failed,
+                DevqlTaskStatus::Cancelled => TaskStatus::Cancelled,
+            },
             submitted_at_unix: value.submitted_at_unix as i64,
             started_at_unix: value.started_at_unix.map(|value| value as i64),
             updated_at_unix: value.updated_at_unix as i64,
             completed_at_unix: value.completed_at_unix.map(|value| value as i64),
             queue_position: value.queue_position.map(to_graphql_count),
             tasks_ahead: value.tasks_ahead.map(to_graphql_count),
-            phase: value.progress.phase.as_str().to_string(),
-            current_path: value.progress.current_path,
-            paths_total: to_graphql_count(value.progress.paths_total),
-            paths_completed: to_graphql_count(value.progress.paths_completed),
-            paths_remaining: to_graphql_count(value.progress.paths_remaining),
-            paths_unchanged: to_graphql_count(value.progress.paths_unchanged),
-            paths_added: to_graphql_count(value.progress.paths_added),
-            paths_changed: to_graphql_count(value.progress.paths_changed),
-            paths_removed: to_graphql_count(value.progress.paths_removed),
-            cache_hits: to_graphql_count(value.progress.cache_hits),
-            cache_misses: to_graphql_count(value.progress.cache_misses),
-            parse_errors: to_graphql_count(value.progress.parse_errors),
             error: value.error,
-            summary: value.summary.map(Into::into),
+            sync_spec,
+            ingest_spec,
+            sync_progress,
+            ingest_progress,
+            sync_result,
+            ingest_result,
         }
     }
 }
 
-impl From<SyncTaskRecord> for SyncProgressEvent {
-    fn from(value: SyncTaskRecord) -> Self {
-        let task: SyncTaskObject = value.into();
+impl From<DevqlTaskRecord> for TaskProgressEvent {
+    fn from(value: DevqlTaskRecord) -> Self {
+        Self { task: value.into() }
+    }
+}
+
+impl From<TaskKind> for crate::daemon::DevqlTaskKind {
+    fn from(value: TaskKind) -> Self {
+        match value {
+            TaskKind::Sync => Self::Sync,
+            TaskKind::Ingest => Self::Ingest,
+        }
+    }
+}
+
+impl From<TaskStatus> for crate::daemon::DevqlTaskStatus {
+    fn from(value: TaskStatus) -> Self {
+        match value {
+            TaskStatus::Queued => Self::Queued,
+            TaskStatus::Running => Self::Running,
+            TaskStatus::Completed => Self::Completed,
+            TaskStatus::Failed => Self::Failed,
+            TaskStatus::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
+impl From<DevqlTaskKindCounts> for TaskKindCountsObject {
+    fn from(value: DevqlTaskKindCounts) -> Self {
         Self {
-            task_id: task.task_id,
-            repo_id: task.repo_id,
-            repo_name: task.repo_name,
-            repo_identity: task.repo_identity,
-            source: task.source,
-            mode: task.mode,
-            status: task.status,
-            submitted_at_unix: task.submitted_at_unix,
-            started_at_unix: task.started_at_unix,
-            updated_at_unix: task.updated_at_unix,
-            completed_at_unix: task.completed_at_unix,
-            queue_position: task.queue_position,
-            tasks_ahead: task.tasks_ahead,
-            phase: task.phase,
-            current_path: task.current_path,
-            paths_total: task.paths_total,
-            paths_completed: task.paths_completed,
-            paths_remaining: task.paths_remaining,
-            paths_unchanged: task.paths_unchanged,
-            paths_added: task.paths_added,
-            paths_changed: task.paths_changed,
-            paths_removed: task.paths_removed,
-            cache_hits: task.cache_hits,
-            cache_misses: task.cache_misses,
-            parse_errors: task.parse_errors,
-            error: task.error,
-            summary: task.summary,
+            kind: match value.kind {
+                crate::daemon::DevqlTaskKind::Sync => TaskKind::Sync,
+                crate::daemon::DevqlTaskKind::Ingest => TaskKind::Ingest,
+            },
+            queued_tasks: to_graphql_count(value.queued_tasks),
+            running_tasks: to_graphql_count(value.running_tasks),
+            failed_tasks: to_graphql_count(value.failed_tasks),
+            completed_recent_tasks: to_graphql_count(value.completed_recent_tasks),
+        }
+    }
+}
+
+impl From<DevqlTaskQueueStatus> for TaskQueueStatusObject {
+    fn from(value: DevqlTaskQueueStatus) -> Self {
+        Self {
+            persisted: value.persisted,
+            queued_tasks: to_graphql_count(value.state.queued_tasks),
+            running_tasks: to_graphql_count(value.state.running_tasks),
+            failed_tasks: to_graphql_count(value.state.failed_tasks),
+            completed_recent_tasks: to_graphql_count(value.state.completed_recent_tasks),
+            by_kind: value.state.by_kind.into_iter().map(Into::into).collect(),
+            paused: value
+                .current_repo_control
+                .as_ref()
+                .map(|control| control.paused)
+                .unwrap_or(false),
+            paused_reason: value
+                .current_repo_control
+                .as_ref()
+                .and_then(|control| control.paused_reason.clone()),
+            last_action: value.state.last_action,
+            last_updated_unix: value.state.last_updated_unix as i64,
+            current_repo_tasks: value.current_repo_tasks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<DevqlTaskControlResult> for TaskQueueControlResultObject {
+    fn from(value: DevqlTaskControlResult) -> Self {
+        Self {
+            message: value.message,
+            repo_id: value.control.repo_id,
+            paused: value.control.paused,
+            paused_reason: value.control.paused_reason,
+            updated_at_unix: value.control.updated_at_unix as i64,
         }
     }
 }
 
 fn to_graphql_count(value: impl TryInto<i32>) -> i32 {
     value.try_into().unwrap_or(i32::MAX)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn sample_sync_record() -> SyncTaskRecord {
-        SyncTaskRecord {
-            task_id: "sync-task-1".to_string(),
-            repo_id: "repo-1".to_string(),
-            repo_name: "bitloops".to_string(),
-            repo_provider: "local".to_string(),
-            repo_organisation: "local".to_string(),
-            repo_identity: "local/bitloops".to_string(),
-            daemon_config_root: std::path::PathBuf::from("/tmp/config"),
-            repo_root: std::path::PathBuf::from("/tmp/repo"),
-            source: crate::daemon::SyncTaskSource::ManualCli,
-            mode: crate::daemon::SyncTaskMode::Validate,
-            status: crate::daemon::SyncTaskStatus::Running,
-            submitted_at_unix: 1,
-            started_at_unix: Some(2),
-            updated_at_unix: 3,
-            completed_at_unix: None,
-            queue_position: Some((i32::MAX as u64) + 1),
-            tasks_ahead: Some((i32::MAX as u64) + 2),
-            progress: crate::host::devql::SyncProgressUpdate {
-                phase: crate::host::devql::SyncProgressPhase::MaterialisingPaths,
-                current_path: Some("src/lib.rs".to_string()),
-                paths_total: (i32::MAX as usize) + 3,
-                paths_completed: (i32::MAX as usize) + 4,
-                paths_remaining: (i32::MAX as usize) + 5,
-                paths_unchanged: (i32::MAX as usize) + 6,
-                paths_added: (i32::MAX as usize) + 7,
-                paths_changed: (i32::MAX as usize) + 8,
-                paths_removed: (i32::MAX as usize) + 9,
-                cache_hits: (i32::MAX as usize) + 10,
-                cache_misses: (i32::MAX as usize) + 11,
-                parse_errors: (i32::MAX as usize) + 12,
-            },
-            error: Some("boom".to_string()),
-            summary: Some(crate::host::devql::SyncSummary {
-                success: false,
-                mode: "validate".to_string(),
-                parser_version: "parser@1".to_string(),
-                extractor_version: "extractor@1".to_string(),
-                active_branch: Some("main".to_string()),
-                head_commit_sha: Some("abc".to_string()),
-                head_tree_sha: Some("def".to_string()),
-                paths_unchanged: 1,
-                paths_added: 2,
-                paths_changed: 3,
-                paths_removed: 4,
-                cache_hits: 5,
-                cache_misses: 6,
-                parse_errors: 7,
-                validation: Some(crate::host::devql::SyncValidationSummary {
-                    valid: false,
-                    expected_artefacts: 10,
-                    actual_artefacts: 9,
-                    expected_edges: 8,
-                    actual_edges: 7,
-                    missing_artefacts: 1,
-                    stale_artefacts: 2,
-                    mismatched_artefacts: 3,
-                    missing_edges: 4,
-                    stale_edges: 5,
-                    mismatched_edges: 6,
-                    files_with_drift: vec![crate::host::devql::SyncValidationFileDrift {
-                        path: "src/lib.rs".to_string(),
-                        missing_artefacts: 1,
-                        stale_artefacts: 2,
-                        mismatched_artefacts: 3,
-                        missing_edges: 4,
-                        stale_edges: 5,
-                        mismatched_edges: 6,
-                    }],
-                }),
-            }),
-        }
-    }
-
-    #[test]
-    fn sync_task_object_from_record_maps_fields_and_clamps_counts() {
-        let object = SyncTaskObject::from(sample_sync_record());
-        assert_eq!(object.task_id, "sync-task-1");
-        assert_eq!(object.source, "manual_cli");
-        assert_eq!(object.mode, "validate");
-        assert_eq!(object.status, "running");
-        assert_eq!(object.phase, "materialising_paths");
-        assert_eq!(object.queue_position, Some(i32::MAX));
-        assert_eq!(object.tasks_ahead, Some(i32::MAX));
-        assert_eq!(object.paths_total, i32::MAX);
-        assert_eq!(object.cache_misses, i32::MAX);
-        assert_eq!(object.parse_errors, i32::MAX);
-        let summary = object.summary.expect("summary");
-        assert_eq!(summary.mode, "validate");
-        assert_eq!(summary.paths_added, 2);
-        assert!(summary.validation.is_some());
-    }
-
-    #[test]
-    fn sync_progress_event_reuses_sync_task_conversion() {
-        let event = SyncProgressEvent::from(sample_sync_record());
-        assert_eq!(event.task_id, "sync-task-1");
-        assert_eq!(event.phase, "materialising_paths");
-        assert_eq!(event.queue_position, Some(i32::MAX));
-        assert_eq!(event.paths_changed, i32::MAX);
-        assert_eq!(event.error.as_deref(), Some("boom"));
-        assert!(event.summary.is_some());
-    }
-
-    #[test]
-    fn to_graphql_count_clamps_large_inputs() {
-        assert_eq!(to_graphql_count(123u32), 123);
-        assert_eq!(to_graphql_count((i32::MAX as i64) + 1), i32::MAX);
-    }
 }

--- a/bitloops/src/host/capability_host/gateways/sqlite_relational.rs
+++ b/bitloops/src/host/capability_host/gateways/sqlite_relational.rs
@@ -56,7 +56,7 @@ impl SqliteRelationalGateway {
                 .query_row(params![commit_sha], |row| row.get(0))
                 .with_context(|| {
                     format!(
-                        "no production artefacts found for commit {}; materialize production artefacts first (use `bitloops devql ingest` or `bitloops devql sync`)",
+                        "no production artefacts found for commit {}; materialise production artefacts first (use `bitloops devql tasks enqueue --kind ingest --status` or `bitloops devql tasks enqueue --kind sync --status`)",
                         commit_sha
                     )
                 })?;

--- a/bitloops/src/host/devql/capture.rs
+++ b/bitloops/src/host/devql/capture.rs
@@ -158,7 +158,7 @@ async fn sync_changed_paths(
     {
         crate::daemon::enqueue_sync_for_config(
             cfg,
-            crate::daemon::SyncTaskSource::Watcher,
+            crate::daemon::DevqlTaskSource::Watcher,
             crate::host::devql::SyncMode::Paths(paths),
         )
         .context("queueing DevQL sync for watcher capture paths")?;

--- a/bitloops/src/host/devql/commands_refresh.rs
+++ b/bitloops/src/host/devql/commands_refresh.rs
@@ -33,7 +33,7 @@ impl PostCommitArtefactRefreshStats {
         }
     }
 
-    fn queued(files_seen: usize, queued: crate::daemon::SyncEnqueueResult) -> Self {
+    fn queued(files_seen: usize, queued: crate::daemon::DevqlTaskEnqueueResult) -> Self {
         Self {
             files_seen,
             files_indexed: 0,
@@ -125,9 +125,9 @@ async fn sync_changed_paths(
     #[cfg(not(test))]
     {
         let source = match source_hook {
-            "post-commit" => crate::daemon::SyncTaskSource::PostCommit,
-            "post-merge" => crate::daemon::SyncTaskSource::PostMerge,
-            _ => crate::daemon::SyncTaskSource::ManualCli,
+            "post-commit" => crate::daemon::DevqlTaskSource::PostCommit,
+            "post-merge" => crate::daemon::DevqlTaskSource::PostMerge,
+            _ => crate::daemon::DevqlTaskSource::ManualCli,
         };
         let queued = crate::daemon::enqueue_sync_for_config(cfg, source, SyncMode::Paths(paths))
             .with_context(|| format!("queueing DevQL sync for {source_hook} refresh"))?;
@@ -189,7 +189,7 @@ pub async fn run_post_checkout_branch_seed(
     {
         crate::daemon::enqueue_sync_for_config(
             cfg,
-            crate::daemon::SyncTaskSource::PostCheckout,
+            crate::daemon::DevqlTaskSource::PostCheckout,
             SyncMode::Full,
         )
         .context("queueing full DevQL sync for post-checkout branch seed")?;
@@ -205,11 +205,14 @@ fn is_zero_git_oid(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::daemon::{SyncTaskMode, SyncTaskRecord, SyncTaskSource, SyncTaskStatus};
+    use crate::daemon::{
+        DevqlTaskKind, DevqlTaskProgress, DevqlTaskRecord, DevqlTaskSource, DevqlTaskSpec,
+        DevqlTaskStatus, SyncTaskMode, SyncTaskSpec,
+    };
 
-    fn sample_queued_result() -> crate::daemon::SyncEnqueueResult {
-        crate::daemon::SyncEnqueueResult {
-            task: SyncTaskRecord {
+    fn sample_queued_result() -> crate::daemon::DevqlTaskEnqueueResult {
+        crate::daemon::DevqlTaskEnqueueResult {
+            task: DevqlTaskRecord {
                 task_id: "sync-task-123".to_string(),
                 repo_id: "repo-1".to_string(),
                 repo_name: "demo".to_string(),
@@ -218,20 +221,23 @@ mod tests {
                 repo_identity: "local/demo".to_string(),
                 daemon_config_root: PathBuf::from("/tmp/repo"),
                 repo_root: PathBuf::from("/tmp/repo"),
-                source: SyncTaskSource::PostCommit,
-                mode: SyncTaskMode::Paths {
-                    paths: vec!["src/lib.rs".to_string()],
-                },
-                status: SyncTaskStatus::Queued,
+                kind: DevqlTaskKind::Sync,
+                source: DevqlTaskSource::PostCommit,
+                spec: DevqlTaskSpec::Sync(SyncTaskSpec {
+                    mode: SyncTaskMode::Paths {
+                        paths: vec!["src/lib.rs".to_string()],
+                    },
+                }),
+                status: DevqlTaskStatus::Queued,
                 submitted_at_unix: 1,
                 started_at_unix: None,
                 updated_at_unix: 1,
                 completed_at_unix: None,
                 queue_position: Some(3),
                 tasks_ahead: Some(2),
-                progress: SyncProgressUpdate::default(),
+                progress: DevqlTaskProgress::Sync(SyncProgressUpdate::default()),
                 error: None,
-                summary: None,
+                result: None,
             },
             merged: true,
         }

--- a/bitloops/src/host/devql/commands_sync/orchestrator.rs
+++ b/bitloops/src/host/devql/commands_sync/orchestrator.rs
@@ -55,7 +55,7 @@ pub async fn run_sync_with_summary_and_observer_and_diffs(
         return match execute_sync_validation(cfg, &relational).await {
             Ok(summary) => Ok((summary, SyncFileDiff::default(), SyncArtefactDiff::default())),
             Err(err) if is_missing_sync_schema_error(&err) => Err(err).context(
-                "DevQL sync schema is not initialised. Run `bitloops devql init` before `bitloops devql sync --validate`.",
+                "DevQL sync schema is not initialised. Run `bitloops devql init` before `bitloops devql tasks enqueue --kind sync --validate --status`.",
             ),
             Err(err) => Err(err),
         };
@@ -67,7 +67,7 @@ pub async fn run_sync_with_summary_and_observer_and_diffs(
             Ok((summary, file_diff, artefact_diff))
         }
         Err(err) if is_missing_sync_schema_error(&err) => Err(err).context(
-            "DevQL sync schema is not initialised. Run `bitloops devql init` before `bitloops devql sync`.",
+            "DevQL sync schema is not initialised. Run `bitloops devql init` before `bitloops devql tasks enqueue --kind sync --status`.",
         ),
         Err(err) => Err(err),
     }

--- a/bitloops/src/host/devql/ingestion/types.rs
+++ b/bitloops/src/host/devql/ingestion/types.rs
@@ -2,9 +2,9 @@ use crate::host::checkpoints::strategy::manual_commit::CommittedInfo;
 
 // Shared types used across ingestion modules.
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", default)]
-pub(crate) struct IngestionCounters {
+pub struct IngestionCounters {
     pub(crate) success: bool,
     #[serde(skip_serializing)]
     pub(crate) init_requested: bool,
@@ -25,8 +25,9 @@ pub(crate) struct IngestionCounters {
     pub(crate) symbol_clone_sources_scored: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum IngestionProgressPhase {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestionProgressPhase {
     Initializing,
     Extracting,
     Persisting,
@@ -34,8 +35,9 @@ pub(crate) enum IngestionProgressPhase {
     Failed,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct IngestionProgressUpdate {
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IngestionProgressUpdate {
     pub(crate) phase: IngestionProgressPhase,
     pub(crate) commits_total: usize,
     pub(crate) commits_processed: usize,

--- a/bitloops/src/host/devql/tests/devql_tests.rs
+++ b/bitloops/src/host/devql/tests/devql_tests.rs
@@ -649,17 +649,24 @@ mod query_pipeline;
 
 #[test]
 fn devql_cli_parses_ingest_defaults() {
-    let parsed =
-        Cli::try_parse_from(["bitloops", "devql", "ingest"]).expect("devql ingest should parse");
+    let parsed = Cli::try_parse_from(["bitloops", "devql", "tasks", "enqueue", "--kind", "ingest"])
+        .expect("devql task ingest enqueue should parse");
 
     let Some(Commands::Devql(args)) = parsed.command else {
         panic!("expected devql command");
     };
-    let Some(DevqlCommand::Ingest(ingest)) = args.command else {
-        panic!("expected devql ingest command");
+    let Some(DevqlCommand::Tasks(tasks)) = args.command else {
+        panic!("expected devql tasks command");
     };
-
-    let _ = ingest;
+    match tasks.command {
+        crate::cli::devql::DevqlTasksCommand::Enqueue(enqueue) => {
+            assert!(matches!(
+                enqueue.kind,
+                crate::cli::devql::DevqlTaskKindArg::Ingest
+            ));
+        }
+        other => panic!("expected task enqueue command, got {other:?}"),
+    }
 }
 
 #[test]

--- a/bitloops/src/host/devql/tests/devql_tests/identity_and_schema.rs
+++ b/bitloops/src/host/devql/tests/devql_tests/identity_and_schema.rs
@@ -293,8 +293,17 @@ fn incoming_revision_is_newer_rejects_older_commits_and_uses_commit_sha_as_tiebr
 #[test]
 fn devql_ingest_rejects_removed_init_flag() {
     assert!(
-        crate::cli::Cli::try_parse_from(["bitloops", "devql", "ingest", "--init=false"]).is_err(),
-        "devql ingest should reject the removed --init flag"
+        crate::cli::Cli::try_parse_from([
+            "bitloops",
+            "devql",
+            "tasks",
+            "enqueue",
+            "--kind",
+            "ingest",
+            "--init=false",
+        ])
+        .is_err(),
+        "devql task enqueue ingest should reject the removed --init flag"
     );
 }
 

--- a/bitloops/src/host/runtime_store.rs
+++ b/bitloops/src/host/runtime_store.rs
@@ -16,7 +16,8 @@ mod util;
 mod tests;
 
 pub use types::{
-    DaemonSqliteRuntimeStore, PersistedCapabilityEventQueueState, PersistedSyncQueueState,
-    RepoSqliteRuntimeStore, RepoWatcherRegistration, RuntimeMetadataBlobType, RuntimeStore,
-    SessionMetadataSnapshot, SqliteRuntimeStore, TaskCheckpointArtefact,
+    DaemonSqliteRuntimeStore, LegacySyncTaskRecord, PersistedCapabilityEventQueueState,
+    PersistedDevqlTaskQueueState, PersistedSyncQueueState, RepoSqliteRuntimeStore,
+    RepoWatcherRegistration, RuntimeMetadataBlobType, RuntimeStore, SessionMetadataSnapshot,
+    SqliteRuntimeStore, TaskCheckpointArtefact,
 };

--- a/bitloops/src/host/runtime_store/daemon_documents.rs
+++ b/bitloops/src/host/runtime_store/daemon_documents.rs
@@ -446,7 +446,9 @@ fn migrate_legacy_sync_queue_state(
                 tasks_ahead: task.tasks_ahead,
                 progress: crate::daemon::DevqlTaskProgress::Sync(task.progress),
                 error: task.error,
-                result: task.summary.map(crate::daemon::DevqlTaskResult::Sync),
+                result: task
+                    .summary
+                    .map(|summary| crate::daemon::DevqlTaskResult::Sync(Box::new(summary))),
             })
             .collect(),
         repo_controls: Default::default(),

--- a/bitloops/src/host/runtime_store/daemon_documents.rs
+++ b/bitloops/src/host/runtime_store/daemon_documents.rs
@@ -14,7 +14,8 @@ use crate::storage::SqliteConnectionPool;
 use crate::utils::paths::default_global_runtime_db_path;
 
 use super::types::{
-    DaemonSqliteRuntimeStore, PersistedCapabilityEventQueueState, PersistedSyncQueueState,
+    DaemonSqliteRuntimeStore, PersistedCapabilityEventQueueState, PersistedDevqlTaskQueueState,
+    PersistedSyncQueueState,
 };
 
 const RUNTIME_DOCUMENTS_SCHEMA: &str = r#"
@@ -55,6 +56,10 @@ impl DaemonSqliteRuntimeStore {
 
     pub fn runtime_state_exists(&self) -> Result<bool> {
         self.document_exists(document_key_runtime_state())
+    }
+
+    pub fn devql_task_state_exists(&self) -> Result<bool> {
+        self.document_exists(document_key_devql_task_state())
     }
 
     pub fn sync_state_exists(&self) -> Result<bool> {
@@ -139,6 +144,46 @@ impl DaemonSqliteRuntimeStore {
             state.normalise_legacy_values();
         }
         Ok(state)
+    }
+
+    pub fn load_devql_task_queue_state(&self) -> Result<Option<PersistedDevqlTaskQueueState>> {
+        let mut state: Option<PersistedDevqlTaskQueueState> =
+            self.load_document(document_key_devql_task_state(), None)?;
+        if let Some(state) = state.as_mut() {
+            state.normalise_legacy_values();
+            return Ok(Some(state.clone()));
+        }
+
+        let Some(legacy_state) = self.load_sync_queue_state()? else {
+            return Ok(None);
+        };
+        let migrated = migrate_legacy_sync_queue_state(legacy_state);
+        self.save_document(document_key_devql_task_state(), &migrated)?;
+        Ok(Some(migrated))
+    }
+
+    pub fn mutate_devql_task_queue_state<T>(
+        &self,
+        mutate: impl FnOnce(&mut PersistedDevqlTaskQueueState) -> Result<T>,
+    ) -> Result<T> {
+        if !self.devql_task_state_exists()?
+            && let Some(legacy_state) = self.load_sync_queue_state()?
+        {
+            self.save_document(
+                document_key_devql_task_state(),
+                &migrate_legacy_sync_queue_state(legacy_state),
+            )?;
+        }
+
+        self.mutate_document(
+            document_key_devql_task_state(),
+            None,
+            PersistedDevqlTaskQueueState::default,
+            |state| {
+                state.normalise_legacy_values();
+                mutate(state)
+            },
+        )
     }
 
     pub fn mutate_sync_queue_state<T>(
@@ -348,6 +393,10 @@ fn document_key_sync_state() -> &'static str {
     "sync_queue_state"
 }
 
+fn document_key_devql_task_state() -> &'static str {
+    "devql_task_queue_state"
+}
+
 fn document_key_enrichment_state() -> &'static str {
     "enrichment_queue_state"
 }
@@ -364,6 +413,46 @@ fn daemon_state_root() -> PathBuf {
 
 fn sync_state_legacy_path() -> PathBuf {
     daemon_state_root().join(crate::daemon::SYNC_STATE_FILE_NAME)
+}
+
+fn migrate_legacy_sync_queue_state(
+    legacy: PersistedSyncQueueState,
+) -> PersistedDevqlTaskQueueState {
+    PersistedDevqlTaskQueueState {
+        version: legacy.version,
+        tasks: legacy
+            .tasks
+            .into_iter()
+            .map(|task| crate::daemon::DevqlTaskRecord {
+                task_id: task.task_id,
+                repo_id: task.repo_id,
+                repo_name: task.repo_name,
+                repo_provider: task.repo_provider,
+                repo_organisation: task.repo_organisation,
+                repo_identity: task.repo_identity,
+                daemon_config_root: task.daemon_config_root,
+                repo_root: task.repo_root,
+                kind: crate::daemon::DevqlTaskKind::Sync,
+                source: task.source,
+                spec: crate::daemon::DevqlTaskSpec::Sync(crate::daemon::SyncTaskSpec {
+                    mode: task.mode,
+                }),
+                status: task.status,
+                submitted_at_unix: task.submitted_at_unix,
+                started_at_unix: task.started_at_unix,
+                updated_at_unix: task.updated_at_unix,
+                completed_at_unix: task.completed_at_unix,
+                queue_position: task.queue_position,
+                tasks_ahead: task.tasks_ahead,
+                progress: crate::daemon::DevqlTaskProgress::Sync(task.progress),
+                error: task.error,
+                result: task.summary.map(crate::daemon::DevqlTaskResult::Sync),
+            })
+            .collect(),
+        repo_controls: Default::default(),
+        last_action: legacy.last_action,
+        updated_at_unix: legacy.updated_at_unix,
+    }
 }
 
 fn enrichment_state_legacy_path() -> PathBuf {

--- a/bitloops/src/host/runtime_store/tests.rs
+++ b/bitloops/src/host/runtime_store/tests.rs
@@ -464,7 +464,7 @@ fn daemon_runtime_store_loads_legacy_sync_queue_state_with_config_root_field() {
         || {
             let store = DaemonSqliteRuntimeStore::open().expect("open daemon runtime store");
 
-            let task = crate::daemon::SyncTaskRecord {
+            let task = crate::host::runtime_store::LegacySyncTaskRecord {
                 task_id: "sync-task-legacy".to_string(),
                 repo_id: "repo-1".to_string(),
                 repo_name: "bitloops".to_string(),
@@ -473,9 +473,9 @@ fn daemon_runtime_store_loads_legacy_sync_queue_state_with_config_root_field() {
                 repo_identity: "local/bitloops".to_string(),
                 daemon_config_root: PathBuf::from("/tmp/legacy-config"),
                 repo_root: PathBuf::from("/tmp/repo"),
-                source: crate::daemon::SyncTaskSource::ManualCli,
+                source: crate::daemon::DevqlTaskSource::ManualCli,
                 mode: crate::daemon::SyncTaskMode::Full,
-                status: crate::daemon::SyncTaskStatus::Queued,
+                status: crate::daemon::DevqlTaskStatus::Queued,
                 submitted_at_unix: 1,
                 started_at_unix: None,
                 updated_at_unix: 1,

--- a/bitloops/src/host/runtime_store/types.rs
+++ b/bitloops/src/host/runtime_store/types.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -40,7 +41,41 @@ pub struct DaemonSqliteRuntimeStore {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PersistedSyncQueueState {
     pub version: u8,
-    pub tasks: Vec<crate::daemon::SyncTaskRecord>,
+    pub tasks: Vec<LegacySyncTaskRecord>,
+    pub last_action: Option<String>,
+    pub updated_at_unix: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LegacySyncTaskRecord {
+    pub task_id: String,
+    pub repo_id: String,
+    pub repo_name: String,
+    pub repo_provider: String,
+    pub repo_organisation: String,
+    pub repo_identity: String,
+    #[serde(alias = "config_root", default)]
+    pub daemon_config_root: PathBuf,
+    pub repo_root: PathBuf,
+    pub source: crate::daemon::DevqlTaskSource,
+    pub mode: crate::daemon::SyncTaskMode,
+    pub status: crate::daemon::DevqlTaskStatus,
+    pub submitted_at_unix: u64,
+    pub started_at_unix: Option<u64>,
+    pub updated_at_unix: u64,
+    pub completed_at_unix: Option<u64>,
+    pub queue_position: Option<u64>,
+    pub tasks_ahead: Option<u64>,
+    pub progress: crate::host::devql::SyncProgressUpdate,
+    pub error: Option<String>,
+    pub summary: Option<crate::host::devql::SyncSummary>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PersistedDevqlTaskQueueState {
+    pub version: u8,
+    pub tasks: Vec<crate::daemon::DevqlTaskRecord>,
+    pub repo_controls: BTreeMap<String, crate::daemon::RepoTaskControlState>,
     pub last_action: Option<String>,
     pub updated_at_unix: u64,
 }
@@ -177,6 +212,18 @@ impl Default for PersistedSyncQueueState {
     }
 }
 
+impl Default for PersistedDevqlTaskQueueState {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            tasks: Vec::new(),
+            repo_controls: BTreeMap::new(),
+            last_action: Some("initialized".to_string()),
+            updated_at_unix: 0,
+        }
+    }
+}
+
 impl Default for PersistedCapabilityEventQueueState {
     fn default() -> Self {
         Self {
@@ -189,6 +236,22 @@ impl Default for PersistedCapabilityEventQueueState {
 }
 
 impl PersistedSyncQueueState {
+    pub(crate) fn normalise_legacy_values(&mut self) {
+        for task in &mut self.tasks {
+            task.normalise_legacy_values();
+        }
+    }
+}
+
+impl LegacySyncTaskRecord {
+    pub(crate) fn normalise_legacy_values(&mut self) {
+        if self.daemon_config_root.as_os_str().is_empty() {
+            self.daemon_config_root = self.repo_root.clone();
+        }
+    }
+}
+
+impl PersistedDevqlTaskQueueState {
     pub(crate) fn normalise_legacy_values(&mut self) {
         for task in &mut self.tasks {
             task.normalise_legacy_values();


### PR DESCRIPTION
## Summary

This pull request introduces a major overhaul of the DevQL task orchestration system, replacing the previous sync-only queue with a unified, generic task subsystem for both sync and ingest operations. The GraphQL and CLI interfaces have been updated to expose this new task-centric model, and the schema has been significantly refactored to support these changes. Test cases and internal APIs have been updated accordingly.

**DevQL Task Orchestration & API Overhaul**

* Replaced the sync-only daemon queue with a generic, persisted DevQL task subsystem that manages both sync and ingest tasks, supporting migration from legacy sync queues and enabling concurrent sync and ingest per repository.
* Updated the daemon worker activation to use `activate_task_worker` instead of the sync-specific worker.

**GraphQL/SDL Schema Refactor**

* Refactored the GraphQL schema (`bitloops/schema.graphql`, `bitloops/schema.slim.graphql`) to remove sync/ingest-specific mutations and queries, replacing them with generic task operations such as `enqueueTask`, `task`, `tasks`, `taskQueue`, `pauseTaskQueue`, `resumeTaskQueue`, `cancelTask`, and `taskProgress`. Added new types/enums for `Task`, `TaskKind`, `TaskStatus`, and related task tracking structures. [[1]](diffhunk://#diff-3e400421f4a6c3307e77752470890129583077805e0051350ecf6105e9657df4L339-R358) [[2]](diffhunk://#diff-3e400421f4a6c3307e77752470890129583077805e0051350ecf6105e9657df4L582-R595) [[3]](diffhunk://#diff-3e400421f4a6c3307e77752470890129583077805e0051350ecf6105e9657df4L616-R630) [[4]](diffhunk://#diff-3e400421f4a6c3307e77752470890129583077805e0051350ecf6105e9657df4L663-R676) [[5]](diffhunk://#diff-3e400421f4a6c3307e77752470890129583077805e0051350ecf6105e9657df4R742-R811) [[6]](diffhunk://#diff-e2a2bb5cbea50915578ef307b1247062f43eb279dd45667d6590be5ecb213d2eL373-R392) [[7]](diffhunk://#diff-e2a2bb5cbea50915578ef307b1247062f43eb279dd45667d6590be5ecb213d2eL574-R587) [[8]](diffhunk://#diff-e2a2bb5cbea50915578ef307b1247062f43eb279dd45667d6590be5ecb213d2eL630-R644) [[9]](diffhunk://#diff-e2a2bb5cbea50915578ef307b1247062f43eb279dd45667d6590be5ecb213d2eL648-R661) [[10]](diffhunk://#diff-e2a2bb5cbea50915578ef307b1247062f43eb279dd45667d6590be5ecb213d2eR727-R796)

**CLI and GraphQL Surface Changes**

* Updated CLI commands and GraphQL mutations to use the new task interface, removing direct ingest execution and sync-only fields, and ensuring all operations are routed through the shared task coordinator.

**Test Updates**

* Updated integration tests to use the new `enqueueTask` mutation instead of the old `ingest` mutation, and adjusted assertions to validate the new task-based workflow and result structure. [[1]](diffhunk://#diff-d59d094ac6639ad01fbd0e37c82a54919d203b7d45122019354c3cb170303b38L577-R577) [[2]](diffhunk://#diff-d59d094ac6639ad01fbd0e37c82a54919d203b7d45122019354c3cb170303b38L643-R725) [[3]](diffhunk://#diff-d59d094ac6639ad01fbd0e37c82a54919d203b7d45122019354c3cb170303b38L704-L707)

**Documentation**

* Updated the `CHANGELOG.md` to document the new shared DevQL task orchestration and the task-first API changes.

These changes modernize the orchestration and API surface, unify task handling, and set the foundation for more flexible and robust DevQL operations going forward.

## Validation

- [X] I ran the relevant tests locally.

## Jira

- [X] Linked Jira issue(s) are updated with implementation notes and test results. CLI-1626

