### PR TITLE
Fix release workflow environment for published artifact verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,6 +329,7 @@ jobs:
     name: Verify published release artifacts
     runs-on: self-hosted
     needs: publish
+    environment: "Production CLI"
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:


### PR DESCRIPTION
## Summary
- add the `Production CLI` environment to the `Verify published release artifacts` job in `.github/workflows/release.yml`
- ensure the job can access the environment-scoped secrets and settings it needs after `publish`

## Testing
- Not run (not requested)