### PR TITLE
Align test_harness current-state sync with the generic queue and fix linkage parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Semantic-clone real-path fixture completeness and expectations**: real-path BDD fixtures now persist summary embeddings alongside code embeddings, and the semantic-clone feature expectations were refreshed to match the classifier's explainable output, including the lower-threshold clone case and unrelated-pair suppression coverage.
 - **Semantic-clones health coverage for summary generation**: capability health now validates `summary_generation` slot binding, expected task type, runtime presence, runtime command resolution, and live runtime handshakes alongside embeddings, so misconfigured semantic summary profiles fail fast instead of appearing healthy.
 - **Repo-scoped exclusion reconciliation now ignores daemon config directories that are not repositories**: the coordinator only seeds reconciliation from the current path when that path is itself a Git repository, and registry-driven reconciliation now keeps only repositories bound to the active daemon config. This prevents exclusion updates from spilling into unrelated daemon config roots or repos registered under a different binding.
+- **Test-harness current-state parity for Rust linkage discovery**: automatic sync now schedules and materializes `test_harness.current_state` through the generic cursor queue, closes the Ruff-style static-linkage gap, and documents legacy `ingest-tests` as commit-scoped historical ingestion rather than the default workspace-validation path.
 
 ## [0.0.14] - 2026-04-12
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,6 +53,33 @@ On macOS, `dev-test-*` and `dev-install` automatically sign produced binaries to
 `cargo qat-devql-ingest` is the focused DevQL ingest alias.
 `cargo qat-devql-sync` is the focused DevQL sync alias.
 
+### QAT scenario filtering
+
+QAT suites support opt-in Cucumber tag filtering via `CUCUMBER_FILTER_TAGS`. If the variable is unset, the full suite runs as before.
+
+- Run only tagged scenarios in the focused DevQL sync suite:
+
+```bash
+CUCUMBER_FILTER_TAGS='@test_harness_sync' cargo qat-devql-sync
+```
+
+- Use the direct `cargo test` form when you want the suite to stream step-by-step output:
+
+```bash
+CUCUMBER_FILTER_TAGS='@test_harness_sync' \
+cargo test \
+  --manifest-path bitloops/Cargo.toml \
+  --features qat-tests \
+  --test qat_acceptance \
+  qat_devql_sync \
+  -- --ignored --nocapture
+```
+
+- Tag expressions use standard Cucumber syntax, for example:
+  - `@test_harness_sync`
+  - `@devql and @sync`
+  - `@test_harness_sync and not @slow`
+
 ### Fast-lane thread tuning
 
 - Override the local fast-lane default with `BITLOOPS_TEST_THREADS=<n> cargo dev-test-fast`.

--- a/bitloops/qat/features/devql-sync/sync_workspace.feature
+++ b/bitloops/qat/features/devql-sync/sync_workspace.feature
@@ -16,7 +16,7 @@ Feature: DevQL sync workspace reconciliation
     And DevQL sync summary shows 0 parse errors in bitloops
     And DevQL artefacts query returns results in bitloops
 
-  @devql @sync
+  @devql @sync @test_harness_sync
   Scenario: Sync materializes test-harness coverage for discovered tests
     Given I run CleanStart for flow "SyncTestHarnessPopulate"
     And I start the daemon in bitloops
@@ -29,7 +29,7 @@ Feature: DevQL sync workspace reconciliation
     Then daemon capability-event status shows TestHarness sync handler completed in bitloops
     Then TestHarness query for "createUser" at current workspace state with view "tests" returns results in bitloops
 
-  @devql @sync
+  @devql @sync @test_harness_sync
   Scenario: Sync removes test-harness coverage when test files are deleted
     Given I run CleanStart for flow "SyncTestHarnessDeleteTestFile"
     And I start the daemon in bitloops

--- a/bitloops/src/adapters/languages/rust/test_support/attributes.rs
+++ b/bitloops/src/adapters/languages/rust/test_support/attributes.rs
@@ -252,8 +252,13 @@ pub(crate) fn build_rust_parameterized_test_case(
     function_end_line: i64,
 ) -> RustScenarioSeed {
     let raw = attribute_node.utf8_text(source).unwrap_or_default();
-    let rule_variant = extract_rule_variant_from_rust_test_case(raw);
-    let fixture_path = extract_fixture_path_from_rust_test_case(raw);
+    let raw_args = extract_rust_attribute_args(raw).unwrap_or_default();
+    let (case_args, explicit_case_name) = split_rust_test_case_args_and_name(raw_args);
+    let rule_variant = extract_rule_variant_from_rust_test_case(case_args);
+    let fixture_path = extract_fixture_path_from_rust_test_case(case_args);
+    let extra_case_name = explicit_case_name.or_else(|| {
+        extract_additional_test_case_string_argument(case_args, fixture_path.as_deref())
+    });
 
     let mut name_parts = Vec::new();
     if let Some(rule_variant) = rule_variant.as_deref() {
@@ -261,6 +266,22 @@ pub(crate) fn build_rust_parameterized_test_case(
     }
     if let Some(fixture_path) = fixture_path.as_deref() {
         name_parts.push(fixture_path.to_string());
+    }
+    if let Some(extra_case_name) = extra_case_name {
+        name_parts.push(extra_case_name);
+    } else {
+        for summary in split_top_level_arguments(case_args)
+            .into_iter()
+            .map(summarize_rust_test_case_argument)
+            .filter(|summary| !summary.is_empty())
+        {
+            let already_present = Some(summary.as_str()) == rule_variant.as_deref()
+                || Some(summary.as_str()) == fixture_path.as_deref()
+                || name_parts.iter().any(|part| part == &summary);
+            if !already_present {
+                name_parts.push(summary);
+            }
+        }
     }
 
     let name = if name_parts.is_empty() {
@@ -325,6 +346,99 @@ fn extract_fixture_path_from_rust_test_case(raw_attribute: &str) -> Option<Strin
         .find(|literal| {
             literal.ends_with(".py") || literal.ends_with(".pyi") || literal.ends_with(".ipynb")
         })
+}
+
+fn split_rust_test_case_args_and_name(raw_args: &str) -> (&str, Option<String>) {
+    let Some(separator) = find_top_level_separator(raw_args, ';') else {
+        return (raw_args.trim(), None);
+    };
+
+    let case_args = raw_args[..separator].trim();
+    let case_name_raw = raw_args[separator + 1..].trim();
+    let case_name = extract_single_string_literal(case_name_raw).or_else(|| {
+        let compact: String = case_name_raw
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect();
+        (!compact.is_empty()).then_some(compact)
+    });
+    (case_args, case_name)
+}
+
+fn extract_additional_test_case_string_argument(
+    raw_args: &str,
+    fixture_path: Option<&str>,
+) -> Option<String> {
+    split_top_level_arguments(raw_args)
+        .into_iter()
+        .find_map(|argument| {
+            let literal = extract_single_string_literal(argument)?;
+            (Some(literal.as_str()) != fixture_path).then_some(literal)
+        })
+}
+
+fn summarize_rust_test_case_argument(argument: &str) -> String {
+    let trimmed = argument.trim();
+    if let Some(literal) = extract_single_string_literal(trimmed) {
+        return literal;
+    }
+    if let Some(rule_variant) = extract_rule_variant_from_rust_test_case(trimmed) {
+        return rule_variant;
+    }
+    if let Some(fixture_path) = extract_fixture_path_from_rust_test_case(trimmed) {
+        return fixture_path;
+    }
+    trimmed.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+fn extract_single_string_literal(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let quote = trimmed.chars().next()?;
+    if (quote != '"' && quote != '\'') || !trimmed.ends_with(quote) || trimmed.len() < 2 {
+        return None;
+    }
+    Some(trimmed[1..trimmed.len() - 1].to_string())
+}
+
+fn find_top_level_separator(raw: &str, separator: char) -> Option<usize> {
+    let mut paren_depth = 0i32;
+    let mut brace_depth = 0i32;
+    let mut bracket_depth = 0i32;
+    let mut in_string: Option<char> = None;
+    let mut escaped = false;
+
+    for (idx, ch) in raw.char_indices() {
+        if let Some(quote) = in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == quote {
+                in_string = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => in_string = Some(ch),
+            '(' => paren_depth += 1,
+            ')' => paren_depth -= 1,
+            '{' => brace_depth += 1,
+            '}' => brace_depth -= 1,
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth -= 1,
+            _ if ch == separator && paren_depth == 0 && brace_depth == 0 && bracket_depth == 0 => {
+                return Some(idx);
+            }
+            _ => {}
+        }
+    }
+
+    None
 }
 
 fn rust_scoped_tokens(raw: &str) -> Vec<String> {

--- a/bitloops/src/adapters/languages/rust/test_support/enumeration.rs
+++ b/bitloops/src/adapters/languages/rust/test_support/enumeration.rs
@@ -36,21 +36,29 @@ pub(crate) fn parse_enumerated_doctests(output: &str) -> Vec<EnumeratedTestScena
 
 pub(crate) fn parse_enumerated_host_tests(output: &str) -> Vec<EnumeratedTestScenario> {
     let mut scenarios = Vec::new();
+    let mut current_host_context_path: Option<String> = None;
 
     for line in output.lines() {
         let trimmed = line.trim();
+        if trimmed.starts_with("Doc-tests ") || trimmed.ends_with(" benchmarks") {
+            current_host_context_path = None;
+            continue;
+        }
+        if let Some(context_path) = parse_running_host_test_context_path(trimmed) {
+            current_host_context_path = Some(context_path);
+            continue;
+        }
         if !trimmed.ends_with(": test") || trimmed.contains(" - ") {
             continue;
         }
 
         let name = trimmed.trim_end_matches(": test").trim();
-        if name.is_empty()
-            || name.starts_with("Doc-tests ")
-            || name.starts_with("Running ")
-            || name.ends_with(" benchmarks")
-        {
+        if name.is_empty() || name.starts_with("Doc-tests ") || name.starts_with("Running ") {
             continue;
         }
+        let Some(relative_path) = current_host_context_path.clone() else {
+            continue;
+        };
 
         let segments: Vec<&str> = name.split("::").collect();
         let scenario_name = segments.last().copied().unwrap_or(name).to_string();
@@ -64,7 +72,7 @@ pub(crate) fn parse_enumerated_host_tests(output: &str) -> Vec<EnumeratedTestSce
             language: "rust".to_string(),
             suite_name,
             scenario_name: scenario_name.clone(),
-            relative_path: "__synthetic_tests__/workspace.rs".to_string(),
+            relative_path,
             start_line: 1,
             reference_candidates: vec![ReferenceCandidate::SymbolName(scenario_name)],
             discovery_source: ScenarioDiscoverySource::Enumeration,
@@ -78,4 +86,80 @@ fn parse_doctest_descriptor(raw: &str) -> Option<(String, i64)> {
     let (item_name, line_part) = raw.rsplit_once("(line ")?;
     let line_number = line_part.trim_end_matches(')').parse().ok()?;
     Some((item_name.trim().to_string(), line_number))
+}
+
+fn parse_running_host_test_context_path(line: &str) -> Option<String> {
+    let descriptor = line.strip_prefix("Running ")?.trim();
+    if descriptor.is_empty() || descriptor.starts_with("Doc-tests ") {
+        return None;
+    }
+
+    Some(format!(
+        "__synthetic_tests__/{}",
+        sanitize_host_test_context_descriptor(descriptor)
+    ))
+}
+
+fn sanitize_host_test_context_descriptor(input: &str) -> String {
+    input
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '/' | '.' | '-' | '_' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_enumerated_host_tests;
+
+    #[test]
+    fn host_enumeration_namespaces_duplicate_test_names_by_running_binary() {
+        let output = r#"
+Running unittests src/lib.rs (target/debug/deps/crate_a-1111111111111111)
+main: test
+Running tests/api.rs (target/debug/deps/api-2222222222222222)
+main: test
+"#;
+
+        let scenarios = parse_enumerated_host_tests(output);
+        assert_eq!(scenarios.len(), 2);
+        assert_eq!(scenarios[0].suite_name, "enumerated");
+        assert_eq!(scenarios[0].scenario_name, "main");
+        assert_eq!(scenarios[1].suite_name, "enumerated");
+        assert_eq!(scenarios[1].scenario_name, "main");
+        assert_ne!(scenarios[0].relative_path, scenarios[1].relative_path);
+        assert!(
+            scenarios[0]
+                .relative_path
+                .contains("crate_a-1111111111111111"),
+            "expected first synthetic path to retain its running binary context"
+        );
+        assert!(
+            scenarios[1].relative_path.contains("api-2222222222222222"),
+            "expected second synthetic path to retain its running binary context"
+        );
+    }
+
+    #[test]
+    fn host_enumeration_ignores_unscoped_doc_test_names_without_running_context() {
+        let output = r#"
+Running tests/api.rs (target/debug/deps/api-2222222222222222)
+smoke: test
+Doc-tests crate_a
+main: test
+Doc-tests crate_b
+main: test
+"#;
+
+        let scenarios = parse_enumerated_host_tests(output);
+        assert_eq!(scenarios.len(), 1);
+        assert_eq!(scenarios[0].scenario_name, "smoke");
+        assert_eq!(scenarios[0].suite_name, "enumerated");
+        assert!(
+            scenarios[0].relative_path.contains("api-2222222222222222"),
+            "expected scoped host test to retain its running binary context"
+        );
+    }
 }

--- a/bitloops/src/capability_packs/test_harness/event_handlers.rs
+++ b/bitloops/src/capability_packs/test_harness/event_handlers.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use serde_json::Value;
 
 use crate::capability_packs::test_harness::mapping;
 use crate::capability_packs::test_harness::mapping::linker::build_production_index;
 use crate::capability_packs::test_harness::mapping::materialize::{
-    MaterializationContext, materialize_source_discovery,
+    MaterializationContext, materialize_enumerated_scenarios, materialize_source_discovery,
 };
 use crate::capability_packs::test_harness::mapping::model::StructuralMappingStats;
 use crate::host::capability_host::{
@@ -14,6 +14,9 @@ use crate::host::capability_host::{
     CurrentStateConsumerRequest, CurrentStateConsumerResult, ReconcileMode,
 };
 use crate::host::devql::{RelationalStorage, esc_pg};
+use crate::host::language_adapter::{
+    DiscoveredTestFile, EnumeratedTestScenario, LanguageAdapterContext,
+};
 use crate::models::{TestArtefactCurrentRecord, TestArtefactEdgeCurrentRecord};
 
 use super::types::{TEST_HARNESS_CAPABILITY_ID, TEST_HARNESS_CURRENT_STATE_CONSUMER_ID};
@@ -50,6 +53,10 @@ async fn reconcile_delta(
     request: &CurrentStateConsumerRequest,
     context: &CurrentStateConsumerContext,
 ) -> Result<()> {
+    if requires_full_reconcile_for_delta(request) {
+        return reconcile_full(request, context).await;
+    }
+
     let mut discovered_files = Vec::new();
     let mut content_ids: HashMap<String, String> = HashMap::new();
     let mut processed_paths: HashSet<String> = HashSet::new();
@@ -86,6 +93,17 @@ async fn reconcile_delta(
     }
 
     if !discovered_files.is_empty() || !processed_paths.is_empty() {
+        let enumerated_scenarios = match enumerate_delta_scenarios(
+            request,
+            context,
+            &discovered_files,
+            &processed_paths,
+        ) {
+            DeltaEnumerationDecision::Incremental(scenarios) => scenarios,
+            DeltaEnumerationDecision::RequiresFullReconcile => {
+                return reconcile_full(request, context).await;
+            }
+        };
         let production = context
             .relational
             .load_current_production_artefacts(&request.repo_id)?;
@@ -106,6 +124,7 @@ async fn reconcile_delta(
             stats: &mut stats,
         };
         materialize_source_discovery(&mut materialization, &discovered_files);
+        materialize_enumerated_scenarios(&mut materialization, &enumerated_scenarios);
 
         persist_discovered_files(
             &context.storage,
@@ -139,6 +158,62 @@ async fn reconcile_delta(
     Ok(())
 }
 
+fn requires_full_reconcile_for_delta(request: &CurrentStateConsumerRequest) -> bool {
+    !request.artefact_upserts.is_empty() || !request.artefact_removals.is_empty()
+}
+
+enum DeltaEnumerationDecision {
+    Incremental(Vec<EnumeratedTestScenario>),
+    RequiresFullReconcile,
+}
+
+fn enumerate_delta_scenarios(
+    request: &CurrentStateConsumerRequest,
+    context: &CurrentStateConsumerContext,
+    discovered_files: &[DiscoveredTestFile],
+    processed_paths: &HashSet<String>,
+) -> DeltaEnumerationDecision {
+    if discovered_files.is_empty() || processed_paths.is_empty() {
+        return DeltaEnumerationDecision::Incremental(Vec::new());
+    }
+
+    let language_context = LanguageAdapterContext::new(
+        request.repo_root.clone(),
+        request.repo_id.clone(),
+        request.head_commit_sha.clone(),
+    );
+    let mut enumerated = Vec::new();
+
+    for support in context.language_services.test_supports() {
+        let source_files = discovered_files
+            .iter()
+            .filter(|file| file.language == support.language_id())
+            .cloned()
+            .collect::<Vec<_>>();
+        if source_files.is_empty() {
+            continue;
+        }
+
+        let enumeration = support.enumerate_tests(&language_context);
+        let reconciled = support.reconcile(&source_files, enumeration);
+        if reconciled
+            .enumerated_scenarios
+            .iter()
+            .any(|scenario| scenario.relative_path.starts_with("__synthetic_tests__/"))
+        {
+            return DeltaEnumerationDecision::RequiresFullReconcile;
+        }
+        enumerated.extend(
+            reconciled
+                .enumerated_scenarios
+                .into_iter()
+                .filter(|scenario| processed_paths.contains(&scenario.relative_path)),
+        );
+    }
+
+    DeltaEnumerationDecision::Incremental(enumerated)
+}
+
 async fn reconcile_full(
     request: &CurrentStateConsumerRequest,
     context: &CurrentStateConsumerContext,
@@ -169,6 +244,7 @@ async fn replace_repo_state(
     test_artefacts: &[TestArtefactCurrentRecord],
     test_edges: &[TestArtefactEdgeCurrentRecord],
 ) -> Result<()> {
+    ensure_unique_test_artefact_ids(test_artefacts)?;
     let mut statements = vec![
         delete_repo_test_edges_sql(repo_id),
         delete_repo_test_artefacts_sql(repo_id),
@@ -193,6 +269,7 @@ async fn persist_discovered_files(
     test_artefacts: &[TestArtefactCurrentRecord],
     test_edges: &[TestArtefactEdgeCurrentRecord],
 ) -> Result<()> {
+    ensure_unique_test_artefact_ids(test_artefacts)?;
     let mut statements = Vec::new();
     for path in processed_paths {
         statements.push(delete_test_edges_for_path_sql(repo_id, path));
@@ -209,6 +286,48 @@ async fn persist_discovered_files(
             .map(|edge| insert_test_edge_sql(storage, edge)),
     );
     storage.exec_batch_transactional(&statements).await
+}
+
+fn ensure_unique_test_artefact_ids(test_artefacts: &[TestArtefactCurrentRecord]) -> Result<()> {
+    let mut by_artefact_id: HashMap<&str, Vec<&TestArtefactCurrentRecord>> = HashMap::new();
+    for artefact in test_artefacts {
+        by_artefact_id
+            .entry(artefact.artefact_id.as_str())
+            .or_default()
+            .push(artefact);
+    }
+
+    let duplicates = by_artefact_id
+        .into_iter()
+        .filter_map(|(artefact_id, artefacts)| {
+            (artefacts.len() > 1).then(|| {
+                let details = artefacts
+                    .iter()
+                    .map(|artefact| {
+                        format!(
+                            "path={}, kind={}, name={}, discovery_source={}",
+                            artefact.path,
+                            artefact.canonical_kind,
+                            artefact.name,
+                            artefact.discovery_source
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ; ");
+                format!("{artefact_id} => {details}")
+            })
+        })
+        .take(5)
+        .collect::<Vec<_>>();
+
+    if !duplicates.is_empty() {
+        bail!(
+            "duplicate test artefact ids detected before persistence: {}",
+            duplicates.join(" | ")
+        );
+    }
+
+    Ok(())
 }
 
 async fn delete_paths(
@@ -365,4 +484,516 @@ fn nullable_i64_sql(value: Option<i64>) -> String {
     value
         .map(|value| value.to_string())
         .unwrap_or_else(|| "NULL".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    use anyhow::{Result, anyhow, bail};
+    use rusqlite::Connection;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::{TestHarnessCurrentStateConsumer, ensure_unique_test_artefact_ids};
+    use crate::capability_packs::test_harness::storage::init_test_domain_database;
+    use crate::host::capability_host::gateways::{
+        CapabilityMailboxStatus, CapabilityWorkplaneEnqueueResult, CapabilityWorkplaneGateway,
+        DefaultHostServicesGateway, HostServicesGateway, LanguageServicesGateway,
+        RelationalGateway,
+    };
+    use crate::host::capability_host::{
+        ChangedArtefact, ChangedFile, CurrentStateConsumer, CurrentStateConsumerContext,
+        CurrentStateConsumerRequest, ReconcileMode,
+    };
+    use crate::host::devql::RelationalStorage;
+    use crate::host::language_adapter::{
+        DiscoveredTestFile, DiscoveredTestScenario, DiscoveredTestSuite, EnumeratedTestScenario,
+        EnumerationMode, EnumerationResult, LanguageAdapterContext, LanguageTestSupport,
+        ReconciledDiscovery, ReferenceCandidate, ScenarioDiscoverySource,
+    };
+    use crate::models::ProductionArtefact;
+    use crate::models::TestArtefactCurrentRecord;
+
+    #[derive(Default)]
+    struct NoopWorkplaneGateway;
+
+    impl CapabilityWorkplaneGateway for NoopWorkplaneGateway {
+        fn enqueue_jobs(
+            &self,
+            _jobs: Vec<crate::host::capability_host::gateways::CapabilityWorkplaneJob>,
+        ) -> Result<CapabilityWorkplaneEnqueueResult> {
+            Ok(CapabilityWorkplaneEnqueueResult::default())
+        }
+
+        fn mailbox_status(&self) -> Result<BTreeMap<String, CapabilityMailboxStatus>> {
+            Ok(BTreeMap::new())
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeRelationalGateway {
+        production: Vec<ProductionArtefact>,
+    }
+
+    impl RelationalGateway for FakeRelationalGateway {
+        fn resolve_checkpoint_id(&self, _repo_id: &str, _checkpoint_ref: &str) -> Result<String> {
+            bail!("resolve_checkpoint_id is not used in test_harness event handler tests")
+        }
+
+        fn artefact_exists(&self, _repo_id: &str, _artefact_id: &str) -> Result<bool> {
+            Ok(false)
+        }
+
+        fn load_repo_id_for_commit(&self, _commit_sha: &str) -> Result<String> {
+            bail!("load_repo_id_for_commit is not used in test_harness event handler tests")
+        }
+
+        fn load_current_production_artefacts(
+            &self,
+            _repo_id: &str,
+        ) -> Result<Vec<ProductionArtefact>> {
+            Ok(self.production.clone())
+        }
+
+        fn load_production_artefacts(&self, _commit_sha: &str) -> Result<Vec<ProductionArtefact>> {
+            Ok(self.production.clone())
+        }
+
+        fn load_artefacts_for_file_lines(
+            &self,
+            _commit_sha: &str,
+            _file_path: &str,
+        ) -> Result<Vec<(String, i64, i64)>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeLanguageServicesGateway {
+        support: Arc<FakeLanguageTestSupport>,
+    }
+
+    impl LanguageServicesGateway for FakeLanguageServicesGateway {
+        fn test_supports(&self) -> Vec<Arc<dyn LanguageTestSupport>> {
+            vec![self.support.clone()]
+        }
+
+        fn resolve_test_support_for_path(
+            &self,
+            relative_path: &str,
+        ) -> Option<Arc<dyn LanguageTestSupport>> {
+            self.support
+                .supports_any(relative_path)
+                .then(|| self.support.clone() as Arc<dyn LanguageTestSupport>)
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeLanguageTestSupport {
+        language_id: &'static str,
+        discovered_by_path: HashMap<String, DiscoveredTestFile>,
+        enumeration: EnumerationResult,
+    }
+
+    impl FakeLanguageTestSupport {
+        fn supports_any(&self, relative_path: &str) -> bool {
+            self.discovered_by_path.contains_key(relative_path)
+        }
+    }
+
+    impl LanguageTestSupport for FakeLanguageTestSupport {
+        fn language_id(&self) -> &'static str {
+            self.language_id
+        }
+
+        fn priority(&self) -> u8 {
+            0
+        }
+
+        fn supports_path(&self, _absolute_path: &Path, relative_path: &str) -> bool {
+            self.supports_any(relative_path)
+        }
+
+        fn discover_tests(
+            &self,
+            _absolute_path: &Path,
+            relative_path: &str,
+        ) -> Result<DiscoveredTestFile> {
+            self.discovered_by_path
+                .get(relative_path)
+                .cloned()
+                .ok_or_else(|| anyhow!("unexpected test discovery request for {relative_path}"))
+        }
+
+        fn enumerate_tests(&self, _ctx: &LanguageAdapterContext) -> EnumerationResult {
+            self.enumeration.clone()
+        }
+
+        fn reconcile(
+            &self,
+            _source_files: &[DiscoveredTestFile],
+            enumeration: EnumerationResult,
+        ) -> ReconciledDiscovery {
+            ReconciledDiscovery {
+                enumerated_scenarios: enumeration.scenarios,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn merged_delta_materializes_enumerated_scenarios_only_for_changed_paths() -> Result<()> {
+        let fixture = TestFixture::new()?;
+        fixture.write_file("tests/changed.fake", "changed")?;
+
+        let changed_discovery = DiscoveredTestFile {
+            relative_path: "tests/changed.fake".to_string(),
+            language: "fake".to_string(),
+            reference_candidates: Vec::new(),
+            suites: Vec::new(),
+        };
+        let unchanged_discovery = DiscoveredTestFile {
+            relative_path: "tests/unchanged.fake".to_string(),
+            language: "fake".to_string(),
+            reference_candidates: Vec::new(),
+            suites: Vec::new(),
+        };
+
+        let support = Arc::new(FakeLanguageTestSupport {
+            language_id: "fake",
+            discovered_by_path: HashMap::from([
+                ("tests/changed.fake".to_string(), changed_discovery),
+                ("tests/unchanged.fake".to_string(), unchanged_discovery),
+            ]),
+            enumeration: EnumerationResult {
+                mode: EnumerationMode::Full,
+                scenarios: vec![
+                    enumerated_scenario("tests/changed.fake", "generated_changed_case"),
+                    enumerated_scenario("tests/unchanged.fake", "generated_unchanged_case"),
+                ],
+                notes: Vec::new(),
+            },
+        });
+        let context = fixture.context(support, vec![production_artefact()])?;
+        let request = CurrentStateConsumerRequest {
+            repo_id: "repo-1".to_string(),
+            repo_root: fixture.repo_root(),
+            active_branch: Some("main".to_string()),
+            head_commit_sha: Some("HEAD".to_string()),
+            from_generation_seq_exclusive: 0,
+            to_generation_seq_inclusive: 1,
+            reconcile_mode: ReconcileMode::MergedDelta,
+            file_upserts: vec![ChangedFile {
+                path: "tests/changed.fake".to_string(),
+                language: "fake".to_string(),
+                content_id: "changed-content".to_string(),
+            }],
+            file_removals: Vec::new(),
+            artefact_upserts: Vec::new(),
+            artefact_removals: Vec::new(),
+        };
+
+        TestHarnessCurrentStateConsumer
+            .reconcile(&request, &context)
+            .await?;
+
+        assert_eq!(
+            load_test_scenarios(fixture.db_path())?,
+            vec![(
+                "tests/changed.fake".to_string(),
+                "generated_changed_case".to_string(),
+                "enumeration".to_string(),
+            )]
+        );
+        assert_eq!(count_test_edges(fixture.db_path())?, 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn merged_delta_materializes_synthetic_enumerated_scenarios() -> Result<()> {
+        let fixture = TestFixture::new()?;
+        fixture.write_file("tests/changed.fake", "changed")?;
+
+        let changed_discovery = DiscoveredTestFile {
+            relative_path: "tests/changed.fake".to_string(),
+            language: "fake".to_string(),
+            reference_candidates: Vec::new(),
+            suites: Vec::new(),
+        };
+
+        let support = Arc::new(FakeLanguageTestSupport {
+            language_id: "fake",
+            discovered_by_path: HashMap::from([(
+                "tests/changed.fake".to_string(),
+                changed_discovery,
+            )]),
+            enumeration: EnumerationResult {
+                mode: EnumerationMode::Full,
+                scenarios: vec![enumerated_scenario(
+                    "__synthetic_tests__/target_debug_deps_changed",
+                    "generated_changed_case",
+                )],
+                notes: Vec::new(),
+            },
+        });
+        let context = fixture.context(support, vec![production_artefact()])?;
+        let request = CurrentStateConsumerRequest {
+            repo_id: "repo-1".to_string(),
+            repo_root: fixture.repo_root(),
+            active_branch: Some("main".to_string()),
+            head_commit_sha: Some("HEAD".to_string()),
+            from_generation_seq_exclusive: 0,
+            to_generation_seq_inclusive: 1,
+            reconcile_mode: ReconcileMode::MergedDelta,
+            file_upserts: vec![ChangedFile {
+                path: "tests/changed.fake".to_string(),
+                language: "fake".to_string(),
+                content_id: "changed-content".to_string(),
+            }],
+            file_removals: Vec::new(),
+            artefact_upserts: Vec::new(),
+            artefact_removals: Vec::new(),
+        };
+
+        TestHarnessCurrentStateConsumer
+            .reconcile(&request, &context)
+            .await?;
+
+        assert_eq!(
+            load_test_scenarios(fixture.db_path())?,
+            vec![(
+                "__synthetic_tests__/target_debug_deps_changed".to_string(),
+                "generated_changed_case".to_string(),
+                "enumeration".to_string(),
+            )]
+        );
+        assert_eq!(count_test_edges(fixture.db_path())?, 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn merged_delta_promotes_to_full_reconcile_when_production_artefacts_change() -> Result<()>
+    {
+        let fixture = TestFixture::new()?;
+        fixture.write_file("tests/cases.fake", "cases")?;
+
+        let source_discovery = DiscoveredTestFile {
+            relative_path: "tests/cases.fake".to_string(),
+            language: "fake".to_string(),
+            reference_candidates: Vec::new(),
+            suites: vec![DiscoveredTestSuite {
+                name: "suite".to_string(),
+                start_line: 1,
+                end_line: 3,
+                scenarios: vec![DiscoveredTestScenario {
+                    name: "source_case".to_string(),
+                    start_line: 2,
+                    end_line: 2,
+                    reference_candidates: vec![ReferenceCandidate::ExplicitTarget {
+                        path: "src/prod.fake".to_string(),
+                        start_line: 10,
+                    }],
+                    discovery_source: ScenarioDiscoverySource::Source,
+                }],
+            }],
+        };
+
+        let support = Arc::new(FakeLanguageTestSupport {
+            language_id: "fake",
+            discovered_by_path: HashMap::from([("tests/cases.fake".to_string(), source_discovery)]),
+            enumeration: EnumerationResult::default(),
+        });
+        let context = fixture.context(support, vec![production_artefact()])?;
+        let request = CurrentStateConsumerRequest {
+            repo_id: "repo-1".to_string(),
+            repo_root: fixture.repo_root(),
+            active_branch: Some("main".to_string()),
+            head_commit_sha: Some("HEAD".to_string()),
+            from_generation_seq_exclusive: 1,
+            to_generation_seq_inclusive: 2,
+            reconcile_mode: ReconcileMode::MergedDelta,
+            file_upserts: Vec::new(),
+            file_removals: Vec::new(),
+            artefact_upserts: vec![ChangedArtefact {
+                artefact_id: "prod-artefact".to_string(),
+                symbol_id: "prod-symbol".to_string(),
+                path: "src/prod.fake".to_string(),
+                canonical_kind: Some("function".to_string()),
+                name: "foo".to_string(),
+            }],
+            artefact_removals: Vec::new(),
+        };
+
+        TestHarnessCurrentStateConsumer
+            .reconcile(&request, &context)
+            .await?;
+
+        assert_eq!(
+            load_test_scenarios(fixture.db_path())?,
+            vec![(
+                "tests/cases.fake".to_string(),
+                "source_case".to_string(),
+                "source".to_string(),
+            )]
+        );
+        assert_eq!(count_test_edges(fixture.db_path())?, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_test_artefact_ids_are_reported_before_sqlite_insert() {
+        let duplicate_a = TestArtefactCurrentRecord {
+            artefact_id: "duplicate-artefact-id".to_string(),
+            symbol_id: "symbol-a".to_string(),
+            repo_id: "repo-1".to_string(),
+            content_id: "content-a".to_string(),
+            path: "tests/a.rs".to_string(),
+            language: "rust".to_string(),
+            canonical_kind: "test_scenario".to_string(),
+            language_kind: None,
+            symbol_fqn: Some("suite.a".to_string()),
+            name: "a".to_string(),
+            parent_artefact_id: None,
+            parent_symbol_id: None,
+            start_line: 10,
+            end_line: 10,
+            start_byte: None,
+            end_byte: None,
+            signature: Some("a".to_string()),
+            modifiers: "[]".to_string(),
+            docstring: None,
+            discovery_source: "enumeration".to_string(),
+        };
+        let duplicate_b = TestArtefactCurrentRecord {
+            artefact_id: "duplicate-artefact-id".to_string(),
+            symbol_id: "symbol-b".to_string(),
+            repo_id: "repo-1".to_string(),
+            content_id: "content-b".to_string(),
+            path: "tests/b.rs".to_string(),
+            language: "rust".to_string(),
+            canonical_kind: "test_scenario".to_string(),
+            language_kind: None,
+            symbol_fqn: Some("suite.b".to_string()),
+            name: "b".to_string(),
+            parent_artefact_id: None,
+            parent_symbol_id: None,
+            start_line: 20,
+            end_line: 20,
+            start_byte: None,
+            end_byte: None,
+            signature: Some("b".to_string()),
+            modifiers: "[]".to_string(),
+            docstring: None,
+            discovery_source: "source".to_string(),
+        };
+
+        let error = ensure_unique_test_artefact_ids(&[duplicate_a, duplicate_b]).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("duplicate test artefact ids detected before persistence"));
+        assert!(message.contains("duplicate-artefact-id"));
+        assert!(message.contains("tests/a.rs"));
+        assert!(message.contains("tests/b.rs"));
+    }
+
+    struct TestFixture {
+        temp: TempDir,
+        db_path: PathBuf,
+    }
+
+    impl TestFixture {
+        fn new() -> Result<Self> {
+            let temp = TempDir::new()?;
+            let db_path = temp.path().join("stores").join("relational.sqlite");
+            init_test_domain_database(&db_path)?;
+            Ok(Self { temp, db_path })
+        }
+
+        fn repo_root(&self) -> PathBuf {
+            self.temp.path().to_path_buf()
+        }
+
+        fn db_path(&self) -> &Path {
+            &self.db_path
+        }
+
+        fn write_file(&self, relative_path: &str, contents: &str) -> Result<()> {
+            let absolute_path = self.temp.path().join(relative_path);
+            if let Some(parent) = absolute_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(absolute_path, contents)?;
+            Ok(())
+        }
+
+        fn context(
+            &self,
+            support: Arc<FakeLanguageTestSupport>,
+            production: Vec<ProductionArtefact>,
+        ) -> Result<CurrentStateConsumerContext> {
+            Ok(CurrentStateConsumerContext {
+                config_root: json!({}),
+                storage: Arc::new(RelationalStorage::local_only(self.db_path.clone())),
+                relational: Arc::new(FakeRelationalGateway { production }),
+                language_services: Arc::new(FakeLanguageServicesGateway { support }),
+                host_services: Arc::new(DefaultHostServicesGateway::new("repo-1"))
+                    as Arc<dyn HostServicesGateway>,
+                workplane: Arc::new(NoopWorkplaneGateway),
+            })
+        }
+    }
+
+    fn production_artefact() -> ProductionArtefact {
+        ProductionArtefact {
+            artefact_id: "prod-artefact".to_string(),
+            symbol_id: "prod-symbol".to_string(),
+            symbol_fqn: "crate::foo".to_string(),
+            path: "src/prod.fake".to_string(),
+            start_line: 10,
+        }
+    }
+
+    fn enumerated_scenario(relative_path: &str, scenario_name: &str) -> EnumeratedTestScenario {
+        EnumeratedTestScenario {
+            language: "fake".to_string(),
+            suite_name: "generated_suite".to_string(),
+            scenario_name: scenario_name.to_string(),
+            relative_path: relative_path.to_string(),
+            start_line: 1,
+            reference_candidates: vec![ReferenceCandidate::ExplicitTarget {
+                path: "src/prod.fake".to_string(),
+                start_line: 10,
+            }],
+            discovery_source: ScenarioDiscoverySource::Enumeration,
+        }
+    }
+
+    fn load_test_scenarios(db_path: &Path) -> Result<Vec<(String, String, String)>> {
+        let conn = Connection::open(db_path)?;
+        let mut stmt = conn.prepare(
+            "SELECT path, name, discovery_source
+             FROM test_artefacts_current
+             WHERE canonical_kind = 'test_scenario'
+             ORDER BY path, name",
+        )?;
+        let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?;
+        let mut scenarios = Vec::new();
+        for row in rows {
+            scenarios.push(row?);
+        }
+        Ok(scenarios)
+    }
+
+    fn count_test_edges(db_path: &Path) -> Result<i64> {
+        let conn = Connection::open(db_path)?;
+        Ok(conn.query_row(
+            "SELECT COUNT(*) FROM test_artefact_edges_current",
+            [],
+            |row| row.get(0),
+        )?)
+    }
 }

--- a/bitloops/src/capability_packs/test_harness/ingest/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/tests.rs
@@ -1,3 +1,9 @@
+//! Legacy commit-scoped test-harness ingestion.
+//!
+//! Prefer automatic current-state sync for workspace validation and current-tree
+//! test linkage queries. Keep this path only for historical or commit-scoped
+//! materialization where the caller explicitly targets a commit SHA.
+
 use std::path::Path;
 
 use anyhow::Result;
@@ -24,6 +30,10 @@ pub struct IngestTestsSummary {
     pub issues: Vec<IngestTestsIssue>,
 }
 
+/// Materialize test discovery/linkage for a specific historical commit.
+///
+/// This is the legacy commit-scoped path. Automatic current-state sync should be
+/// the default for validating the active workspace state.
 pub fn execute(
     repository: &mut impl TestHarnessRepository,
     relational: &dyn RelationalGateway,

--- a/bitloops/src/capability_packs/test_harness/mapping/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/mapping/tests.rs
@@ -332,6 +332,107 @@ mod tests {
 }
 
 #[test]
+fn rust_suites_include_additional_test_case_string_arguments_in_scenario_names() {
+    let source = r#"
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use test_case::test_case;
+
+    #[test_case(
+        Rule::PytestFixtureIncorrectParenthesesStyle,
+        Path::new("PT001.py"),
+        Settings::default(),
+        "PT001_default"
+    )]
+    #[test_case(
+        Rule::PytestFixtureIncorrectParenthesesStyle,
+        Path::new("PT001.py"),
+        Settings { fixture_parentheses: true, ..Settings::default() },
+        "PT001_parentheses"
+    )]
+    fn test_pytest_style(rule_code: Rule, path: &Path, plugin_settings: Settings, name: &str) {}
+}
+"#;
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&LANGUAGE_RUST.into())
+        .expect("failed setting rust parser language");
+
+    let tree = parser
+        .parse(source, None)
+        .expect("failed parsing rust source");
+
+    let suites = collect_rust_suites(
+        tree.root_node(),
+        source,
+        "crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs",
+    );
+    assert_eq!(suites.len(), 1, "expected one inline rust test suite");
+
+    let scenario_names: Vec<&str> = suites[0]
+        .scenarios
+        .iter()
+        .map(|scenario| scenario.name.as_str())
+        .collect();
+    assert_eq!(
+        scenario_names,
+        vec![
+            "test_pytest_style[PytestFixtureIncorrectParenthesesStyle, PT001.py, PT001_default]",
+            "test_pytest_style[PytestFixtureIncorrectParenthesesStyle, PT001.py, PT001_parentheses]",
+        ]
+    );
+}
+
+#[test]
+fn rust_suites_use_generic_test_case_labels_and_arguments_to_avoid_duplicate_names() {
+    let source = r#"
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    #[test_case(Type::Any)]
+    #[test_case(Type::Unknown)]
+    #[test_case(todo_type!())]
+    fn build_intersection_t_and_negative_t_does_not_simplify(ty: Type) {}
+
+    #[test_case("\"%s\"", "\"{}\""; "simple string")]
+    #[test_case("\"%%%s\"", "\"%{}\""; "three percents")]
+    fn test_percent_to_format(sample: &str, expected: &str) {}
+}
+"#;
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&LANGUAGE_RUST.into())
+        .expect("failed setting rust parser language");
+
+    let tree = parser
+        .parse(source, None)
+        .expect("failed parsing rust source");
+
+    let suites = collect_rust_suites(tree.root_node(), source, "tests/parameterized.rs");
+    assert_eq!(suites.len(), 1, "expected one inline rust test suite");
+
+    let scenario_names: Vec<&str> = suites[0]
+        .scenarios
+        .iter()
+        .map(|scenario| scenario.name.as_str())
+        .collect();
+    assert_eq!(
+        scenario_names,
+        vec![
+            "build_intersection_t_and_negative_t_does_not_simplify[Type::Any]",
+            "build_intersection_t_and_negative_t_does_not_simplify[Type::Unknown]",
+            "build_intersection_t_and_negative_t_does_not_simplify[todo_type!()]",
+            "test_percent_to_format[simple string]",
+            "test_percent_to_format[three percents]",
+        ]
+    );
+}
+
+#[test]
 fn rust_suites_detect_wasm_bindgen_test_functions() {
     let source = r#"
 use wasm_bindgen_test::wasm_bindgen_test;

--- a/bitloops/src/capability_packs/test_harness/register.rs
+++ b/bitloops/src/capability_packs/test_harness/register.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use std::sync::Arc;
 
-use crate::host::capability_host::CapabilityRegistrar;
+use crate::host::capability_host::{
+    CapabilityMailboxHandler, CapabilityMailboxPolicy, CapabilityMailboxRegistration,
+    CapabilityRegistrar,
+};
 
 use super::event_handlers::TestHarnessCurrentStateConsumer;
 use super::ingesters::{
@@ -18,6 +21,14 @@ pub fn register_test_harness_pack(registrar: &mut dyn CapabilityRegistrar) -> Re
     registrar.register_stage(build_tests_stage())?;
     registrar.register_stage(build_tests_summary_stage())?;
     registrar.register_stage(build_coverage_stage())?;
+    registrar.register_mailbox(CapabilityMailboxRegistration::new(
+        super::types::TEST_HARNESS_CAPABILITY_ID,
+        super::types::TEST_HARNESS_CURRENT_STATE_CONSUMER_ID,
+        CapabilityMailboxPolicy::Cursor,
+        CapabilityMailboxHandler::CurrentStateConsumer(
+            super::types::TEST_HARNESS_CURRENT_STATE_CONSUMER_ID,
+        ),
+    ))?;
     registrar.register_current_state_consumer(
         crate::host::capability_host::CurrentStateConsumerRegistration::new(
             super::types::TEST_HARNESS_CAPABILITY_ID,
@@ -50,6 +61,7 @@ mod tests {
         stages: Vec<(&'static str, &'static str)>,
         ingesters: Vec<(&'static str, &'static str)>,
         current_state_consumers: Vec<(&'static str, &'static str)>,
+        mailboxes: Vec<(&'static str, &'static str)>,
         schema_modules: Vec<SchemaModule>,
         query_examples: Vec<QueryExample>,
     }
@@ -72,6 +84,15 @@ mod tests {
         ) -> Result<()> {
             self.current_state_consumers
                 .push((registration.capability_id, registration.consumer_id));
+            Ok(())
+        }
+
+        fn register_mailbox(
+            &mut self,
+            registration: crate::host::capability_host::CapabilityMailboxRegistration,
+        ) -> Result<()> {
+            self.mailboxes
+                .push((registration.capability_id, registration.mailbox_name));
             Ok(())
         }
 
@@ -110,6 +131,10 @@ mod tests {
         );
         assert_eq!(
             registrar.current_state_consumers,
+            vec![("test_harness", TEST_HARNESS_CURRENT_STATE_CONSUMER_ID)]
+        );
+        assert_eq!(
+            registrar.mailboxes,
             vec![("test_harness", TEST_HARNESS_CURRENT_STATE_CONSUMER_ID)]
         );
         assert_eq!(registrar.schema_modules, vec![TEST_HARNESS_SCHEMA_MODULE]);

--- a/bitloops/src/cli/devql/args.rs
+++ b/bitloops/src/cli/devql/args.rs
@@ -268,7 +268,10 @@ pub struct DevqlTestHarnessArgs {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum DevqlTestHarnessCommand {
-    /// Parse test files, discover suites/scenarios, and link tests to production artefacts.
+    /// Legacy commit-scoped test discovery/linkage ingestion.
+    ///
+    /// Prefer automatic current-state sync for workspace validation.
+    /// Keep this command for historical or commit-scoped materialization.
     IngestTests(DevqlTestHarnessIngestTestsArgs),
     /// Ingest coverage report (LCOV or LLVM JSON).
     IngestCoverage(DevqlTestHarnessIngestCoverageArgs),
@@ -280,6 +283,10 @@ pub enum DevqlTestHarnessCommand {
 
 #[derive(Args, Debug, Clone)]
 pub struct DevqlTestHarnessIngestTestsArgs {
+    /// Commit SHA to materialize into the historical test-harness tables.
+    ///
+    /// This legacy command is commit-scoped. Prefer automatic current-state sync
+    /// for workspace validation and source-level linkage queries.
     #[arg(long)]
     pub commit: String,
 }

--- a/bitloops/src/cli/devql/test_harness.rs
+++ b/bitloops/src/cli/devql/test_harness.rs
@@ -32,6 +32,9 @@ pub(super) async fn run(args: DevqlTestHarnessArgs, repo_root: &Path) -> Result<
 }
 
 async fn run_ingest_tests(repo_root: &Path, args: &DevqlTestHarnessIngestTestsArgs) -> Result<()> {
+    // Legacy commit-scoped ingestion path.
+    // Prefer automatic current-state sync for workspace validation and DevQL
+    // `tests(linkageSource: "static_analysis")` queries against the current tree.
     let repo = resolve_repo_identity(repo_root)?;
     let host = DevqlCapabilityHost::builtin(repo_root.to_path_buf(), repo)?;
     host.ensure_migrations_applied_sync()?;

--- a/bitloops/src/cli/devql/tests.rs
+++ b/bitloops/src/cli/devql/tests.rs
@@ -894,6 +894,29 @@ fn devql_cli_parses_knowledge_add_command() {
 }
 
 #[test]
+fn devql_test_harness_ingest_tests_help_marks_command_as_legacy() {
+    let help_text = match Cli::try_parse_from([
+        "bitloops",
+        "devql",
+        "test-harness",
+        "ingest-tests",
+        "--help",
+    ]) {
+        Ok(_) => panic!("--help should return a clap error"),
+        Err(err) => err.to_string(),
+    };
+
+    assert!(
+        help_text.contains("Legacy commit-scoped test discovery/linkage ingestion"),
+        "expected ingest-tests help to mark the command as legacy:\n{help_text}"
+    );
+    assert!(
+        help_text.contains("Prefer automatic current-state sync for workspace validation"),
+        "expected ingest-tests help to steer users toward current-state sync:\n{help_text}"
+    );
+}
+
+#[test]
 fn devql_cli_parses_knowledge_associate_command() {
     let parsed = Cli::try_parse_from([
         "bitloops",

--- a/bitloops/tests/qat_support/helpers/core.rs
+++ b/bitloops/tests/qat_support/helpers/core.rs
@@ -432,13 +432,8 @@ fn run_init_bitloops_with_agent_config(
     let normalised_agent_name = normalise_onboarding_agent_name(agent_name);
     world.agent_name = Some(normalised_agent_name.to_string());
 
-    let args_owned = build_init_bitloops_args_with_options(
-        normalised_agent_name,
-        force,
-        sync,
-        ingest,
-        backfill,
-    );
+    let args_owned =
+        build_init_bitloops_args_with_options(normalised_agent_name, force, sync, ingest, backfill);
     let label = format!("bitloops {}", args_owned.join(" "));
     let mut attempts = 0_u8;
 
@@ -592,7 +587,10 @@ pub fn run_devql_ingest_for_repo(world: &mut QatWorld, repo_name: &str) -> Resul
     world.last_command_exit_code = Some(output.status.code().unwrap_or(-1));
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     world.last_command_stdout = Some(stdout);
-    ensure_success(&output, "bitloops devql tasks enqueue --kind ingest --status")
+    ensure_success(
+        &output,
+        "bitloops devql tasks enqueue --kind ingest --status",
+    )
 }
 
 pub fn assert_version_output(world: &mut QatWorld) -> Result<()> {
@@ -1375,7 +1373,9 @@ pub fn wait_for_test_harness_capability_event_completion_for_repo(
                     let run_id = persisted_run.run_id;
                     let handler_id = persisted_run.handler_id;
                     let event_kind = persisted_run.event_kind;
-                    let error = persisted_run.error.unwrap_or_else(|| "<no error>".to_string());
+                    let error = persisted_run
+                        .error
+                        .unwrap_or_else(|| "<no error>".to_string());
                     bail!(
                         "test_harness capability event run failed while waiting for completion: run_id={run_id}; handler_id={handler_id}; event_kind={event_kind}; error={error}"
                     );
@@ -1402,92 +1402,34 @@ pub fn wait_for_test_harness_capability_event_completion_for_repo(
 
 fn load_latest_test_harness_capability_event_run(
     world: &QatWorld,
-) -> Result<Option<(std::path::PathBuf, bitloops::daemon::CapabilityEventRunRecord)>> {
+) -> Result<
+    Option<(
+        std::path::PathBuf,
+        bitloops::daemon::CapabilityEventRunRecord,
+    )>,
+> {
     let candidates = daemon_runtime_store_candidate_paths(world.run_dir());
 
-    let mut latest: Option<(std::path::PathBuf, bitloops::daemon::CapabilityEventRunRecord)> =
-        None;
+    let mut latest: Option<(
+        std::path::PathBuf,
+        bitloops::daemon::CapabilityEventRunRecord,
+    )> = None;
     for path in &candidates {
         if !path.exists() {
             continue;
         }
-        use rusqlite::OptionalExtension;
 
         let store = bitloops::host::runtime_store::DaemonSqliteRuntimeStore::open_at(path.clone())
             .with_context(|| format!("opening daemon runtime store {}", path.display()))?;
-
-        let Some(run) = store.with_connection(|conn| {
-            conn.query_row(
-                "SELECT run_id, repo_id, capability_id, consumer_id, from_generation_seq, to_generation_seq, reconcile_mode, status, attempts, submitted_at_unix, started_at_unix, updated_at_unix, completed_at_unix, error \
-                 FROM pack_reconcile_runs \
-                 WHERE capability_id = ?1 AND consumer_id = ?2 \
-                 ORDER BY updated_at_unix DESC, submitted_at_unix DESC \
-                 LIMIT 1",
-                rusqlite::params!["test_harness", "test_harness.current_state"],
-                |row| {
-                    let as_u64 = |index| -> rusqlite::Result<u64> {
-                        row.get::<_, i64>(index)
-                            .map(|value| u64::try_from(value).unwrap_or_default())
-                    };
-                    let opt_u64 = |index| -> rusqlite::Result<Option<u64>> {
-                        row.get::<_, Option<i64>>(index).map(|value| {
-                            value.map(|value| u64::try_from(value).unwrap_or_default())
-                        })
-                    };
-                    let consumer_id = row.get::<_, String>(3)?;
-                    let status = match row.get::<_, String>(7)?.as_str() {
-                        "queued" => bitloops::daemon::CapabilityEventRunStatus::Queued,
-                        "running" => bitloops::daemon::CapabilityEventRunStatus::Running,
-                        "completed" => bitloops::daemon::CapabilityEventRunStatus::Completed,
-                        "failed" => bitloops::daemon::CapabilityEventRunStatus::Failed,
-                        "cancelled" => bitloops::daemon::CapabilityEventRunStatus::Cancelled,
-                        other => {
-                            return Err(rusqlite::Error::FromSqlConversionFailure(
-                                11,
-                                rusqlite::types::Type::Text,
-                                Box::new(std::io::Error::other(format!(
-                                    "unknown capability-event run status `{other}`"
-                                ))),
-                            ));
-                        }
-                    };
-
-                    Ok(bitloops::daemon::CapabilityEventRunRecord {
-                        run_id: row.get(0)?,
-                        repo_id: row.get(1)?,
-                        capability_id: row.get(2)?,
-                        consumer_id: consumer_id.clone(),
-                        handler_id: consumer_id.clone(),
-                        from_generation_seq: as_u64(4)?,
-                        to_generation_seq: as_u64(5)?,
-                        reconcile_mode: row.get(6)?,
-                        event_kind: String::new(),
-                        lane_key: format!("{}:{consumer_id}", row.get::<_, String>(1)?),
-                        event_payload_json: String::new(),
-                        status,
-                        attempts: row.get(8)?,
-                        submitted_at_unix: as_u64(9)?,
-                        started_at_unix: opt_u64(10)?,
-                        updated_at_unix: as_u64(11)?,
-                        completed_at_unix: opt_u64(12)?,
-                        error: row.get(13)?,
-                    })
-                },
-            )
-            .optional()
-            .map_err(anyhow::Error::from)
-        })?
-        else {
+        let Some(run) = latest_capability_event_run(
+            load_latest_test_harness_current_state_run(&store)?,
+            load_latest_test_harness_pack_reconcile_run(&store)?,
+        ) else {
             continue;
         };
 
         let replace = latest.as_ref().is_none_or(|(_, current)| {
-            (run.updated_at_unix, run.completed_at_unix.unwrap_or_default(), run.submitted_at_unix)
-                > (
-                    current.updated_at_unix,
-                    current.completed_at_unix.unwrap_or_default(),
-                    current.submitted_at_unix,
-                )
+            capability_event_run_sort_key(&run) > capability_event_run_sort_key(current)
         });
         if replace {
             latest = Some((path.clone(), run));
@@ -1495,6 +1437,161 @@ fn load_latest_test_harness_capability_event_run(
     }
 
     Ok(latest)
+}
+
+fn latest_capability_event_run(
+    current_state_run: Option<bitloops::daemon::CapabilityEventRunRecord>,
+    legacy_run: Option<bitloops::daemon::CapabilityEventRunRecord>,
+) -> Option<bitloops::daemon::CapabilityEventRunRecord> {
+    match (current_state_run, legacy_run) {
+        (Some(current_state), Some(legacy)) => {
+            if capability_event_run_sort_key(&legacy)
+                > capability_event_run_sort_key(&current_state)
+            {
+                Some(legacy)
+            } else {
+                Some(current_state)
+            }
+        }
+        (Some(current_state), None) => Some(current_state),
+        (None, Some(legacy)) => Some(legacy),
+        (None, None) => None,
+    }
+}
+
+fn capability_event_run_sort_key(
+    run: &bitloops::daemon::CapabilityEventRunRecord,
+) -> (u64, u64, u64) {
+    (
+        run.updated_at_unix,
+        run.completed_at_unix.unwrap_or_default(),
+        run.submitted_at_unix,
+    )
+}
+
+fn load_latest_test_harness_current_state_run(
+    store: &bitloops::host::runtime_store::DaemonSqliteRuntimeStore,
+) -> Result<Option<bitloops::daemon::CapabilityEventRunRecord>> {
+    use rusqlite::OptionalExtension;
+
+    store.with_connection(|conn| {
+        conn.query_row(
+            "SELECT run_id, repo_id, repo_root, mailbox_name, capability_id, from_generation_seq, to_generation_seq, reconcile_mode, status, attempts, submitted_at_unix, started_at_unix, updated_at_unix, completed_at_unix, error \
+             FROM capability_workplane_cursor_runs \
+             WHERE capability_id = ?1 AND mailbox_name = ?2 \
+             ORDER BY updated_at_unix DESC, submitted_at_unix DESC \
+             LIMIT 1",
+            rusqlite::params!["test_harness", "test_harness.current_state"],
+            |row| {
+                let as_u64 = |index| -> rusqlite::Result<u64> {
+                    row.get::<_, i64>(index)
+                        .map(|value| u64::try_from(value).unwrap_or_default())
+                };
+                let opt_u64 = |index| -> rusqlite::Result<Option<u64>> {
+                    row.get::<_, Option<i64>>(index).map(|value| {
+                        value.and_then(|value| u64::try_from(value).ok())
+                    })
+                };
+                let repo_id = row.get::<_, String>(1)?;
+                let consumer_id = row.get::<_, String>(3)?;
+
+                Ok(bitloops::daemon::CapabilityEventRunRecord {
+                    run_id: row.get(0)?,
+                    repo_id: repo_id.clone(),
+                    capability_id: row.get(4)?,
+                    consumer_id: consumer_id.clone(),
+                    handler_id: consumer_id.clone(),
+                    from_generation_seq: as_u64(5)?,
+                    to_generation_seq: as_u64(6)?,
+                    reconcile_mode: row.get(7)?,
+                    event_kind: "current_state_consumer".to_string(),
+                    lane_key: format!("{repo_id}:{consumer_id}"),
+                    event_payload_json: String::new(),
+                    status: parse_capability_event_run_status(&row.get::<_, String>(8)?)?,
+                    attempts: row.get(9)?,
+                    submitted_at_unix: as_u64(10)?,
+                    started_at_unix: opt_u64(11)?,
+                    updated_at_unix: as_u64(12)?,
+                    completed_at_unix: opt_u64(13)?,
+                    error: row.get(14)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(anyhow::Error::from)
+    })
+}
+
+fn load_latest_test_harness_pack_reconcile_run(
+    store: &bitloops::host::runtime_store::DaemonSqliteRuntimeStore,
+) -> Result<Option<bitloops::daemon::CapabilityEventRunRecord>> {
+    use rusqlite::OptionalExtension;
+
+    store.with_connection(|conn| {
+        conn.query_row(
+            "SELECT run_id, repo_id, capability_id, consumer_id, from_generation_seq, to_generation_seq, reconcile_mode, status, attempts, submitted_at_unix, started_at_unix, updated_at_unix, completed_at_unix, error \
+             FROM pack_reconcile_runs \
+             WHERE capability_id = ?1 AND consumer_id = ?2 \
+             ORDER BY updated_at_unix DESC, submitted_at_unix DESC \
+             LIMIT 1",
+            rusqlite::params!["test_harness", "test_harness.current_state"],
+            |row| {
+                let as_u64 = |index| -> rusqlite::Result<u64> {
+                    row.get::<_, i64>(index)
+                        .map(|value| u64::try_from(value).unwrap_or_default())
+                };
+                let opt_u64 = |index| -> rusqlite::Result<Option<u64>> {
+                    row.get::<_, Option<i64>>(index).map(|value| {
+                        value.and_then(|value| u64::try_from(value).ok())
+                    })
+                };
+                let repo_id = row.get::<_, String>(1)?;
+                let consumer_id = row.get::<_, String>(3)?;
+
+                Ok(bitloops::daemon::CapabilityEventRunRecord {
+                    run_id: row.get(0)?,
+                    repo_id: repo_id.clone(),
+                    capability_id: row.get(2)?,
+                    consumer_id: consumer_id.clone(),
+                    handler_id: consumer_id.clone(),
+                    from_generation_seq: as_u64(4)?,
+                    to_generation_seq: as_u64(5)?,
+                    reconcile_mode: row.get(6)?,
+                    event_kind: String::new(),
+                    lane_key: format!("{repo_id}:{consumer_id}"),
+                    event_payload_json: String::new(),
+                    status: parse_capability_event_run_status(&row.get::<_, String>(7)?)?,
+                    attempts: row.get(8)?,
+                    submitted_at_unix: as_u64(9)?,
+                    started_at_unix: opt_u64(10)?,
+                    updated_at_unix: as_u64(11)?,
+                    completed_at_unix: opt_u64(12)?,
+                    error: row.get(13)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(anyhow::Error::from)
+    })
+}
+
+fn parse_capability_event_run_status(
+    value: &str,
+) -> rusqlite::Result<bitloops::daemon::CapabilityEventRunStatus> {
+    match value {
+        "queued" => Ok(bitloops::daemon::CapabilityEventRunStatus::Queued),
+        "running" => Ok(bitloops::daemon::CapabilityEventRunStatus::Running),
+        "completed" => Ok(bitloops::daemon::CapabilityEventRunStatus::Completed),
+        "failed" => Ok(bitloops::daemon::CapabilityEventRunStatus::Failed),
+        "cancelled" => Ok(bitloops::daemon::CapabilityEventRunStatus::Cancelled),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(format!(
+                "unknown capability-event run status `{other}`"
+            ))),
+        )),
+    }
 }
 
 fn resolve_qat_sync_state_path(
@@ -2132,7 +2229,10 @@ fn open_relational_connection(world: &QatWorld) -> Result<rusqlite::Connection> 
 
 fn query_repo_id_optional(conn: &rusqlite::Connection, sql: &str) -> Result<Option<String>> {
     use rusqlite::OptionalExtension;
-    match conn.query_row(sql, [], |row| row.get::<_, String>(0)).optional() {
+    match conn
+        .query_row(sql, [], |row| row.get::<_, String>(0))
+        .optional()
+    {
         Ok(value) => Ok(value),
         Err(err) => {
             let message = err.to_string();
@@ -2365,7 +2465,10 @@ fn current_branch_name(world: &QatWorld) -> Result<String> {
 }
 
 fn post_commit_devql_refresh_disabled_env() -> [(&'static str, OsString); 1] {
-    [("BITLOOPS_DISABLE_POST_COMMIT_DEVQL_REFRESH", OsString::from("1"))]
+    [(
+        "BITLOOPS_DISABLE_POST_COMMIT_DEVQL_REFRESH",
+        OsString::from("1"),
+    )]
 }
 
 fn write_and_commit_rust_file(
@@ -2383,9 +2486,7 @@ fn write_and_commit_rust_file(
     fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     fs::write(
         &path,
-        format!(
-            "pub fn {function_name}() -> usize {{\n    {body_value}\n}}\n"
-        ),
+        format!("pub fn {function_name}() -> usize {{\n    {body_value}\n}}\n"),
     )
     .with_context(|| format!("writing {}", path.display()))?;
     run_git_success(world, &["add", "-A"], env, "git add -A")?;
@@ -2407,10 +2508,7 @@ fn refresh_rewrite_delta(world: &mut QatWorld, expected_segment_len: usize) -> R
     let post = git_reachable_shas(world, Some(expected_segment_len))?;
     world.post_rewrite_shas = post.clone();
     let pre: std::collections::BTreeSet<String> = world.pre_rewrite_shas.iter().cloned().collect();
-    world.rewrite_new_shas = post
-        .into_iter()
-        .filter(|sha| !pre.contains(sha))
-        .collect();
+    world.rewrite_new_shas = post.into_iter().filter(|sha| !pre.contains(sha)).collect();
     Ok(())
 }
 
@@ -2722,7 +2820,10 @@ pub fn reset_and_rewrite_last_commits_for_repo(
     Ok(())
 }
 
-pub fn assert_all_reachable_shas_completed_in_ledger(world: &QatWorld, repo_name: &str) -> Result<()> {
+pub fn assert_all_reachable_shas_completed_in_ledger(
+    world: &QatWorld,
+    repo_name: &str,
+) -> Result<()> {
     ensure_bitloops_repo_name(repo_name)?;
     let reachable = git_reachable_shas(world, None)?;
     let completed: std::collections::BTreeSet<String> =
@@ -2806,10 +2907,16 @@ pub fn assert_expected_shas_have_file_state_rows(world: &QatWorld, repo_name: &s
     Ok(())
 }
 
-pub fn assert_no_new_completed_shas_since_snapshot(world: &QatWorld, repo_name: &str) -> Result<()> {
+pub fn assert_no_new_completed_shas_since_snapshot(
+    world: &QatWorld,
+    repo_name: &str,
+) -> Result<()> {
     ensure_bitloops_repo_name(repo_name)?;
-    let before: std::collections::BTreeSet<String> =
-        world.completed_ledger_shas_snapshot.iter().cloned().collect();
+    let before: std::collections::BTreeSet<String> = world
+        .completed_ledger_shas_snapshot
+        .iter()
+        .cloned()
+        .collect();
     let after: std::collections::BTreeSet<String> =
         completed_ledger_shas(world)?.into_iter().collect();
     let new_shas: Vec<String> = after.difference(&before).cloned().collect();
@@ -2830,11 +2937,15 @@ pub fn assert_exact_expected_shas_newly_completed_since_snapshot(
         !world.expected_commit_shas.is_empty(),
         "no expected commit SHAs captured for new-ledger assertion"
     );
-    let before: std::collections::BTreeSet<String> =
-        world.completed_ledger_shas_snapshot.iter().cloned().collect();
+    let before: std::collections::BTreeSet<String> = world
+        .completed_ledger_shas_snapshot
+        .iter()
+        .cloned()
+        .collect();
     let after: std::collections::BTreeSet<String> =
         completed_ledger_shas(world)?.into_iter().collect();
-    let actual_new: std::collections::BTreeSet<String> = after.difference(&before).cloned().collect();
+    let actual_new: std::collections::BTreeSet<String> =
+        after.difference(&before).cloned().collect();
     let expected_new: std::collections::BTreeSet<String> =
         world.expected_commit_shas.iter().cloned().collect();
     ensure!(
@@ -2910,16 +3021,15 @@ pub fn assert_only_latest_reachable_shas_completed_in_ledger(
         "expected at least {latest_count} reachable commits, found {}",
         reachable.len()
     );
-    let expected_latest: std::collections::BTreeSet<String> = reachable
-        .iter()
-        .take(latest_count)
-        .cloned()
-        .collect();
+    let expected_latest: std::collections::BTreeSet<String> =
+        reachable.iter().take(latest_count).cloned().collect();
     let completed_set: std::collections::BTreeSet<String> =
         completed_ledger_shas(world)?.into_iter().collect();
     let reachable_set: std::collections::BTreeSet<String> = reachable.into_iter().collect();
-    let completed_reachable: std::collections::BTreeSet<String> =
-        completed_set.intersection(&reachable_set).cloned().collect();
+    let completed_reachable: std::collections::BTreeSet<String> = completed_set
+        .intersection(&reachable_set)
+        .cloned()
+        .collect();
     ensure!(
         completed_reachable == expected_latest,
         "expected completed reachable SHAs {:?}, got {:?}",
@@ -2955,7 +3065,8 @@ pub fn assert_pre_rewrite_shas_absent_from_post_segment(
         !world.pre_rewrite_shas.is_empty() && !world.post_rewrite_shas.is_empty(),
         "pre/post rewrite SHA segments are not populated"
     );
-    let post: std::collections::BTreeSet<String> = world.post_rewrite_shas.iter().cloned().collect();
+    let post: std::collections::BTreeSet<String> =
+        world.post_rewrite_shas.iter().cloned().collect();
     let retained_old: Vec<String> = world
         .pre_rewrite_shas
         .iter()

--- a/bitloops/tests/qat_support/helpers/daemon_harness.rs
+++ b/bitloops/tests/qat_support/helpers/daemon_harness.rs
@@ -59,6 +59,13 @@ fn daemon_runtime_store_candidate_paths(run_dir: &Path) -> Vec<PathBuf> {
             .join("Library")
             .join("Application Support")
             .join("bitloops")
+            .join("stores")
+            .join("runtime")
+            .join("runtime.sqlite"),
+        home_dir
+            .join("Library")
+            .join("Application Support")
+            .join("bitloops")
             .join("daemon")
             .join("runtime.sqlite"),
     ]

--- a/bitloops/tests/qat_support/helpers/tests.rs
+++ b/bitloops/tests/qat_support/helpers/tests.rs
@@ -7,7 +7,9 @@ use std::time::Duration as StdDuration;
 
 use crate::qat_support::world::QatRunConfig;
 use bitloops::cli::versioncheck::DISABLE_VERSION_CHECK_ENV;
+use bitloops::daemon::CapabilityEventRunStatus;
 use bitloops::host::devql::watch::DISABLE_WATCHER_AUTOSTART_ENV;
+use bitloops::host::runtime_store::DaemonSqliteRuntimeStore;
 
 #[test]
 fn sanitize_name_normalizes_user_input() {
@@ -367,10 +369,175 @@ fn daemon_runtime_store_candidate_paths_cover_isolated_state_dirs() {
             PathBuf::from("/tmp/qat-run/home/xdg-state/bitloops/daemon/runtime.sqlite"),
             PathBuf::from("/tmp/qat-run/home/.local/state/bitloops/daemon/runtime.sqlite"),
             PathBuf::from(
+                "/tmp/qat-run/home/Library/Application Support/bitloops/stores/runtime/runtime.sqlite"
+            ),
+            PathBuf::from(
                 "/tmp/qat-run/home/Library/Application Support/bitloops/daemon/runtime.sqlite"
             ),
         ]
     );
+}
+
+#[test]
+fn load_latest_test_harness_capability_event_run_reads_macos_current_state_store() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let run_dir = temp.path().join("run");
+    let repo_dir = temp.path().join("repo");
+    let bin_dir = temp.path().join("bin");
+    let suite_root = temp.path().join("suite");
+    fs::create_dir_all(&run_dir).expect("create run dir");
+    fs::create_dir_all(&repo_dir).expect("create repo dir");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    fs::create_dir_all(&suite_root).expect("create suite root");
+
+    let runtime_path = run_dir
+        .join("home")
+        .join("Library")
+        .join("Application Support")
+        .join("bitloops")
+        .join("stores")
+        .join("runtime")
+        .join("runtime.sqlite");
+    let runtime_parent = runtime_path.parent().expect("runtime parent");
+    fs::create_dir_all(runtime_parent).expect("create runtime parent");
+    let store = DaemonSqliteRuntimeStore::open_at(runtime_path).expect("open runtime store");
+    store
+        .with_connection(|conn| {
+            conn.execute(
+                "INSERT INTO capability_workplane_cursor_runs (run_id, repo_id, repo_root, mailbox_name, capability_id, from_generation_seq, to_generation_seq, reconcile_mode, status, attempts, submitted_at_unix, started_at_unix, updated_at_unix, completed_at_unix, error) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                rusqlite::params![
+                    "run-1",
+                    "repo-1",
+                    "/tmp/repo",
+                    "test_harness.current_state",
+                    "test_harness",
+                    1_i64,
+                    2_i64,
+                    "full_reconcile",
+                    "completed",
+                    1_i64,
+                    100_i64,
+                    101_i64,
+                    102_i64,
+                    103_i64,
+                    Option::<String>::None,
+                ],
+            )?;
+            Ok(())
+        })
+        .expect("insert current-state run");
+
+    let world = QatWorld {
+        run_dir: Some(run_dir),
+        repo_dir: Some(repo_dir),
+        run_config: Some(Arc::new(QatRunConfig {
+            binary_path: bin_dir.join("bitloops"),
+            suite_root,
+        })),
+        ..Default::default()
+    };
+
+    let (_, run) = load_latest_test_harness_capability_event_run(&world)
+        .expect("load latest run")
+        .expect("completed run should be found");
+
+    assert_eq!(run.run_id, "run-1");
+    assert_eq!(run.status, CapabilityEventRunStatus::Completed);
+    assert_eq!(run.capability_id, "test_harness");
+    assert_eq!(run.consumer_id, "test_harness.current_state");
+    assert_eq!(run.event_kind, "current_state_consumer");
+}
+
+#[test]
+fn load_latest_test_harness_capability_event_run_prefers_newer_legacy_run() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let run_dir = temp.path().join("run");
+    let repo_dir = temp.path().join("repo");
+    let bin_dir = temp.path().join("bin");
+    let suite_root = temp.path().join("suite");
+    fs::create_dir_all(&run_dir).expect("create run dir");
+    fs::create_dir_all(&repo_dir).expect("create repo dir");
+    fs::create_dir_all(&bin_dir).expect("create bin dir");
+    fs::create_dir_all(&suite_root).expect("create suite root");
+
+    let runtime_path = run_dir
+        .join("home")
+        .join("Library")
+        .join("Application Support")
+        .join("bitloops")
+        .join("stores")
+        .join("runtime")
+        .join("runtime.sqlite");
+    let runtime_parent = runtime_path.parent().expect("runtime parent");
+    fs::create_dir_all(runtime_parent).expect("create runtime parent");
+    let store = DaemonSqliteRuntimeStore::open_at(runtime_path).expect("open runtime store");
+    store
+        .with_connection(|conn| {
+            conn.execute(
+                "INSERT INTO capability_workplane_cursor_runs (run_id, repo_id, repo_root, mailbox_name, capability_id, from_generation_seq, to_generation_seq, reconcile_mode, status, attempts, submitted_at_unix, started_at_unix, updated_at_unix, completed_at_unix, error) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                rusqlite::params![
+                    "run-current-state",
+                    "repo-1",
+                    "/tmp/repo",
+                    "test_harness.current_state",
+                    "test_harness",
+                    1_i64,
+                    2_i64,
+                    "full_reconcile",
+                    "completed",
+                    1_i64,
+                    100_i64,
+                    101_i64,
+                    102_i64,
+                    103_i64,
+                    Option::<String>::None,
+                ],
+            )?;
+            conn.execute(
+                "INSERT INTO pack_reconcile_runs (run_id, repo_id, repo_root, capability_id, consumer_id, from_generation_seq, to_generation_seq, reconcile_mode, status, attempts, submitted_at_unix, started_at_unix, updated_at_unix, completed_at_unix, error) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                rusqlite::params![
+                    "run-legacy",
+                    "repo-1",
+                    "/tmp/repo",
+                    "test_harness",
+                    "test_harness.current_state",
+                    3_i64,
+                    4_i64,
+                    "merged_delta",
+                    "completed",
+                    1_i64,
+                    200_i64,
+                    201_i64,
+                    202_i64,
+                    203_i64,
+                    Option::<String>::None,
+                ],
+            )?;
+            Ok(())
+        })
+        .expect("insert mixed-schema runs");
+
+    let world = QatWorld {
+        run_dir: Some(run_dir),
+        repo_dir: Some(repo_dir),
+        run_config: Some(Arc::new(QatRunConfig {
+            binary_path: bin_dir.join("bitloops"),
+            suite_root,
+        })),
+        ..Default::default()
+    };
+
+    let (_, run) = load_latest_test_harness_capability_event_run(&world)
+        .expect("load latest run")
+        .expect("completed run should be found");
+
+    assert_eq!(run.run_id, "run-legacy");
+    assert_eq!(run.status, CapabilityEventRunStatus::Completed);
+    assert_eq!(run.capability_id, "test_harness");
+    assert_eq!(run.consumer_id, "test_harness.current_state");
 }
 
 #[test]

--- a/bitloops/tests/qat_support/runner.rs
+++ b/bitloops/tests/qat_support/runner.rs
@@ -2,7 +2,9 @@ use super::helpers::{sanitize_name, stop_daemon_for_scenario};
 use super::steps;
 use super::world::{QatRunConfig, QatWorld};
 use anyhow::{Context, Result, bail};
-use cucumber::{World as _, writer::Stats as _};
+use cucumber::{
+    World as _, gherkin, gherkin::tagexpr::TagOperation, tag::Ext as _, writer::Stats as _,
+};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -20,6 +22,8 @@ pub enum Suite {
     Onboarding,
     Quickstart,
 }
+
+const CUCUMBER_FILTER_TAGS_ENV: &str = "CUCUMBER_FILTER_TAGS";
 
 pub async fn run_suite(binary_path: PathBuf, suite: Suite) -> Result<()> {
     let max_concurrent = resolve_max_concurrent_scenarios();
@@ -48,7 +52,7 @@ pub async fn run_suite(binary_path: PathBuf, suite: Suite) -> Result<()> {
     });
 
     let before_config = Arc::clone(&config);
-    let result = QatWorld::cucumber()
+    let cucumber = QatWorld::cucumber()
         .steps(steps::collection())
         .max_concurrent_scenarios(max_concurrent)
         .before(move |_, _, scenario, world| {
@@ -71,9 +75,19 @@ pub async fn run_suite(binary_path: PathBuf, suite: Suite) -> Result<()> {
             })
         })
         .fail_on_skipped()
-        .with_default_cli()
-        .run(feature_path)
-        .await;
+        .with_default_cli();
+
+    let result = if let Some(tags_filter) =
+        parse_cucumber_tags_filter(env::var(CUCUMBER_FILTER_TAGS_ENV).ok().as_deref())?
+    {
+        cucumber
+            .filter_run(feature_path, move |feature, rule, scenario| {
+                scenario_matches_tags_filter(feature, rule, scenario, &tags_filter)
+            })
+            .await
+    } else {
+        cucumber.run(feature_path).await
+    };
 
     if result.execution_has_failed() || result.parsing_errors() != 0 {
         bail!(
@@ -288,9 +302,36 @@ fn resolve_max_concurrent_scenarios() -> usize {
         .unwrap_or(1)
 }
 
+fn parse_cucumber_tags_filter(raw: Option<&str>) -> Result<Option<TagOperation>> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+
+    let parsed = raw.parse::<TagOperation>().with_context(|| {
+        format!("parsing {CUCUMBER_FILTER_TAGS_ENV} value `{raw}` as a cucumber tag expression")
+    })?;
+    Ok(Some(parsed))
+}
+
+fn scenario_matches_tags_filter(
+    feature: &gherkin::Feature,
+    rule: Option<&gherkin::Rule>,
+    scenario: &gherkin::Scenario,
+    tags_filter: &TagOperation,
+) -> bool {
+    tags_filter.eval(
+        feature
+            .tags
+            .iter()
+            .chain(rule.iter().flat_map(|current| current.tags.iter()))
+            .chain(scenario.tags.iter()),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cucumber::gherkin::{Feature, LineCol, Rule, Scenario, Span};
 
     #[test]
     fn prepare_suite_binary_copies_snapshot() {
@@ -341,5 +382,69 @@ mod tests {
                 .join("devql-ingest")
                 .join("ingest_workspace.feature")
         );
+    }
+
+    #[test]
+    fn parse_cucumber_tags_filter_treats_missing_or_blank_values_as_disabled() {
+        assert!(parse_cucumber_tags_filter(None).unwrap().is_none());
+        assert!(parse_cucumber_tags_filter(Some("")).unwrap().is_none());
+        assert!(parse_cucumber_tags_filter(Some("   ")).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_cucumber_tags_filter_accepts_valid_tag_expression() {
+        let parsed = parse_cucumber_tags_filter(Some("@test_harness_sync and not @slow"))
+            .expect("parse tag filter")
+            .expect("tag filter should be present");
+
+        assert!(parsed.eval(["test_harness_sync"]));
+        assert!(!parsed.eval(["test_harness_sync", "slow"]));
+    }
+
+    #[test]
+    fn scenario_matches_tags_filter_merges_feature_rule_and_scenario_tags() {
+        let feature = Feature {
+            keyword: "Feature".to_string(),
+            name: "feature".to_string(),
+            description: None,
+            background: None,
+            scenarios: Vec::new(),
+            rules: Vec::new(),
+            tags: vec!["feature_tag".to_string()],
+            span: Span::default(),
+            position: LineCol::default(),
+            path: None,
+        };
+        let rule = Rule {
+            keyword: "Rule".to_string(),
+            name: "rule".to_string(),
+            description: None,
+            background: None,
+            scenarios: Vec::new(),
+            tags: vec!["rule_tag".to_string()],
+            span: Span::default(),
+            position: LineCol::default(),
+        };
+        let scenario = Scenario {
+            keyword: "Scenario".to_string(),
+            name: "scenario".to_string(),
+            description: None,
+            steps: Vec::new(),
+            examples: Vec::new(),
+            tags: vec!["scenario_tag".to_string()],
+            span: Span::default(),
+            position: LineCol::default(),
+        };
+        let filter =
+            parse_cucumber_tags_filter(Some("@feature_tag and @rule_tag and @scenario_tag"))
+                .expect("parse tag filter")
+                .expect("tag filter should be present");
+
+        assert!(scenario_matches_tags_filter(
+            &feature,
+            Some(&rule),
+            &scenario,
+            &filter
+        ));
     }
 }


### PR DESCRIPTION
## Summary

This PR aligns `test_harness` with the generic current-state queue path used by `semantic_clones` and fixes the remaining parity gaps between manual ingestion and automatic current-state sync.

## What changed

- register a cursor mailbox for `test_harness.current_state` so the generic sync scheduler enqueues it after sync
- fix `MergedDelta` current-state reconcile so it:
  - promotes to full reconcile when production artefacts change
  - materializes enumerated scenarios for delta updates
  - falls back to full reconcile when enumeration produces synthetic Rust paths that cannot be updated safely incrementally
- improve Rust test-harness scenario identity handling to avoid duplicate `test_artefact_id` collisions in parameterized/enumerated cases
- improve QAT/runtime helpers to read the current runtime-store path and choose the newest test-harness run across mixed schemas
- add focused regressions for:
  - synthetic enumerated scenarios in delta reconcile
  - mixed runtime-store run selection
  - current-state registration/sync behavior

## Why

The automatic current-state flow was not fully equivalent to the older manual ingestion path. In practice this showed up in the Ruff `astral-sh__ruff-15309` validation case, where `selectArtefacts(...).tests(linkageSource: "static_analysis")` returned no results even though the expected static test linkage existed.

After these changes, the current-state flow now produces the expected Ruff linkage results.

## Validation

Ran targeted verification:
- `cargo test -p bitloops --lib merged_delta_`
- `cargo test --manifest-path bitloops/Cargo.toml --features qat-tests --test qat_acceptance load_latest_test_harness_capability_event_run_`
- `cargo qat-devql-sync`
- `cargo dev-install`

Live validation against:
- `/Users/markos/code/bitloops/harness-evaluation/astral-sh__ruff-15309`

After reinstalling and restarting the daemon:
- `bitloops init --sync=true --ingest=false --exclude "*.py"`

Observed:
- `test_harness.current_state` completed in `capability_workplane_cursor_runs`
- Ruff current-state tables populated:
  - `test_artefacts_current = 5732`
  - `test_artefact_edges_current = 72094`
- the F523 artefact query now returns the expected static linkages:
  - `rules[StringDotFormatExtraPositionalArguments, F523.py]`
  - `StringDotFormatExtraPositionalArguments[doctest:416]`

## Notes
