### PR TITLE
test: enhance enumerated doctests to preserve line identity for duplicate items

### DIFF
--- a/bitloops/src/adapters/languages/rust/test_support.rs
+++ b/bitloops/src/adapters/languages/rust/test_support.rs
@@ -221,35 +221,32 @@ impl RustTestMappingHelper {
             .scenarios
             .into_iter()
             .filter(|scenario| {
-                let normalized_key =
-                    if scenario.discovery_source == ScenarioDiscoverySource::Doctest {
-                        let item_name = scenario_base_name(&scenario.scenario_name);
-                        scenario
-                            .reference_candidates
-                            .iter()
-                            .find_map(|candidate| match candidate {
-                                ReferenceCandidate::ExplicitTarget { path, start_line } => {
-                                    Some(normalized_enumerated_doctest_key(
-                                        path,
-                                        &item_name,
-                                        *start_line,
-                                    ))
-                                }
-                                _ => None,
-                            })
-                            .unwrap_or_else(|| {
-                                normalized_enumerated_doctest_key(
-                                    &scenario.relative_path,
-                                    &item_name,
-                                    0,
-                                )
-                            })
-                    } else {
-                        normalized_enumerated_test_key(&format!(
-                            "{}::{}",
-                            scenario.suite_name, scenario.scenario_name
-                        ))
-                    };
+                let normalized_key = if scenario.discovery_source
+                    == ScenarioDiscoverySource::Doctest
+                {
+                    let item_name = scenario_base_name(&scenario.scenario_name);
+                    scenario
+                        .reference_candidates
+                        .iter()
+                        .find_map(|candidate| match candidate {
+                            ReferenceCandidate::ExplicitTarget { path, start_line } => Some(
+                                normalized_enumerated_doctest_key(path, &item_name, *start_line),
+                            ),
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| {
+                            normalized_enumerated_doctest_key(
+                                &scenario.relative_path,
+                                &item_name,
+                                0,
+                            )
+                        })
+                } else {
+                    normalized_enumerated_test_key(&format!(
+                        "{}::{}",
+                        scenario.suite_name, scenario.scenario_name
+                    ))
+                };
 
                 if scenario.discovery_source == ScenarioDiscoverySource::Doctest {
                     !source_doctest_keys.contains(&normalized_key)
@@ -333,8 +330,8 @@ fn normalize_rel_path(path: &Path) -> String {
 mod tests {
     use super::RustTestMappingHelper;
     use crate::host::language_adapter::{
-        DiscoveredTestFile, DiscoveredTestScenario, DiscoveredTestSuite, EnumerationMode,
-        EnumerationResult, EnumeratedTestScenario, ReferenceCandidate, ScenarioDiscoverySource,
+        DiscoveredTestFile, DiscoveredTestScenario, DiscoveredTestSuite, EnumeratedTestScenario,
+        EnumerationMode, EnumerationResult, ReferenceCandidate, ScenarioDiscoverySource,
     };
 
     #[test]

--- a/bitloops/src/adapters/languages/rust/test_support.rs
+++ b/bitloops/src/adapters/languages/rust/test_support.rs
@@ -18,7 +18,7 @@ use tree_sitter_rust::LANGUAGE as LANGUAGE_RUST;
 use self::enumeration::{parse_enumerated_doctests, parse_enumerated_host_tests};
 use self::matching::{
     doctest_match_keys, normalized_enumerated_doctest_key, normalized_enumerated_test_key,
-    source_scenario_match_keys,
+    scenario_base_name, source_scenario_match_keys,
 };
 use crate::host::language_adapter::{
     DiscoveredTestFile, EnumerationMode, EnumerationResult, LanguageAdapterContext,
@@ -223,6 +223,7 @@ impl RustTestMappingHelper {
             .filter(|scenario| {
                 let normalized_key =
                     if scenario.discovery_source == ScenarioDiscoverySource::Doctest {
+                        let item_name = scenario_base_name(&scenario.scenario_name);
                         scenario
                             .reference_candidates
                             .iter()
@@ -230,7 +231,7 @@ impl RustTestMappingHelper {
                                 ReferenceCandidate::ExplicitTarget { path, start_line } => {
                                     Some(normalized_enumerated_doctest_key(
                                         path,
-                                        &scenario.scenario_name,
+                                        &item_name,
                                         *start_line,
                                     ))
                                 }
@@ -239,7 +240,7 @@ impl RustTestMappingHelper {
                             .unwrap_or_else(|| {
                                 normalized_enumerated_doctest_key(
                                     &scenario.relative_path,
-                                    &scenario.scenario_name,
+                                    &item_name,
                                     0,
                                 )
                             })
@@ -326,4 +327,62 @@ fn read_source_file(path: &Path) -> Result<String> {
 
 fn normalize_rel_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RustTestMappingHelper;
+    use crate::host::language_adapter::{
+        DiscoveredTestFile, DiscoveredTestScenario, DiscoveredTestSuite, EnumerationMode,
+        EnumerationResult, EnumeratedTestScenario, ReferenceCandidate, ScenarioDiscoverySource,
+    };
+
+    #[test]
+    fn reconcile_dedupes_enumerated_doctest_when_source_doctest_exists() {
+        let source_files = vec![DiscoveredTestFile {
+            relative_path: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            reference_candidates: Vec::new(),
+            suites: vec![DiscoveredTestSuite {
+                name: "crate::doctests".to_string(),
+                start_line: 1,
+                end_line: 1,
+                scenarios: vec![DiscoveredTestScenario {
+                    name: "sample::documented_increment[doctest:12]".to_string(),
+                    start_line: 12,
+                    end_line: 15,
+                    reference_candidates: vec![ReferenceCandidate::ExplicitTarget {
+                        path: "src/lib.rs".to_string(),
+                        start_line: 12,
+                    }],
+                    discovery_source: ScenarioDiscoverySource::Doctest,
+                }],
+            }],
+        }];
+
+        let enumeration = EnumerationResult {
+            mode: EnumerationMode::Full,
+            scenarios: vec![EnumeratedTestScenario {
+                language: "rust".to_string(),
+                suite_name: "src::lib.rs::doctests".to_string(),
+                scenario_name: "sample::documented_increment[doctest:12]".to_string(),
+                relative_path: "src/lib.rs".to_string(),
+                start_line: 12,
+                reference_candidates: vec![ReferenceCandidate::ExplicitTarget {
+                    path: "src/lib.rs".to_string(),
+                    start_line: 12,
+                }],
+                discovery_source: ScenarioDiscoverySource::Doctest,
+            }],
+            notes: Vec::new(),
+        };
+
+        let reconciled = RustTestMappingHelper::reconcile(&source_files, enumeration);
+
+        assert!(
+            reconciled.enumerated_scenarios.is_empty(),
+            "expected source doctest to suppress the matching enumerated doctest, got {:?}",
+            reconciled.enumerated_scenarios
+        );
+    }
 }

--- a/bitloops/src/adapters/languages/rust/test_support/enumeration.rs
+++ b/bitloops/src/adapters/languages/rust/test_support/enumeration.rs
@@ -17,10 +17,12 @@ pub(crate) fn parse_enumerated_doctests(output: &str) -> Vec<EnumeratedTestScena
             continue;
         };
 
+        let scenario_name = format!("{item_name}[doctest:{line_number}]");
+
         scenarios.push(EnumeratedTestScenario {
             language: "rust".to_string(),
             suite_name: format!("{}::doctests", path.replace('/', "::")),
-            scenario_name: item_name.clone(),
+            scenario_name,
             relative_path: path.to_string(),
             start_line: line_number,
             reference_candidates: vec![ReferenceCandidate::ExplicitTarget {

--- a/bitloops/src/adapters/languages/rust/test_support/matching.rs
+++ b/bitloops/src/adapters/languages/rust/test_support/matching.rs
@@ -66,7 +66,7 @@ pub(crate) fn doctest_match_keys(
     keys
 }
 
-fn scenario_base_name(name: &str) -> String {
+pub(crate) fn scenario_base_name(name: &str) -> String {
     name.split('[').next().unwrap_or(name).trim().to_string()
 }
 

--- a/bitloops/src/capability_packs/test_harness/mapping/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/mapping/tests.rs
@@ -672,7 +672,10 @@ fn parses_enumerated_doctest_output() {
 
     assert_eq!(scenarios.len(), 1);
     assert_eq!(scenarios[0].relative_path, "crates/sample/src/lib.rs");
-    assert_eq!(scenarios[0].scenario_name, "sample::documented_increment");
+    assert_eq!(
+        scenarios[0].scenario_name,
+        "sample::documented_increment[doctest:12]"
+    );
     assert!(
         scenarios[0]
             .reference_candidates
@@ -681,6 +684,24 @@ fn parses_enumerated_doctest_output() {
                 start_line: 12,
             }),
         "expected parsed doctest line target"
+    );
+}
+
+#[test]
+fn enumerated_doctests_preserve_line_identity_for_duplicate_items() {
+    let scenarios = parse_enumerated_doctests(
+        r#"crates/sample/src/lib.rs - sample::documented_increment (line 12): test
+crates/sample/src/lib.rs - sample::documented_increment (line 24): test"#,
+    );
+
+    assert_eq!(scenarios.len(), 2);
+    assert_eq!(
+        scenarios[0].scenario_name,
+        "sample::documented_increment[doctest:12]"
+    );
+    assert_eq!(
+        scenarios[1].scenario_name,
+        "sample::documented_increment[doctest:24]"
     );
 }
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed and why -->

## Validation

- [ ] I ran the relevant tests locally.
- [ ] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [ ] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

