### PR TITLE
Cli 1644 use bitloops local toml to clear hooks when disab

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -220,11 +220,8 @@ Storage behavior:
 ### Enable / Disable
 
 ```bash
-bitloops enable              # writes to config.json (or config.local.json if shared exists)
-bitloops enable --local      # writes to config.local.json
-bitloops enable --project    # writes to config.json
-bitloops disable             # writes enabled: false to config.local.json
-bitloops disable --project   # writes enabled: false to config.json
+bitloops enable              # writes capture.enabled=true to the nearest repo policy and restores persisted agent surfaces
+bitloops disable             # writes capture.enabled=false to the nearest repo policy and removes persisted agent surfaces
 ```
 
 ### Status

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ The `bitloops-embeddings` binary is released separately in `bitloops/bitloops-em
    bitloops disable
    ```
 
+   `bitloops disable` removes Bitloops-managed agent prompt surfaces for the agents recorded in the repo policy.
+   `bitloops enable` reinstalls those same managed surfaces and resumes capture.
+
 4. Work as usual and commit normally. Bitloops will capture the relevant
    developer-agent context around those changes.
 
@@ -166,7 +169,7 @@ bitloops checkpoints status
 
 ## Uninstall
 
-Remove Bitloops hooks from the current repository:
+Remove Bitloops-managed agent prompt surfaces from the current Bitloops project:
 
 ```bash
 bitloops disable

--- a/bitloops/qat/features/onboarding/onboarding.feature
+++ b/bitloops/qat/features/onboarding/onboarding.feature
@@ -82,7 +82,7 @@ Feature: Activation and Onboarding
         Then  git hooks exist for the open-code agent in bitloops
 
     # ── Disable Bitloops in a repository ─────────────────────
-    Scenario: Disable stops capture and status reflects disabled state
+    Scenario: Disable stops capture, removes agent surfaces, and leaves git hooks intact
         Given I run CleanStart for flow "disable-repo"
         And   I start the daemon in bitloops
         And   I run InitCommit for bitloops
@@ -90,6 +90,7 @@ Feature: Activation and Onboarding
         And   I run bitloops enable in bitloops
         And   I run bitloops disable in bitloops
         Then  bitloops status shows disabled in bitloops
+        And   agent hooks are removed for the claude-code agent in bitloops
 
     # ── Uninstall Bitloops from a repository ─────────────────
     Scenario: Uninstall removes agent and git hooks from the repository

--- a/bitloops/src/cli.rs
+++ b/bitloops/src/cli.rs
@@ -22,6 +22,7 @@ pub mod root;
 pub(crate) mod telemetry_consent;
 pub mod uninstall;
 pub mod versioncheck;
+pub(crate) mod agent_surfaces;
 
 /// Bitloops CLI
 #[derive(Parser)]

--- a/bitloops/src/cli.rs
+++ b/bitloops/src/cli.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+pub(crate) mod agent_surfaces;
 pub mod checkpoints;
 pub mod clean;
 pub mod daemon;
@@ -22,7 +23,6 @@ pub mod root;
 pub(crate) mod telemetry_consent;
 pub mod uninstall;
 pub mod versioncheck;
-pub(crate) mod agent_surfaces;
 
 /// Bitloops CLI
 #[derive(Parser)]

--- a/bitloops/src/cli/agent_surfaces.rs
+++ b/bitloops/src/cli/agent_surfaces.rs
@@ -31,7 +31,7 @@ pub(crate) fn reconcile_project_agent_surfaces(
             continue;
         }
         let label = registry.uninstall_agent_hooks(project_root, &agent)?;
-        writeln!(out, "Removed {label} hooks and prompt surfaces.")?;
+        writeln!(out, "Ensured {label} hooks and prompt surfaces are removed.")?;
     }
 
     for agent in selected_agents {
@@ -53,7 +53,12 @@ pub(crate) fn reconcile_project_agent_surfaces(
     Ok(())
 }
 
-pub(crate) fn uninstall_project_agent_surfaces(
+/// Attempts cleanup for configured and already-detected agents and returns the
+/// number of agent families considered for cleanup.
+///
+/// This is not an exact "files removed" count; adapter uninstall routines are
+/// currently best-effort and do not report no-op vs changed.
+pub(crate) fn cleanup_project_agent_surfaces(
     project_root: &Path,
     configured_agents: &[String],
     out: &mut dyn Write,
@@ -74,7 +79,7 @@ pub(crate) fn uninstall_project_agent_surfaces(
 
     for agent in &candidates {
         let label = registry.uninstall_agent_hooks(project_root, agent)?;
-        writeln!(out, "Removed {label} hooks and prompt surfaces.")?;
+        writeln!(out, "Ensured {label} hooks and prompt surfaces are removed.")?;
     }
 
     Ok(candidates.len())

--- a/bitloops/src/cli/agent_surfaces.rs
+++ b/bitloops/src/cli/agent_surfaces.rs
@@ -31,7 +31,10 @@ pub(crate) fn reconcile_project_agent_surfaces(
             continue;
         }
         let label = registry.uninstall_agent_hooks(project_root, &agent)?;
-        writeln!(out, "Ensured {label} hooks and prompt surfaces are removed.")?;
+        writeln!(
+            out,
+            "Ensured {label} hooks and prompt surfaces are removed."
+        )?;
     }
 
     for agent in selected_agents {
@@ -79,7 +82,10 @@ pub(crate) fn cleanup_project_agent_surfaces(
 
     for agent in &candidates {
         let label = registry.uninstall_agent_hooks(project_root, agent)?;
-        writeln!(out, "Ensured {label} hooks and prompt surfaces are removed.")?;
+        writeln!(
+            out,
+            "Ensured {label} hooks and prompt surfaces are removed."
+        )?;
     }
 
     Ok(candidates.len())

--- a/bitloops/src/cli/agent_surfaces.rs
+++ b/bitloops/src/cli/agent_surfaces.rs
@@ -38,9 +38,15 @@ pub(crate) fn reconcile_project_agent_surfaces(
         let (label, installed) =
             registry.install_agent_hooks(project_root, agent, local_dev, force)?;
         if installed > 0 {
-            writeln!(out, "Installed {installed} {label} hooks and prompt surfaces.")?;
+            writeln!(
+                out,
+                "Installed {installed} {label} hooks and prompt surfaces."
+            )?;
         } else {
-            writeln!(out, "{label} hooks and prompt surfaces are already initialised.")?;
+            writeln!(
+                out,
+                "{label} hooks and prompt surfaces are already initialised."
+            )?;
         }
     }
 

--- a/bitloops/src/cli/agent_surfaces.rs
+++ b/bitloops/src/cli/agent_surfaces.rs
@@ -1,0 +1,75 @@
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+use crate::adapters::agents::AgentAdapterRegistry;
+
+pub(crate) fn configured_agents_or_bail(start: &Path) -> Result<Vec<String>> {
+    let agents = crate::config::settings::supported_agents(start)?;
+    if agents.is_empty() {
+        bail!(
+            "No supported agents are configured for this Bitloops project. Run `bitloops init` to select agents before enabling Bitloops."
+        );
+    }
+    Ok(agents)
+}
+
+pub(crate) fn reconcile_project_agent_surfaces(
+    project_root: &Path,
+    selected_agents: &[String],
+    local_dev: bool,
+    force: bool,
+    out: &mut dyn Write,
+) -> Result<()> {
+    let registry = AgentAdapterRegistry::builtin();
+    let selected = selected_agents.iter().cloned().collect::<BTreeSet<_>>();
+
+    for agent in registry.installed_agents(project_root) {
+        if selected.contains(&agent) {
+            continue;
+        }
+        let label = registry.uninstall_agent_hooks(project_root, &agent)?;
+        writeln!(out, "Removed {label} hooks and prompt surfaces.")?;
+    }
+
+    for agent in selected_agents {
+        let (label, installed) =
+            registry.install_agent_hooks(project_root, agent, local_dev, force)?;
+        if installed > 0 {
+            writeln!(out, "Installed {installed} {label} hooks and prompt surfaces.")?;
+        } else {
+            writeln!(out, "{label} hooks and prompt surfaces are already initialised.")?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn uninstall_project_agent_surfaces(
+    project_root: &Path,
+    configured_agents: &[String],
+    out: &mut dyn Write,
+) -> Result<usize> {
+    let registry = AgentAdapterRegistry::builtin();
+    let mut seen = BTreeSet::new();
+    let mut candidates = Vec::new();
+
+    for agent in configured_agents
+        .iter()
+        .cloned()
+        .chain(registry.installed_agents(project_root).into_iter())
+    {
+        if seen.insert(agent.clone()) {
+            candidates.push(agent);
+        }
+    }
+
+    for agent in &candidates {
+        let label = registry.uninstall_agent_hooks(project_root, agent)?;
+        writeln!(out, "Removed {label} hooks and prompt surfaces.")?;
+    }
+
+    Ok(candidates.len())
+}

--- a/bitloops/src/cli/enable.rs
+++ b/bitloops/src/cli/enable.rs
@@ -195,8 +195,10 @@ pub(crate) async fn run_with_io(
         .context("resolving editable Bitloops project config")?;
     let selected_agents = crate::cli::agent_surfaces::configured_agents_or_bail(&cwd)?;
     let settings = load_settings(&cwd).unwrap_or_default();
-    let git_count =
-        crate::adapters::agents::claude_code::git_hooks::install_git_hooks(&git_root, settings.local_dev)?;
+    let git_count = crate::adapters::agents::claude_code::git_hooks::install_git_hooks(
+        &git_root,
+        settings.local_dev,
+    )?;
     if git_count > 0 {
         writeln!(out, "Installed {git_count} git hook(s).")?;
     }

--- a/bitloops/src/cli/enable.rs
+++ b/bitloops/src/cli/enable.rs
@@ -43,7 +43,8 @@ pub struct EnableArgs {
     #[arg(long, short = 'f', hide = true)]
     pub force: bool,
 
-    /// Target a specific agent setup (claude-code|copilot|cursor|gemini|opencode).
+    /// Deprecated hidden compatibility flag. Use `bitloops init --agent <agent>`
+    /// to persist supported agents before running `bitloops enable`.
     #[arg(long, hide = true)]
     pub agent: Option<String>,
 
@@ -162,6 +163,13 @@ pub(crate) async fn run_with_io(
     out: &mut dyn Write,
     input: &mut dyn BufRead,
 ) -> Result<()> {
+    if let Some(agent) = args.agent.as_deref() {
+        bail!(
+            "`bitloops enable --agent {agent}` is no longer supported. \
+Run `bitloops init --agent {agent}` to persist supported agents before enabling Bitloops."
+        );
+    }
+
     let cwd = env::current_dir().context("getting current directory")?;
     let git_root = find_repo_root(&cwd)?;
     let telemetry_choice =
@@ -365,7 +373,7 @@ pub fn run_disable(start: &Path, out: &mut dyn Write, use_project_settings: bool
         .context("resolving editable Bitloops project config")?;
     let configured_agents = crate::config::settings::supported_agents(start)?;
     set_capture_enabled(&target_path, false)?;
-    crate::cli::agent_surfaces::uninstall_project_agent_surfaces(
+    crate::cli::agent_surfaces::cleanup_project_agent_surfaces(
         &project_root,
         &configured_agents,
         out,

--- a/bitloops/src/cli/enable.rs
+++ b/bitloops/src/cli/enable.rs
@@ -184,13 +184,30 @@ pub(crate) async fn run_with_io(
     }
 
     let policy = discover_repo_policy(&cwd)?;
+    let project_root = policy
+        .root
+        .clone()
+        .context("resolving Bitloops project root from repo policy")?;
     let target_path = policy
         .local_path
         .clone()
         .or(policy.shared_path.clone())
         .context("resolving editable Bitloops project config")?;
-    set_capture_enabled(&target_path, true)?;
+    let selected_agents = crate::cli::agent_surfaces::configured_agents_or_bail(&cwd)?;
     let settings = load_settings(&cwd).unwrap_or_default();
+    let git_count =
+        crate::adapters::agents::claude_code::git_hooks::install_git_hooks(&git_root, settings.local_dev)?;
+    if git_count > 0 {
+        writeln!(out, "Installed {git_count} git hook(s).")?;
+    }
+    crate::cli::agent_surfaces::reconcile_project_agent_surfaces(
+        &project_root,
+        &selected_agents,
+        settings.local_dev,
+        args.force,
+        out,
+    )?;
+    set_capture_enabled(&target_path, true)?;
     restart_watcher_if_running(&git_root);
 
     writeln!(out, "Bitloops enabled in this project! :)")?;
@@ -335,12 +352,22 @@ pub fn initialized_agents(repo_root: &Path) -> Vec<String> {
 pub fn run_disable(start: &Path, out: &mut dyn Write, use_project_settings: bool) -> Result<()> {
     let _ = use_project_settings;
     let policy = discover_repo_policy(start)?;
+    let project_root = policy
+        .root
+        .clone()
+        .context("resolving Bitloops project root from repo policy")?;
     let target_path = policy
         .local_path
         .clone()
         .or(policy.shared_path.clone())
         .context("resolving editable Bitloops project config")?;
+    let configured_agents = crate::config::settings::supported_agents(start)?;
     set_capture_enabled(&target_path, false)?;
+    crate::cli::agent_surfaces::uninstall_project_agent_surfaces(
+        &project_root,
+        &configured_agents,
+        out,
+    )?;
     let repo_root = find_repo_root(start)?;
     restart_watcher_if_running(&repo_root);
     writeln!(
@@ -396,18 +423,6 @@ pub fn count_session_states(repo_root: &Path) -> usize {
 pub fn count_shadow_branches(repo_root: &Path) -> usize {
     let _ = repo_root;
     0
-}
-
-pub(crate) fn remove_agent_hooks(repo_root: &Path, out: &mut dyn Write) -> Result<()> {
-    let registry = AgentAdapterRegistry::builtin();
-    for agent in registry.available_agents() {
-        if registry.are_agent_hooks_installed(repo_root, &agent)? {
-            let label = registry.uninstall_agent_hooks(repo_root, &agent)?;
-            writeln!(out, "  Removed {label} hooks")?;
-        }
-    }
-
-    Ok(())
 }
 
 pub fn check_bitloops_dir_exists(repo_root: &Path) -> bool {

--- a/bitloops/src/cli/enable_tests.rs
+++ b/bitloops/src/cli/enable_tests.rs
@@ -473,6 +473,38 @@ enabled = true
 }
 
 #[test]
+fn run_disable_removes_selected_agent_surfaces_and_preserves_git_hooks() {
+    with_isolated_daemon_config(|| {
+        let dir = tempfile::tempdir().unwrap();
+        setup_git_repo(&dir);
+        setup_settings(
+            &dir,
+            r#"
+[capture]
+strategy = "manual-commit"
+enabled = true
+
+[agents]
+supported = ["codex"]
+"#,
+        );
+        git_hooks::install_git_hooks(dir.path(), false).unwrap();
+        crate::adapters::agents::codex::hooks::install_hooks_at(dir.path(), false, false).unwrap();
+
+        let mut out = Vec::new();
+        run_disable(dir.path(), &mut out, false).unwrap();
+
+        assert!(!crate::adapters::agents::codex::hooks::are_hooks_installed_at(dir.path()));
+        assert!(!dir.path().join(".agents/skills/bitloops/using-devql/SKILL.md").exists());
+        assert!(git_hooks::is_git_hook_installed(dir.path()));
+
+        let policy = std::fs::read_to_string(settings_path(dir.path())).unwrap();
+        assert!(policy.contains("enabled = false"));
+        assert!(policy.contains("supported = [\"codex\"]"));
+    });
+}
+
+#[test]
 fn run_disable_already_disabled() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(&dir);
@@ -631,6 +663,41 @@ enabled = true
         project_content.contains("enabled = false"),
         "project settings should be disabled in place: {project_content}"
     );
+}
+
+#[test]
+fn supported_agents_normalizes_aliases_and_deduplicates() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(&dir);
+    setup_settings(
+        &dir,
+        r#"
+[capture]
+enabled = true
+
+[agents]
+supported = ["Gemini", "gemini", "cursor"]
+"#,
+    );
+
+    let agents = crate::config::settings::supported_agents(dir.path()).unwrap();
+    assert_eq!(agents, vec!["gemini".to_string(), "cursor".to_string()]);
+}
+
+#[test]
+fn supported_agents_returns_empty_when_agents_supported_is_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(&dir);
+    setup_settings(
+        &dir,
+        r#"
+[capture]
+enabled = true
+"#,
+    );
+
+    let agents = crate::config::settings::supported_agents(dir.path()).unwrap();
+    assert!(agents.is_empty());
 }
 
 #[test]
@@ -1364,6 +1431,81 @@ fn run_enable_without_agent_installs_default_agent_and_git_hooks() {
         assert!(!dir.path().join(".claude/settings.json").exists());
         assert!(!git_hooks::is_git_hook_installed(dir.path()));
     });
+}
+
+#[test]
+fn run_enable_requires_persisted_supported_agents() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(&dir);
+    setup_settings(
+        &dir,
+        r#"
+[capture]
+strategy = "manual-commit"
+enabled = false
+"#,
+    );
+
+    with_ready_daemon_and_repo_cwd(dir.path(), || {
+        let err = run_enable_command(EnableArgs {
+            local: false,
+            project: false,
+            force: false,
+            agent: None,
+            telemetry: Some(false),
+            no_telemetry: false,
+            install_embeddings: false,
+        })
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("bitloops init"));
+        assert!(!dir.path().join(".claude/settings.json").exists());
+    });
+}
+
+#[test]
+fn run_enable_reinstalls_supported_agent_surfaces_from_policy() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_git_repo(&dir);
+    setup_settings(
+        &dir,
+        r#"
+[capture]
+strategy = "manual-commit"
+enabled = false
+
+[agents]
+supported = ["cursor", "gemini"]
+"#,
+    );
+
+    with_ready_daemon_and_repo_cwd(dir.path(), || {
+        let mut out = Vec::new();
+        let mut input = std::io::Cursor::new("");
+        let runtime = test_runtime();
+        runtime
+            .block_on(run_with_io(
+                EnableArgs {
+                    local: false,
+                    project: false,
+                    force: false,
+                    agent: None,
+                    telemetry: Some(false),
+                    no_telemetry: false,
+                    install_embeddings: false,
+                },
+                &mut out,
+                &mut input,
+            ))
+            .unwrap();
+    });
+
+    assert!(dir.path().join(".cursor/hooks.json").exists());
+    assert!(dir.path().join(".cursor/rules/bitloops-using-devql.mdc").exists());
+    assert!(dir.path().join(".gemini/skills/bitloops/using-devql/SKILL.md").exists());
+    let gemini_md = std::fs::read_to_string(dir.path().join("GEMINI.md")).unwrap();
+    assert!(gemini_md.contains("@./.gemini/skills/bitloops/using-devql/SKILL.md"));
+    assert!(git_hooks::is_git_hook_installed(dir.path()));
 }
 
 #[test]

--- a/bitloops/src/cli/enable_tests.rs
+++ b/bitloops/src/cli/enable_tests.rs
@@ -4,6 +4,7 @@ use crate::adapters::agents::claude_code::hooks as claude_hooks;
 use crate::adapters::agents::codex::hooks as codex_hooks;
 use crate::adapters::agents::copilot::agent::CopilotCliAgent;
 use crate::adapters::agents::cursor::agent::CursorAgent;
+use crate::adapters::agents::gemini::agent::GeminiCliAgent;
 use crate::cli::devql::graphql::{with_graphql_executor_hook, with_ingest_daemon_bootstrap_hook};
 use crate::cli::embeddings::{
     ManagedEmbeddingsBinaryInstallOutcome, with_managed_embeddings_install_hook,
@@ -466,9 +467,12 @@ enabled = true
             "sanity check git command should still work"
         );
         assert!(git_hooks::is_git_hook_installed(dir.path()));
-        assert!(codex_hooks::are_hooks_installed_at(dir.path()));
+        assert!(!codex_hooks::are_hooks_installed_at(dir.path()));
         assert!(dir.path().join(".codex/config.toml").exists());
-        assert!(!settings::is_enabled(dir.path()).unwrap());
+
+        let content = fs::read_to_string(settings_path(dir.path())).unwrap();
+        assert!(content.contains("enabled = false"));
+        assert!(!content.contains("supported = ["));
     });
 }
 
@@ -495,12 +499,62 @@ supported = ["codex"]
         run_disable(dir.path(), &mut out, false).unwrap();
 
         assert!(!crate::adapters::agents::codex::hooks::are_hooks_installed_at(dir.path()));
-        assert!(!dir.path().join(".agents/skills/bitloops/using-devql/SKILL.md").exists());
+        assert!(
+            !dir.path()
+                .join(".agents/skills/bitloops/using-devql/SKILL.md")
+                .exists()
+        );
         assert!(git_hooks::is_git_hook_installed(dir.path()));
 
         let policy = std::fs::read_to_string(settings_path(dir.path())).unwrap();
         assert!(policy.contains("enabled = false"));
         assert!(policy.contains("supported = [\"codex\"]"));
+    });
+}
+
+#[test]
+fn run_disable_removes_multiple_selected_agent_surfaces_and_preserves_git_hooks() {
+    with_isolated_daemon_config(|| {
+        let dir = tempfile::tempdir().unwrap();
+        setup_git_repo(&dir);
+        setup_settings(
+            &dir,
+            r#"
+[capture]
+strategy = "manual-commit"
+enabled = true
+
+[agents]
+supported = ["cursor", "gemini"]
+"#,
+        );
+        git_hooks::install_git_hooks(dir.path(), false).unwrap();
+        crate::adapters::agents::cursor::hooks::install_hooks_at(dir.path(), false, false).unwrap();
+        GeminiCliAgent
+            .install_hooks_at(dir.path(), false, false)
+            .unwrap();
+
+        let mut out = Vec::new();
+        run_disable(dir.path(), &mut out, false).unwrap();
+
+        assert!(!crate::adapters::agents::cursor::hooks::are_hooks_installed_at(dir.path()));
+        assert!(
+            !dir.path()
+                .join(".cursor/rules/bitloops-using-devql.mdc")
+                .exists()
+        );
+        assert!(!GeminiCliAgent.are_hooks_installed_at(dir.path()));
+        assert!(
+            !dir.path()
+                .join(".gemini/skills/bitloops/using-devql/SKILL.md")
+                .exists()
+        );
+        assert!(!dir.path().join("GEMINI.md").exists());
+        assert!(git_hooks::is_git_hook_installed(dir.path()));
+
+        let policy = std::fs::read_to_string(settings_path(dir.path())).unwrap();
+        assert!(policy.contains("enabled = false"));
+        assert!(policy.contains("supported = [\"cursor\", \"gemini\"]"));
     });
 }
 
@@ -513,6 +567,9 @@ fn run_disable_already_disabled() {
         r#"[capture]
 strategy = "manual-commit"
 enabled = false
+
+[agents]
+supported = ["claude-code"]
 "#,
     );
 
@@ -1202,6 +1259,9 @@ fn enable_prompts_for_embeddings_and_defaults_to_yes() {
         &repo,
         r#"[capture]
 enabled = false
+
+[agents]
+supported = ["claude-code"]
 "#,
     );
 
@@ -1281,6 +1341,9 @@ fn enable_install_embeddings_flag_skips_prompt_in_noninteractive_mode() {
         &repo,
         r#"[capture]
 enabled = false
+
+[agents]
+supported = ["claude-code"]
 "#,
     );
 
@@ -1343,6 +1406,9 @@ fn enable_does_not_prompt_when_embeddings_are_already_configured() {
         &repo,
         r#"[capture]
 enabled = false
+
+[agents]
+supported = ["claude-code"]
 "#,
     );
 
@@ -1501,8 +1567,16 @@ supported = ["cursor", "gemini"]
     });
 
     assert!(dir.path().join(".cursor/hooks.json").exists());
-    assert!(dir.path().join(".cursor/rules/bitloops-using-devql.mdc").exists());
-    assert!(dir.path().join(".gemini/skills/bitloops/using-devql/SKILL.md").exists());
+    assert!(
+        dir.path()
+            .join(".cursor/rules/bitloops-using-devql.mdc")
+            .exists()
+    );
+    assert!(
+        dir.path()
+            .join(".gemini/skills/bitloops/using-devql/SKILL.md")
+            .exists()
+    );
     let gemini_md = std::fs::read_to_string(dir.path().join("GEMINI.md")).unwrap();
     assert!(gemini_md.contains("@./.gemini/skills/bitloops/using-devql/SKILL.md"));
     assert!(git_hooks::is_git_hook_installed(dir.path()));
@@ -1666,6 +1740,9 @@ fn run_enable_noninteractive_requires_explicit_telemetry_when_unresolved() {
         r#"[capture]
 strategy = "manual-commit"
 enabled = false
+
+[agents]
+supported = ["claude-code"]
 "#,
     );
 
@@ -1705,6 +1782,9 @@ fn run_enable_with_explicit_no_telemetry_updates_project_config() {
         r#"[capture]
 strategy = "manual-commit"
 enabled = false
+
+[agents]
+supported = ["claude-code"]
 "#,
     );
 

--- a/bitloops/src/cli/enable_tests.rs
+++ b/bitloops/src/cli/enable_tests.rs
@@ -1583,7 +1583,7 @@ supported = ["cursor", "gemini"]
 }
 
 #[test]
-fn run_enable_with_legacy_agent_flag_installs_requested_agent_hooks() {
+fn run_enable_with_legacy_agent_flag_returns_guidance_error() {
     let dir = tempfile::tempdir().unwrap();
     setup_git_repo(&dir);
     with_ready_daemon_and_repo_cwd(dir.path(), || {
@@ -1598,7 +1598,9 @@ fn run_enable_with_legacy_agent_flag_installs_requested_agent_hooks() {
         })
         .unwrap_err();
 
-        assert!(format!("{err:#}").contains("bitloops init"));
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("bitloops enable --agent cursor"));
+        assert!(rendered.contains("bitloops init --agent cursor"));
         assert!(!dir.path().join(".cursor/hooks.json").exists());
         assert!(!git_hooks::is_git_hook_installed(dir.path()));
     });

--- a/bitloops/src/cli/init.rs
+++ b/bitloops/src/cli/init.rs
@@ -6,7 +6,6 @@ use clap::Args;
 #[cfg(test)]
 use std::{cell::RefCell, rc::Rc};
 
-use crate::adapters::agents::AgentAdapterRegistry;
 use crate::cli::embeddings::{EmbeddingsInstallState, inspect_embeddings_install_state};
 use crate::cli::inference::summary_generation_configured;
 use crate::cli::telemetry_consent;
@@ -448,40 +447,6 @@ fn ensure_repo_local_policy_excluded(git_root: &Path, project_root: &Path) -> Re
 
     std::fs::write(&exclude_path, content)
         .with_context(|| format!("writing {}", exclude_path.display()))?;
-    Ok(())
-}
-
-fn reconcile_agent_hooks(
-    project_root: &Path,
-    selected_agents: &[String],
-    local_dev: bool,
-    force: bool,
-    out: &mut dyn Write,
-) -> Result<()> {
-    let registry = AgentAdapterRegistry::builtin();
-    let selected = selected_agents
-        .iter()
-        .cloned()
-        .collect::<std::collections::BTreeSet<_>>();
-
-    for agent in registry.installed_agents(project_root) {
-        if selected.contains(&agent) {
-            continue;
-        }
-        let label = registry.uninstall_agent_hooks(project_root, &agent)?;
-        writeln!(out, "Removed {label} hooks.")?;
-    }
-
-    for agent in selected_agents {
-        let (label, installed) =
-            registry.install_agent_hooks(project_root, agent, local_dev, force)?;
-        if installed > 0 {
-            writeln!(out, "Installed {installed} {label} hook(s).")?;
-        } else {
-            writeln!(out, "{label} hooks are already initialised.")?;
-        }
-    }
-
     Ok(())
 }
 

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -21,7 +21,7 @@ use super::progress::{InitProgressOptions, run_dual_init_progress};
 use super::{
     AgentSelector, DEFAULT_INIT_INGEST_BACKFILL, InitArgs, QueuedEmbeddingsBootstrapTask,
     detect_or_select_agent, ensure_repo_local_policy_excluded, maybe_install_default_daemon,
-    normalize_cli_exclusions, normalize_exclude_from_paths, reconcile_agent_hooks,
+    normalize_cli_exclusions, normalize_exclude_from_paths,
     should_configure_summaries_during_init, should_install_embeddings_during_init,
     should_run_initial_ingest, should_run_initial_sync,
 };
@@ -113,7 +113,7 @@ pub(super) async fn run_for_project_root(
         writeln!(out, "Installed {git_count} git hook(s).")?;
     }
 
-    reconcile_agent_hooks(
+    crate::cli::agent_surfaces::reconcile_project_agent_surfaces(
         project_root,
         &selected_agents,
         settings.local_dev,

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -21,9 +21,8 @@ use super::progress::{InitProgressOptions, run_dual_init_progress};
 use super::{
     AgentSelector, DEFAULT_INIT_INGEST_BACKFILL, InitArgs, QueuedEmbeddingsBootstrapTask,
     detect_or_select_agent, ensure_repo_local_policy_excluded, maybe_install_default_daemon,
-    normalize_cli_exclusions, normalize_exclude_from_paths,
-    should_configure_summaries_during_init, should_install_embeddings_during_init,
-    should_run_initial_ingest, should_run_initial_sync,
+    normalize_cli_exclusions, normalize_exclude_from_paths, should_configure_summaries_during_init,
+    should_install_embeddings_during_init, should_run_initial_ingest, should_run_initial_sync,
 };
 
 pub(super) async fn run_for_project_root(

--- a/bitloops/src/cli/uninstall.rs
+++ b/bitloops/src/cli/uninstall.rs
@@ -75,6 +75,7 @@ async fn run_with_context(
         && !confirm_uninstall(
             out,
             &targets,
+            &scope.agent_project_roots,
             &scope.hook_repo_roots,
             &scope.repo_data_roots,
         )?
@@ -92,7 +93,9 @@ async fn run_with_context(
         .filter(|target| targets.contains(target))
     {
         let result = match target {
-            UninstallTarget::AgentHooks => uninstall_agent_hooks(&scope.hook_repo_roots, out),
+            UninstallTarget::AgentHooks => {
+                uninstall_agent_hooks(&scope.agent_project_roots, out)
+            }
             UninstallTarget::GitHooks => uninstall_git_hooks(&scope.hook_repo_roots, out),
             UninstallTarget::Shell => uninstall_shell_integration(out),
             UninstallTarget::Data => uninstall_data(&scope.repo_data_roots, out),

--- a/bitloops/src/cli/uninstall.rs
+++ b/bitloops/src/cli/uninstall.rs
@@ -93,9 +93,7 @@ async fn run_with_context(
         .filter(|target| targets.contains(target))
     {
         let result = match target {
-            UninstallTarget::AgentHooks => {
-                uninstall_agent_hooks(&scope.agent_project_roots, out)
-            }
+            UninstallTarget::AgentHooks => uninstall_agent_hooks(&scope.agent_project_roots, out),
             UninstallTarget::GitHooks => uninstall_git_hooks(&scope.hook_repo_roots, out),
             UninstallTarget::Shell => uninstall_shell_integration(out),
             UninstallTarget::Data => uninstall_data(&scope.repo_data_roots, out),

--- a/bitloops/src/cli/uninstall/confirm.rs
+++ b/bitloops/src/cli/uninstall/confirm.rs
@@ -98,7 +98,10 @@ mod tests {
         let confirmed = confirm_uninstall_with_input(
             &mut out,
             &targets(&[UninstallTarget::AgentHooks, UninstallTarget::Data]),
-            &[PathBuf::from("/tmp/project-a"), PathBuf::from("/tmp/project-b")],
+            &[
+                PathBuf::from("/tmp/project-a"),
+                PathBuf::from("/tmp/project-b"),
+            ],
             &[PathBuf::from("/tmp/repo-a"), PathBuf::from("/tmp/repo-b")],
             &[PathBuf::from("/tmp/repo-a")],
             &mut input,

--- a/bitloops/src/cli/uninstall/confirm.rs
+++ b/bitloops/src/cli/uninstall/confirm.rs
@@ -9,17 +9,26 @@ use super::targets::{ALL_TARGETS, UninstallTarget};
 pub(super) fn confirm_uninstall(
     out: &mut dyn Write,
     targets: &BTreeSet<UninstallTarget>,
+    agent_project_roots: &[PathBuf],
     hook_repo_roots: &[PathBuf],
     repo_data_roots: &[PathBuf],
 ) -> Result<bool> {
     let stdin = io::stdin();
     let mut input = stdin.lock();
-    confirm_uninstall_with_input(out, targets, hook_repo_roots, repo_data_roots, &mut input)
+    confirm_uninstall_with_input(
+        out,
+        targets,
+        agent_project_roots,
+        hook_repo_roots,
+        repo_data_roots,
+        &mut input,
+    )
 }
 
 fn confirm_uninstall_with_input(
     out: &mut dyn Write,
     targets: &BTreeSet<UninstallTarget>,
+    agent_project_roots: &[PathBuf],
     hook_repo_roots: &[PathBuf],
     repo_data_roots: &[PathBuf],
     input: &mut dyn BufRead,
@@ -31,11 +40,16 @@ fn confirm_uninstall_with_input(
         .copied()
         .filter(|target| targets.contains(target))
     {
-        writeln!(
-            out,
-            "  - {}",
-            target.summary(hook_repo_roots.len(), repo_data_roots.len())
-        )?;
+        let summary = match target {
+            UninstallTarget::AgentHooks => {
+                format!(
+                    "Agent hooks in {} Bitloops project(s)",
+                    agent_project_roots.len()
+                )
+            }
+            _ => target.summary(hook_repo_roots.len(), repo_data_roots.len()),
+        };
+        writeln!(out, "  - {summary}")?;
     }
     write!(out, "\nContinue? [y/N]: ")?;
     out.flush()?;
@@ -68,6 +82,7 @@ mod tests {
                 &targets(&[UninstallTarget::AgentHooks]),
                 &[],
                 &[],
+                &[],
                 &mut input,
             )
             .expect("confirmation should succeed");
@@ -83,6 +98,7 @@ mod tests {
         let confirmed = confirm_uninstall_with_input(
             &mut out,
             &targets(&[UninstallTarget::AgentHooks, UninstallTarget::Data]),
+            &[PathBuf::from("/tmp/project-a"), PathBuf::from("/tmp/project-b")],
             &[PathBuf::from("/tmp/repo-a"), PathBuf::from("/tmp/repo-b")],
             &[PathBuf::from("/tmp/repo-a")],
             &mut input,
@@ -93,7 +109,7 @@ mod tests {
 
         let output = String::from_utf8(out).expect("output should be utf-8");
         assert!(output.contains("This will remove the following Bitloops artefacts:"));
-        assert!(output.contains("Agent hooks in 2 repo(s)"));
+        assert!(output.contains("Agent hooks in 2 Bitloops project(s)"));
         assert!(output.contains("Global data directory and .bitloops dirs in 1 repo(s)"));
         assert!(output.contains("Continue? [y/N]: "));
     }

--- a/bitloops/src/cli/uninstall/hooks.rs
+++ b/bitloops/src/cli/uninstall/hooks.rs
@@ -4,29 +4,32 @@ use std::path::PathBuf;
 use anyhow::Result;
 
 use crate::adapters::agents::claude_code::git_hooks;
-use crate::cli::enable;
 
-pub(super) fn uninstall_agent_hooks(repo_roots: &[PathBuf], out: &mut dyn Write) -> Result<()> {
-    if repo_roots.is_empty() {
-        writeln!(out, "  No known repositories found for agent hook removal.")?;
+pub(super) fn uninstall_agent_hooks(project_roots: &[PathBuf], out: &mut dyn Write) -> Result<()> {
+    if project_roots.is_empty() {
+        writeln!(out, "  No known Bitloops projects found for agent hook removal.")?;
         return Ok(());
     }
 
-    let registry = crate::adapters::agents::AgentAdapterRegistry::builtin();
-    let mut removed = 0usize;
-
-    for repo_root in repo_roots {
-        let installed = registry.installed_agents(repo_root);
-        if installed.is_empty() {
+    let mut removed_projects = 0usize;
+    for project_root in project_roots {
+        let configured = crate::config::settings::supported_agents(project_root).unwrap_or_default();
+        let mut project_out = Vec::new();
+        let removed = crate::cli::agent_surfaces::uninstall_project_agent_surfaces(
+            project_root,
+            &configured,
+            &mut project_out,
+        )?;
+        if removed == 0 {
             continue;
         }
 
-        writeln!(out, "  Agent hooks: {}", repo_root.display())?;
-        enable::remove_agent_hooks(repo_root, out)?;
-        removed += installed.len();
+        writeln!(out, "  Agent hooks: {}", project_root.display())?;
+        write!(out, "{}", String::from_utf8(project_out).unwrap())?;
+        removed_projects += 1;
     }
 
-    if removed == 0 {
+    if removed_projects == 0 {
         writeln!(out, "  No agent hooks found.")?;
     }
 

--- a/bitloops/src/cli/uninstall/hooks.rs
+++ b/bitloops/src/cli/uninstall/hooks.rs
@@ -7,13 +7,17 @@ use crate::adapters::agents::claude_code::git_hooks;
 
 pub(super) fn uninstall_agent_hooks(project_roots: &[PathBuf], out: &mut dyn Write) -> Result<()> {
     if project_roots.is_empty() {
-        writeln!(out, "  No known Bitloops projects found for agent hook removal.")?;
+        writeln!(
+            out,
+            "  No known Bitloops projects found for agent hook removal."
+        )?;
         return Ok(());
     }
 
     let mut removed_projects = 0usize;
     for project_root in project_roots {
-        let configured = crate::config::settings::supported_agents(project_root).unwrap_or_default();
+        let configured =
+            crate::config::settings::supported_agents(project_root).unwrap_or_default();
         let mut project_out = Vec::new();
         let removed = crate::cli::agent_surfaces::uninstall_project_agent_surfaces(
             project_root,

--- a/bitloops/src/cli/uninstall/hooks.rs
+++ b/bitloops/src/cli/uninstall/hooks.rs
@@ -19,12 +19,12 @@ pub(super) fn uninstall_agent_hooks(project_roots: &[PathBuf], out: &mut dyn Wri
         let configured =
             crate::config::settings::supported_agents(project_root).unwrap_or_default();
         let mut project_out = Vec::new();
-        let removed = crate::cli::agent_surfaces::uninstall_project_agent_surfaces(
+        let attempted = crate::cli::agent_surfaces::cleanup_project_agent_surfaces(
             project_root,
             &configured,
             &mut project_out,
         )?;
-        if removed == 0 {
+        if attempted == 0 {
             continue;
         }
 

--- a/bitloops/src/cli/uninstall/repo.rs
+++ b/bitloops/src/cli/uninstall/repo.rs
@@ -11,6 +11,7 @@ use crate::utils::platform_dirs::bitloops_state_dir;
 
 pub(super) struct ResolvedScope {
     pub(super) hook_repo_roots: Vec<PathBuf>,
+    pub(super) agent_project_roots: Vec<PathBuf>,
     pub(super) repo_data_roots: Vec<PathBuf>,
 }
 
@@ -18,9 +19,7 @@ pub(super) fn resolve_scope(
     args: &UninstallArgs,
     targets: &BTreeSet<UninstallTarget>,
 ) -> Result<ResolvedScope> {
-    let hook_repo_roots = if targets.contains(&UninstallTarget::AgentHooks)
-        || targets.contains(&UninstallTarget::GitHooks)
-    {
+    let hook_repo_roots = if targets.contains(&UninstallTarget::GitHooks) {
         if args.only_current_project {
             vec![
                 current_repo_root()?
@@ -28,6 +27,20 @@ pub(super) fn resolve_scope(
             ]
         } else {
             discover_known_repo_roots()?
+        }
+    } else {
+        Vec::new()
+    };
+
+    let agent_project_roots = if targets.contains(&UninstallTarget::AgentHooks) {
+        if args.only_current_project {
+            vec![current_bitloops_project_root()?
+                .or(current_repo_root()?)
+                .context(
+                    "`--only-current-project` requires running inside a git repository or Bitloops project",
+                )?]
+        } else {
+            discover_bitloops_project_roots()?
         }
     } else {
         Vec::new()
@@ -41,6 +54,7 @@ pub(super) fn resolve_scope(
 
     Ok(ResolvedScope {
         hook_repo_roots,
+        agent_project_roots,
         repo_data_roots,
     })
 }
@@ -75,6 +89,49 @@ fn current_repo_root() -> Result<Option<PathBuf>> {
             .canonicalize()
             .unwrap_or_else(|_| repo_root.to_path_buf())
     }))
+}
+
+fn current_bitloops_project_root() -> Result<Option<PathBuf>> {
+    let cwd = env::current_dir().context("getting current directory")?;
+    let snapshot = crate::config::discover_repo_policy_optional(&cwd)?;
+    Ok(snapshot.root.map(|root| root.canonicalize().unwrap_or(root)))
+}
+
+fn discover_bitloops_project_roots() -> Result<Vec<PathBuf>> {
+    let mut roots = BTreeSet::new();
+    let registry = crate::adapters::agents::AgentAdapterRegistry::builtin();
+
+    if let Some(current) = current_bitloops_project_root()? {
+        roots.insert(current);
+    }
+
+    for git_root in discover_known_repo_roots()? {
+        if !registry.installed_agents(&git_root).is_empty() {
+            roots.insert(git_root.clone());
+        }
+        for entry in walkdir::WalkDir::new(&git_root)
+            .into_iter()
+            .filter_entry(|entry| entry.file_name() != ".git")
+        {
+            let Ok(entry) = entry else {
+                continue;
+            };
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy();
+            if matches!(
+                name.as_ref(),
+                crate::config::REPO_POLICY_FILE_NAME | crate::config::REPO_POLICY_LOCAL_FILE_NAME
+            ) {
+                if let Some(parent) = entry.path().parent() {
+                    roots.insert(parent.canonicalize().unwrap_or_else(|_| parent.to_path_buf()));
+                }
+            }
+        }
+    }
+
+    Ok(roots.into_iter().collect())
 }
 
 fn repo_registry_path() -> Option<PathBuf> {

--- a/bitloops/src/cli/uninstall/repo.rs
+++ b/bitloops/src/cli/uninstall/repo.rs
@@ -99,6 +99,22 @@ fn current_bitloops_project_root() -> Result<Option<PathBuf>> {
         .map(|root| root.canonicalize().unwrap_or(root)))
 }
 
+fn should_skip_project_discovery_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | "node_modules"
+            | "target"
+            | "vendor"
+            | ".venv"
+            | "venv"
+            | "__pycache__"
+            | ".next"
+            | "dist"
+            | "build"
+    )
+}
+
 fn discover_bitloops_project_roots() -> Result<Vec<PathBuf>> {
     let mut roots = BTreeSet::new();
     let registry = crate::adapters::agents::AgentAdapterRegistry::builtin();
@@ -111,10 +127,13 @@ fn discover_bitloops_project_roots() -> Result<Vec<PathBuf>> {
         if !registry.installed_agents(&git_root).is_empty() {
             roots.insert(git_root.clone());
         }
-        for entry in walkdir::WalkDir::new(&git_root)
-            .into_iter()
-            .filter_entry(|entry| entry.file_name() != ".git")
-        {
+        for entry in walkdir::WalkDir::new(&git_root).into_iter().filter_entry(|entry| {
+            if !entry.file_type().is_dir() {
+                return true;
+            }
+            let name = entry.file_name().to_string_lossy();
+            !should_skip_project_discovery_dir(name.as_ref())
+        }) {
             let Ok(entry) = entry else {
                 continue;
             };
@@ -143,4 +162,37 @@ fn repo_registry_path() -> Option<PathBuf> {
     bitloops_state_dir()
         .ok()
         .map(|state_dir| state_dir.join("daemon").join("repo-path-registry.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_discovery_skips_known_heavy_directories() {
+        for name in [
+            ".git",
+            "node_modules",
+            "target",
+            "vendor",
+            ".venv",
+            "venv",
+            "__pycache__",
+            ".next",
+            "dist",
+            "build",
+        ] {
+            assert!(should_skip_project_discovery_dir(name), "{name} should be skipped");
+        }
+    }
+
+    #[test]
+    fn project_discovery_keeps_normal_source_directories() {
+        for name in ["packages", "apps", "src", "services", "repo"] {
+            assert!(
+                !should_skip_project_discovery_dir(name),
+                "{name} should remain discoverable"
+            );
+        }
+    }
 }

--- a/bitloops/src/cli/uninstall/repo.rs
+++ b/bitloops/src/cli/uninstall/repo.rs
@@ -127,13 +127,16 @@ fn discover_bitloops_project_roots() -> Result<Vec<PathBuf>> {
         if !registry.installed_agents(&git_root).is_empty() {
             roots.insert(git_root.clone());
         }
-        for entry in walkdir::WalkDir::new(&git_root).into_iter().filter_entry(|entry| {
-            if !entry.file_type().is_dir() {
-                return true;
-            }
-            let name = entry.file_name().to_string_lossy();
-            !should_skip_project_discovery_dir(name.as_ref())
-        }) {
+        for entry in walkdir::WalkDir::new(&git_root)
+            .into_iter()
+            .filter_entry(|entry| {
+                if !entry.file_type().is_dir() {
+                    return true;
+                }
+                let name = entry.file_name().to_string_lossy();
+                !should_skip_project_discovery_dir(name.as_ref())
+            })
+        {
             let Ok(entry) = entry else {
                 continue;
             };
@@ -182,7 +185,10 @@ mod tests {
             "dist",
             "build",
         ] {
-            assert!(should_skip_project_discovery_dir(name), "{name} should be skipped");
+            assert!(
+                should_skip_project_discovery_dir(name),
+                "{name} should be skipped"
+            );
         }
     }
 

--- a/bitloops/src/cli/uninstall/repo.rs
+++ b/bitloops/src/cli/uninstall/repo.rs
@@ -94,7 +94,9 @@ fn current_repo_root() -> Result<Option<PathBuf>> {
 fn current_bitloops_project_root() -> Result<Option<PathBuf>> {
     let cwd = env::current_dir().context("getting current directory")?;
     let snapshot = crate::config::discover_repo_policy_optional(&cwd)?;
-    Ok(snapshot.root.map(|root| root.canonicalize().unwrap_or(root)))
+    Ok(snapshot
+        .root
+        .map(|root| root.canonicalize().unwrap_or(root)))
 }
 
 fn discover_bitloops_project_roots() -> Result<Vec<PathBuf>> {
@@ -123,10 +125,13 @@ fn discover_bitloops_project_roots() -> Result<Vec<PathBuf>> {
             if matches!(
                 name.as_ref(),
                 crate::config::REPO_POLICY_FILE_NAME | crate::config::REPO_POLICY_LOCAL_FILE_NAME
-            ) {
-                if let Some(parent) = entry.path().parent() {
-                    roots.insert(parent.canonicalize().unwrap_or_else(|_| parent.to_path_buf()));
-                }
+            ) && let Some(parent) = entry.path().parent()
+            {
+                roots.insert(
+                    parent
+                        .canonicalize()
+                        .unwrap_or_else(|_| parent.to_path_buf()),
+                );
             }
         }
     }

--- a/bitloops/src/cli/uninstall/targets.rs
+++ b/bitloops/src/cli/uninstall/targets.rs
@@ -96,7 +96,7 @@ impl UninstallTarget {
 
     pub(super) fn picker_label(self) -> &'static str {
         match self {
-            Self::AgentHooks => "Agent hooks in known repositories",
+            Self::AgentHooks => "Agent hooks in known Bitloops projects",
             Self::GitHooks => "Git hooks in known repositories",
             Self::Shell => "Shell completion integration",
             Self::Data => "Global data and repo-local `.bitloops/` data",
@@ -109,7 +109,7 @@ impl UninstallTarget {
 
     pub(super) fn summary(self, hook_repo_count: usize, repo_data_count: usize) -> String {
         match self {
-            Self::AgentHooks => format!("Agent hooks in {hook_repo_count} repo(s)"),
+            Self::AgentHooks => format!("Agent hooks in {hook_repo_count} Bitloops project(s)"),
             Self::GitHooks => format!("Git hooks in {hook_repo_count} repo(s)"),
             Self::Shell => "Shell completion integration".to_string(),
             Self::Data => {

--- a/bitloops/src/cli/uninstall/tests.rs
+++ b/bitloops/src/cli/uninstall/tests.rs
@@ -329,6 +329,135 @@ fn only_current_project_limits_hook_removal() {
 }
 
 #[test]
+fn uninstall_agent_hooks_uses_supported_agents_when_detection_is_false() {
+    let repo = tempfile::tempdir().unwrap();
+    let config = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+
+    with_platform_dirs(&config, &data, &cache, &state, &home, Some(repo.path()), || {
+        fs::write(
+            repo.path().join(".bitloops.local.toml"),
+            r#"
+[capture]
+enabled = false
+
+[agents]
+supported = ["codex"]
+"#,
+        )
+        .unwrap();
+        let skill_path = repo
+            .path()
+            .join(".agents/skills/bitloops/using-devql/SKILL.md");
+        fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+        fs::write(&skill_path, "managed").unwrap();
+
+        run_uninstall_for_test(
+            UninstallArgs {
+                agent_hooks: true,
+                only_current_project: true,
+                force: true,
+                ..UninstallArgs::default()
+            },
+            None,
+            None,
+            &|| Box::pin(async { Ok(()) }),
+            &|| Ok(()),
+            &|| Ok(Vec::new()),
+        )
+        .unwrap();
+
+        assert!(!skill_path.exists());
+    });
+}
+
+#[test]
+fn uninstall_agent_hooks_discovers_nested_bitloops_project_roots() {
+    let repo = tempfile::tempdir().unwrap();
+    let app = repo.path().join("packages/app");
+    let config = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+    fs::create_dir_all(&app).unwrap();
+
+    with_platform_dirs(&config, &data, &cache, &state, &home, None, || {
+        fs::write(
+            app.join(".bitloops.local.toml"),
+            r#"
+[capture]
+enabled = false
+
+[agents]
+supported = ["claude-code"]
+"#,
+        )
+        .unwrap();
+        crate::adapters::agents::claude_code::hooks::install_hooks(&app, false).unwrap();
+
+        let registry_path = bitloops_state_dir()
+            .unwrap()
+            .join("daemon")
+            .join("repo-path-registry.json");
+        write_repo_registry(&registry_path, &[repo.path()]);
+
+        run_uninstall_for_test(
+            UninstallArgs {
+                agent_hooks: true,
+                force: true,
+                ..UninstallArgs::default()
+            },
+            None,
+            None,
+            &|| Box::pin(async { Ok(()) }),
+            &|| Ok(()),
+            &|| Ok(Vec::new()),
+        )
+        .unwrap();
+
+        let settings = fs::read_to_string(app.join(".claude/settings.json")).unwrap();
+        assert!(!settings.contains("bitloops hooks claude-code"));
+    });
+}
+
+#[test]
+fn only_current_project_agent_hooks_falls_back_to_repo_root_without_policy() {
+    let repo = tempfile::tempdir().unwrap();
+    let config = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+
+    with_platform_dirs(&config, &data, &cache, &state, &home, Some(repo.path()), || {
+        codex_hooks::install_hooks_at(repo.path(), false, false).unwrap();
+
+        let scope = super::repo::resolve_scope(
+            &UninstallArgs {
+                agent_hooks: true,
+                only_current_project: true,
+                force: true,
+                ..UninstallArgs::default()
+            },
+            &BTreeSet::from([UninstallTarget::AgentHooks]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            scope.agent_project_roots,
+            vec![repo.path().canonicalize().unwrap()]
+        );
+    });
+}
+
+#[test]
 fn data_target_removes_only_data() {
     let config = tempfile::tempdir().unwrap();
     let data = tempfile::tempdir().unwrap();

--- a/bitloops/src/cli/uninstall/tests.rs
+++ b/bitloops/src/cli/uninstall/tests.rs
@@ -338,41 +338,49 @@ fn uninstall_agent_hooks_uses_supported_agents_when_detection_is_false() {
     let home = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
 
-    with_platform_dirs(&config, &data, &cache, &state, &home, Some(repo.path()), || {
-        fs::write(
-            repo.path().join(".bitloops.local.toml"),
-            r#"
+    with_platform_dirs(
+        &config,
+        &data,
+        &cache,
+        &state,
+        &home,
+        Some(repo.path()),
+        || {
+            fs::write(
+                repo.path().join(".bitloops.local.toml"),
+                r#"
 [capture]
 enabled = false
 
 [agents]
 supported = ["codex"]
 "#,
-        )
-        .unwrap();
-        let skill_path = repo
-            .path()
-            .join(".agents/skills/bitloops/using-devql/SKILL.md");
-        fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
-        fs::write(&skill_path, "managed").unwrap();
+            )
+            .unwrap();
+            let skill_path = repo
+                .path()
+                .join(".agents/skills/bitloops/using-devql/SKILL.md");
+            fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+            fs::write(&skill_path, "managed").unwrap();
 
-        run_uninstall_for_test(
-            UninstallArgs {
-                agent_hooks: true,
-                only_current_project: true,
-                force: true,
-                ..UninstallArgs::default()
-            },
-            None,
-            None,
-            &|| Box::pin(async { Ok(()) }),
-            &|| Ok(()),
-            &|| Ok(Vec::new()),
-        )
-        .unwrap();
+            run_uninstall_for_test(
+                UninstallArgs {
+                    agent_hooks: true,
+                    only_current_project: true,
+                    force: true,
+                    ..UninstallArgs::default()
+                },
+                None,
+                None,
+                &|| Box::pin(async { Ok(()) }),
+                &|| Ok(()),
+                &|| Ok(Vec::new()),
+            )
+            .unwrap();
 
-        assert!(!skill_path.exists());
-    });
+            assert!(!skill_path.exists());
+        },
+    );
 }
 
 #[test]
@@ -436,25 +444,33 @@ fn only_current_project_agent_hooks_falls_back_to_repo_root_without_policy() {
     let home = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
 
-    with_platform_dirs(&config, &data, &cache, &state, &home, Some(repo.path()), || {
-        codex_hooks::install_hooks_at(repo.path(), false, false).unwrap();
+    with_platform_dirs(
+        &config,
+        &data,
+        &cache,
+        &state,
+        &home,
+        Some(repo.path()),
+        || {
+            codex_hooks::install_hooks_at(repo.path(), false, false).unwrap();
 
-        let scope = super::repo::resolve_scope(
-            &UninstallArgs {
-                agent_hooks: true,
-                only_current_project: true,
-                force: true,
-                ..UninstallArgs::default()
-            },
-            &BTreeSet::from([UninstallTarget::AgentHooks]),
-        )
-        .unwrap();
+            let scope = super::repo::resolve_scope(
+                &UninstallArgs {
+                    agent_hooks: true,
+                    only_current_project: true,
+                    force: true,
+                    ..UninstallArgs::default()
+                },
+                &BTreeSet::from([UninstallTarget::AgentHooks]),
+            )
+            .unwrap();
 
-        assert_eq!(
-            scope.agent_project_roots,
-            vec![repo.path().canonicalize().unwrap()]
-        );
-    });
+            assert_eq!(
+                scope.agent_project_roots,
+                vec![repo.path().canonicalize().unwrap()]
+            );
+        },
+    );
 }
 
 #[test]

--- a/bitloops/src/cli/uninstall/tests.rs
+++ b/bitloops/src/cli/uninstall/tests.rs
@@ -384,6 +384,57 @@ supported = ["codex"]
 }
 
 #[test]
+fn uninstall_agent_hooks_reports_cleanup_attempts_without_claiming_real_removals() {
+    let repo = tempfile::tempdir().unwrap();
+    let config = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+
+    with_platform_dirs(
+        &config,
+        &data,
+        &cache,
+        &state,
+        &home,
+        Some(repo.path()),
+        || {
+            fs::write(
+                repo.path().join(".bitloops.local.toml"),
+                r#"
+[capture]
+enabled = false
+
+[agents]
+supported = ["codex"]
+"#,
+            )
+            .unwrap();
+
+            let output = run_uninstall_for_test(
+                UninstallArgs {
+                    agent_hooks: true,
+                    only_current_project: true,
+                    force: true,
+                    ..UninstallArgs::default()
+                },
+                None,
+                None,
+                &|| Box::pin(async { Ok(()) }),
+                &|| Ok(()),
+                &|| Ok(Vec::new()),
+            )
+            .unwrap();
+
+            assert!(output.contains("Ensured Codex hooks and prompt surfaces are removed."));
+            assert!(!output.contains("Removed Codex hooks and prompt surfaces."));
+        },
+    );
+}
+
+#[test]
 fn uninstall_agent_hooks_discovers_nested_bitloops_project_roots() {
     let repo = tempfile::tempdir().unwrap();
     let app = repo.path().join("packages/app");
@@ -396,6 +447,12 @@ fn uninstall_agent_hooks_discovers_nested_bitloops_project_roots() {
     fs::create_dir_all(&app).unwrap();
 
     with_platform_dirs(&config, &data, &cache, &state, &home, None, || {
+        fs::create_dir_all(repo.path().join("node_modules/left-pad")).unwrap();
+        fs::create_dir_all(repo.path().join("target/debug/deps")).unwrap();
+        fs::create_dir_all(repo.path().join("vendor/cache/pkg")).unwrap();
+        fs::write(repo.path().join("node_modules/left-pad/package.json"), "{}").unwrap();
+        fs::write(repo.path().join("target/debug/deps/app"), "bin").unwrap();
+        fs::write(repo.path().join("vendor/cache/pkg/lib.txt"), "vendored").unwrap();
         fs::write(
             app.join(".bitloops.local.toml"),
             r#"

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -1,6 +1,6 @@
 //! Thin-CLI policy settings resolved from repo policy TOML plus global daemon CLI config.
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -1,6 +1,6 @@
 //! Thin-CLI policy settings resolved from repo policy TOML plus global daemon CLI config.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -82,6 +82,36 @@ pub fn load_settings(repo_root: &Path) -> Result<BitloopsSettings> {
 
 pub fn load_required_settings(repo_root: &Path) -> Result<BitloopsSettings> {
     load_settings_from_policy(discover_repo_policy(repo_root)?)
+}
+
+pub fn supported_agents(start: &Path) -> Result<Vec<String>> {
+    let policy = discover_repo_policy(start)?;
+    supported_agents_from_policy(&policy)
+}
+
+pub fn supported_agents_from_policy(policy: &super::RepoPolicySnapshot) -> Result<Vec<String>> {
+    let Some(raw) = policy.agents.get("supported") else {
+        return Ok(Vec::new());
+    };
+    let raw = raw
+        .as_array()
+        .ok_or_else(|| anyhow!("`[agents].supported` must be an array of strings"))?;
+
+    let registry = crate::adapters::agents::AgentAdapterRegistry::builtin();
+    let mut seen = std::collections::BTreeSet::new();
+    let mut resolved = Vec::new();
+
+    for value in raw {
+        let name = value
+            .as_str()
+            .ok_or_else(|| anyhow!("`[agents].supported` must contain only strings"))?;
+        let normalized = registry.normalise_agent_name(name)?;
+        if seen.insert(normalized.clone()) {
+            resolved.push(normalized);
+        }
+    }
+
+    Ok(resolved)
 }
 
 fn load_settings_from_policy(policy: super::RepoPolicySnapshot) -> Result<BitloopsSettings> {


### PR DESCRIPTION
## Summary

This updates stale `enable`/`disable` regressions to match the new persisted-agent lifecycle semantics.

## Changes

- Updated `enable` regression fixtures to include persisted `[agents].supported` so they exercise embeddings and telemetry behavior instead of failing early on missing agent policy.
- Updated the legacy `disable` regression to assert current behavior:
  - Bitloops-managed agent surfaces are removed
  - git hooks remain installed, but not copilot
  - policy is disabled in place without adding supported-agent config
- Added multi-agent `disable` coverage for `["cursor", "gemini"]` to mirror existing multi-agent `enable` coverage.

## Verification

- `cargo test --manifest-path bitloops/Cargo.toml enable_prompts_for_embeddings_and_defaults_to_yes`
- `cargo test --manifest-path bitloops/Cargo.toml enable_install_embeddings_flag_skips_prompt_in_noninteractive_mode`
- `cargo test --manifest-path bitloops/Cargo.toml enable_does_not_prompt_when_embeddings_are_already_configured`
- `cargo test --manifest-path bitloops/Cargo.toml run_disable_removes_installed_hooks_without_editing_policy`
- `cargo test --manifest-path bitloops/Cargo.toml run_enable_with_explicit_no_telemetry_updates_project_config`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features`

## Validation

- [X] I ran the relevant tests locally.
- [X] I included the executed commands and outcomes in the PR description.

## TDD RED Evidence Gate (when applicable)

Reference policy: `docs/tdd-red-evidence.md`

- [X] This PR does **not** require RED evidence (explain why), or
- [ ] RED evidence exists on all required Jira test subtasks before implementation completion.
- [ ] RED evidence comments include command, failing result, and meaningful failure message.
- [ ] No tests were bypassed with `#[ignore]` or equivalent shortcuts.

## Jira

- [X] Linked Jira issue(s) are updated with implementation notes and test results. https://bitloops.atlassian.net/browse/CLI-1644
- [ ] Final status transitions match the task definition of done.

