### PR TITLE
CLI-1660 canonicalize Rust macro-generated test scenarios

### DIFF
--- a/bitloops/src/adapters/languages/rust/test_support/macros.rs
+++ b/bitloops/src/adapters/languages/rust/test_support/macros.rs
@@ -6,7 +6,7 @@ use crate::host::language_adapter::{
     DiscoveredTestScenario, ReferenceCandidate, ScenarioDiscoverySource,
 };
 
-use super::attributes::find_matching_delimiter;
+use super::attributes::{find_matching_delimiter, split_top_level_arguments};
 use super::scenarios::{RustDiscoveredScenario, rust_suite_for_node};
 
 pub(crate) fn collect_rust_macro_generated_scenarios(
@@ -28,7 +28,7 @@ pub(crate) fn collect_rust_macro_generated_scenarios(
             && let Some(macro_name) = extract_rust_macro_invocation_name(raw_invocation)
             && test_macro_names.contains(macro_name)
             && let Some(body) = extract_rust_macro_invocation_body(raw_invocation)
-            && let Some(scenario_name) = extract_first_identifier_token(body)
+            && let Some(scenario_name) = extract_macro_generated_scenario_name(macro_name, body)
         {
             let (suite_name, suite_start_line, suite_end_line) =
                 rust_suite_for_node(node, source, relative_path);
@@ -56,6 +56,31 @@ pub(crate) fn collect_rust_macro_generated_scenarios(
     }
 
     scenarios
+}
+
+fn extract_macro_generated_scenario_name(macro_name: &str, body: &str) -> Option<String> {
+    let arguments = split_top_level_arguments(body);
+    if arguments.is_empty() {
+        return None;
+    }
+
+    match macro_name {
+        "matched" => extract_matched_macro_case_name(&arguments),
+        _ => extract_identifier_argument(arguments[0]),
+    }
+}
+
+fn extract_matched_macro_case_name(arguments: &[&str]) -> Option<String> {
+    match arguments {
+        [first, second, ..] if first.trim() == "not" => extract_identifier_argument(second),
+        [first, ..] => extract_identifier_argument(first),
+        [] => None,
+    }
+}
+
+fn extract_identifier_argument(argument: &str) -> Option<String> {
+    let trimmed = argument.trim();
+    is_rust_identifier(trimmed).then(|| trimmed.to_string())
 }
 
 pub(crate) fn collect_rust_proptest_scenarios(
@@ -201,29 +226,6 @@ fn extract_rust_macro_invocation_name(raw_invocation: &str) -> Option<&str> {
     (!name.is_empty()).then_some(name)
 }
 
-fn extract_first_identifier_token(raw: &str) -> Option<String> {
-    let mut chars = raw.char_indices().peekable();
-
-    while let Some((start, ch)) = chars.next() {
-        if !is_rust_identifier_start(ch) {
-            continue;
-        }
-
-        let mut end = start + ch.len_utf8();
-        while let Some((idx, next)) = chars.peek().copied() {
-            if !is_rust_identifier_continue(next) {
-                break;
-            }
-            end = idx + next.len_utf8();
-            chars.next();
-        }
-
-        return Some(raw[start..end].to_string());
-    }
-
-    None
-}
-
 fn extract_callable_symbols_from_rust_text(raw: &str) -> HashSet<String> {
     let mut symbols = HashSet::new();
     let chars: Vec<char> = raw.chars().collect();
@@ -279,6 +281,11 @@ fn is_rust_identifier_start(ch: char) -> bool {
 
 fn is_rust_identifier_continue(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+fn is_rust_identifier(raw: &str) -> bool {
+    raw.chars().next().is_some_and(is_rust_identifier_start)
+        && raw.chars().all(is_rust_identifier_continue)
 }
 
 fn is_rust_non_callable_token(token: &str) -> bool {

--- a/bitloops/src/adapters/languages/rust/test_support/scenarios.rs
+++ b/bitloops/src/adapters/languages/rust/test_support/scenarios.rs
@@ -136,12 +136,64 @@ fn collect_rust_test_scenarios(
     ));
     scenarios.extend(collect_rust_proptest_scenarios(root, source, relative_path));
     scenarios.extend(collect_rust_doctest_scenarios(root, source, relative_path));
+    scenarios = canonicalize_rust_discovered_scenarios(scenarios);
     scenarios.sort_by(|a, b| {
         a.suite_start_line
             .cmp(&b.suite_start_line)
             .then(a.scenario.start_line.cmp(&b.scenario.start_line))
+            .then(a.scenario.name.cmp(&b.scenario.name))
     });
     scenarios
+}
+
+fn canonicalize_rust_discovered_scenarios(
+    scenarios: Vec<RustDiscoveredScenario>,
+) -> Vec<RustDiscoveredScenario> {
+    let mut merged: Vec<RustDiscoveredScenario> = Vec::new();
+    let mut index_by_identity: std::collections::HashMap<(String, String, String), usize> =
+        std::collections::HashMap::new();
+
+    for scenario in scenarios {
+        let key = (
+            scenario.suite_name.clone(),
+            scenario.scenario.name.clone(),
+            scenario.scenario.discovery_source.as_str().to_string(),
+        );
+
+        if let Some(existing_index) = index_by_identity.get(&key).copied() {
+            let existing = &mut merged[existing_index];
+            existing.suite_start_line = existing.suite_start_line.min(scenario.suite_start_line);
+            existing.suite_end_line = existing.suite_end_line.max(scenario.suite_end_line);
+            existing.scenario.start_line = existing
+                .scenario
+                .start_line
+                .min(scenario.scenario.start_line);
+            existing.scenario.end_line = existing.scenario.end_line.max(scenario.scenario.end_line);
+            merge_reference_candidates(
+                &mut existing.scenario.reference_candidates,
+                scenario.scenario.reference_candidates,
+            );
+            continue;
+        }
+
+        index_by_identity.insert(key, merged.len());
+        merged.push(scenario);
+    }
+
+    merged
+}
+
+fn merge_reference_candidates(
+    target: &mut Vec<ReferenceCandidate>,
+    additional: Vec<ReferenceCandidate>,
+) {
+    let mut seen: std::collections::HashSet<ReferenceCandidate> = target.iter().cloned().collect();
+
+    for candidate in additional {
+        if seen.insert(candidate.clone()) {
+            target.push(candidate);
+        }
+    }
 }
 
 fn rust_test_scenarios_for_function(

--- a/bitloops/src/capability_packs/test_harness/mapping/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/mapping/tests.rs
@@ -1,6 +1,11 @@
+use std::collections::HashSet;
+use std::fs;
+use std::sync::Arc;
+
 use crate::adapters::languages::python::test_support::{
     collect_python_suites, resolve_python_import_to_repo_path,
 };
+use crate::adapters::languages::rust::test_support::RustTestMappingHelper;
 use crate::adapters::languages::rust::test_support::enumeration::parse_enumerated_doctests;
 use crate::adapters::languages::rust::test_support::imports::{
     collect_rust_import_paths_for, collect_rust_scoped_call_import_paths_for,
@@ -13,13 +18,18 @@ use crate::adapters::languages::ts_js::test_support::{
     collect_typescript_suites, extract_import_specifier, resolve_import_to_repo_path, unquote,
 };
 
+use tempfile::TempDir;
 use tree_sitter::Parser;
 use tree_sitter_python::LANGUAGE as LANGUAGE_PYTHON;
 use tree_sitter_rust::LANGUAGE as LANGUAGE_RUST;
 use tree_sitter_typescript::LANGUAGE_TYPESCRIPT;
 
+use super::execute;
 use super::linker::{imported_path_matches_production_path, symbol_match_key};
 use super::model::{ReferenceCandidate, ScenarioDiscoverySource};
+use crate::host::capability_host::gateways::LanguageServicesGateway;
+use crate::host::language_adapter::{DiscoveredTestFile, EnumerationResult, LanguageTestSupport};
+use crate::models::ProductionArtefact;
 
 #[test]
 fn extracts_import_specifier_from_statement() {
@@ -519,6 +529,93 @@ mod stable {
 }
 
 #[test]
+fn rust_suites_extract_matched_macro_case_names() {
+    let source = r#"
+macro_rules! matched {
+    ($kind:ident, $name:ident, $glob:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            assert_eq!(evaluate($glob), $expected);
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    matched!(not, matchnot1, "foo", true);
+    matched!(not, matchnot2, "bar", false);
+}
+"#;
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&LANGUAGE_RUST.into())
+        .expect("failed setting rust parser language");
+
+    let tree = parser
+        .parse(source, None)
+        .expect("failed parsing rust source");
+
+    let suites = collect_rust_suites(tree.root_node(), source, "crates/ignore/src/types.rs");
+    assert_eq!(suites.len(), 1, "expected one matched! suite");
+    assert_eq!(suites[0].name, "tests");
+
+    let scenario_names: Vec<&str> = suites[0]
+        .scenarios
+        .iter()
+        .map(|scenario| scenario.name.as_str())
+        .collect();
+    assert_eq!(scenario_names, vec!["matchnot1", "matchnot2"]);
+}
+
+#[test]
+fn rust_suites_canonicalize_cfg_mirrored_macro_generated_cases() {
+    let source = r#"
+macro_rules! slash_case {
+    ($name:ident, $glob:expr) => {
+        #[test]
+        fn $name() {
+            assert!(compile($glob));
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    slash_case!(matchslash2, "foo/bar");
+    #[cfg(not(unix))]
+    slash_case!(matchslash2, "foo\\bar");
+
+    #[cfg(unix)]
+    slash_case!(normal3, "foo/bar");
+    #[cfg(not(unix))]
+    slash_case!(normal3, "foo\\bar");
+}
+"#;
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&LANGUAGE_RUST.into())
+        .expect("failed setting rust parser language");
+
+    let tree = parser
+        .parse(source, None)
+        .expect("failed parsing rust source");
+
+    let suites = collect_rust_suites(tree.root_node(), source, "crates/globset/src/glob.rs");
+    assert_eq!(suites.len(), 1, "expected one slash-case suite");
+    assert_eq!(suites[0].name, "tests");
+
+    let scenario_names: Vec<&str> = suites[0]
+        .scenarios
+        .iter()
+        .map(|scenario| scenario.name.as_str())
+        .collect();
+    assert_eq!(scenario_names, vec!["matchslash2", "normal3"]);
+}
+
+#[test]
 fn rust_suites_expand_rstest_cases_values_and_templates() {
     let source = r#"
 #[cfg(test)]
@@ -813,4 +910,182 @@ describe("outer", () => {
         "expected exactly one inner scenario"
     );
     assert_eq!(inner.scenarios[0].name, "inner test");
+}
+
+#[test]
+fn rust_mapping_canonicalizes_duplicate_macro_generated_scenarios() {
+    let temp = TempDir::new().expect("failed creating temp repo");
+    let repo_root = temp.path();
+
+    fs::create_dir_all(repo_root.join("tests")).expect("failed creating tests directory");
+    fs::create_dir_all(repo_root.join("src")).expect("failed creating src directory");
+    fs::write(
+        repo_root.join("tests/macro_cases.rs"),
+        r#"
+macro_rules! matched {
+    ($kind:ident, $name:ident, $glob:expr, $expected:expr) => {
+        #[test]
+        fn $name() {
+            assert_eq!(evaluate($glob), $expected);
+        }
+    };
+}
+
+macro_rules! slash_case {
+    ($name:ident, $glob:expr) => {
+        #[test]
+        fn $name() {
+            assert!(compile($glob));
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn direct_case() {
+        assert!(compile("baz"));
+    }
+
+    matched!(not, matchnot1, "foo", true);
+    matched!(not, matchnot2, "bar", false);
+
+    #[cfg(unix)]
+    slash_case!(matchslash2, "foo/bar");
+    #[cfg(not(unix))]
+    slash_case!(matchslash2, "foo\\bar");
+
+    #[cfg(unix)]
+    slash_case!(normal3, "foo/bar");
+    #[cfg(not(unix))]
+    slash_case!(normal3, "foo\\bar");
+}
+"#,
+    )
+    .expect("failed writing rust test fixture");
+    fs::write(
+        repo_root.join("src/lib.rs"),
+        r#"
+pub fn compile(value: &str) -> bool {
+    !value.is_empty()
+}
+
+pub fn evaluate(value: &str) -> bool {
+    !value.is_empty()
+}
+"#,
+    )
+    .expect("failed writing rust source fixture");
+
+    let gateway = SourceOnlyLanguageServicesGateway {
+        support: Arc::new(SourceOnlyRustSupport),
+    };
+    let output = execute(
+        "repo-1",
+        repo_root,
+        "commit-1",
+        &[
+            ProductionArtefact {
+                artefact_id: "prod-compile".to_string(),
+                symbol_id: "prod-compile-symbol".to_string(),
+                symbol_fqn: "compile".to_string(),
+                path: "src/lib.rs".to_string(),
+                start_line: 1,
+            },
+            ProductionArtefact {
+                artefact_id: "prod-evaluate".to_string(),
+                symbol_id: "prod-evaluate-symbol".to_string(),
+                symbol_fqn: "evaluate".to_string(),
+                path: "src/lib.rs".to_string(),
+                start_line: 5,
+            },
+        ],
+        &gateway,
+    )
+    .expect("mapping execution should succeed");
+
+    let mut scenario_names: Vec<&str> = output
+        .test_artefacts
+        .iter()
+        .filter(|artefact| artefact.canonical_kind == "test_scenario")
+        .map(|artefact| artefact.name.as_str())
+        .collect();
+    scenario_names.sort_unstable();
+    assert_eq!(
+        scenario_names,
+        vec![
+            "direct_case",
+            "matchnot1",
+            "matchnot2",
+            "matchslash2",
+            "normal3"
+        ]
+    );
+
+    let scenario_artefacts: Vec<_> = output
+        .test_artefacts
+        .iter()
+        .filter(|artefact| artefact.canonical_kind == "test_scenario")
+        .collect();
+    let artefact_ids: HashSet<&str> = scenario_artefacts
+        .iter()
+        .map(|artefact| artefact.artefact_id.as_str())
+        .collect();
+    assert_eq!(artefact_ids.len(), scenario_artefacts.len());
+
+    let symbol_ids: HashSet<&str> = scenario_artefacts
+        .iter()
+        .map(|artefact| artefact.symbol_id.as_str())
+        .collect();
+    assert_eq!(symbol_ids.len(), scenario_artefacts.len());
+
+    assert!(
+        output
+            .test_edges
+            .iter()
+            .any(|edge| edge.to_symbol_id.as_deref() == Some("prod-compile-symbol")),
+        "expected at least one static link to the compile production artefact"
+    );
+}
+
+struct SourceOnlyLanguageServicesGateway {
+    support: Arc<dyn LanguageTestSupport>,
+}
+
+impl LanguageServicesGateway for SourceOnlyLanguageServicesGateway {
+    fn test_supports(&self) -> Vec<Arc<dyn LanguageTestSupport>> {
+        vec![self.support.clone()]
+    }
+}
+
+struct SourceOnlyRustSupport;
+
+impl LanguageTestSupport for SourceOnlyRustSupport {
+    fn language_id(&self) -> &'static str {
+        "rust"
+    }
+
+    fn priority(&self) -> u8 {
+        0
+    }
+
+    fn supports_path(&self, absolute_path: &std::path::Path, relative_path: &str) -> bool {
+        RustTestMappingHelper::supports_path(absolute_path, relative_path)
+    }
+
+    fn discover_tests(
+        &self,
+        absolute_path: &std::path::Path,
+        relative_path: &str,
+    ) -> anyhow::Result<DiscoveredTestFile> {
+        let mut helper = RustTestMappingHelper::new()?;
+        helper.discover_tests(absolute_path, relative_path)
+    }
+
+    fn enumerate_tests(
+        &self,
+        _ctx: &crate::host::language_adapter::LanguageAdapterContext,
+    ) -> EnumerationResult {
+        EnumerationResult::default()
+    }
 }


### PR DESCRIPTION
## Summary
- fix Rust macro-generated scenario name extraction for cases like `matched!(not, matchnot1, ...)`
- canonicalize duplicate source-discovered macro scenarios from cfg-mirrored Rust tests and merge their reference candidates
- add regression coverage for matched-macro parsing, cfg-mirrored dedupe, and mapping-level duplicate-ID prevention

## Why
Rust current-state `test_harness` could emit duplicate test artefact IDs for macro-generated scenarios. That broke materialization before persistence in repos like `burntsushi/ripgrep` and caused static-linkage validation to fail.

## Test Plan
- `cargo test -p bitloops rust_suites_extract_matched_macro_case_names`
- `cargo test -p bitloops rust_suites_canonicalize_cfg_mirrored_macro_generated_cases`
- `cargo test -p bitloops rust_mapping_canonicalizes_duplicate_macro_generated_scenarios`
