### PR TITLE
Restore Codex transcript persistence and offsets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Check Rust file size limits
         run: cargo dev-file-size
   qat:
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: taiki-e/install-action@nextest
 
       - name: Compile test targets
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Check Rust file size limits
         run: cargo dev-file-size
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt
       - name: cargo fmt
@@ -57,7 +57,7 @@ jobs:
       DUCKDB_DOWNLOAD_LIB: '0'
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
@@ -90,7 +90,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
@@ -106,7 +106,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/develop-coverage-baseline.yml
+++ b/.github/workflows/develop-coverage-baseline.yml
@@ -25,7 +25,7 @@ jobs:
       BITLOOPS_ACTIONS_VARIABLES_TOKEN: ${{ secrets.BITLOOPS_ACTIONS_VARIABLES_TOKEN }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/develop-qat.yml
+++ b/.github/workflows/develop-qat.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Codex interaction and checkpoint persistence now survive missing `Stop.transcriptPath` payloads**: the lifecycle-routed Codex hook path now resolves real Codex rollout transcripts from saved pre-prompt/session state and the date-sharded `~/.codex/sessions` store before failing turn-end capture. This restores persistence of `interaction_sessions`, `interaction_turns`, `interaction_events`, and checkpoint save-step data for Codex sessions, keeps later turns scoped to their new transcript fragment instead of replaying from offset `0`, and teaches transcript metadata extraction to read real Codex `response_item` payloads for prompt and summary capture.
+
 ## [0.0.15] - 2026-04-16
 
 ### Added

--- a/bitloops/src/adapters/agents/canonical/progress.rs
+++ b/bitloops/src/adapters/agents/canonical/progress.rs
@@ -47,12 +47,10 @@ impl CanonicalProgressUpdate {
     pub fn with_counts(mut self, completed: u64, total: u64) -> Self {
         self.completed = Some(completed);
         self.total = Some(total);
-        self.percentage = if total == 0 {
-            None
-        } else {
-            let percentage = completed.saturating_mul(100) / total;
-            Some(percentage.min(100) as u8)
-        };
+        self.percentage = completed
+            .saturating_mul(100)
+            .checked_div(total)
+            .map(|percentage| percentage.min(100) as u8);
         self
     }
 

--- a/bitloops/src/adapters/agents/codex/agent.rs
+++ b/bitloops/src/adapters/agents/codex/agent.rs
@@ -3,10 +3,18 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use anyhow::{Result, anyhow};
+use serde::Deserialize;
+use walkdir::WalkDir;
 
 use crate::adapters::agents::{
     AGENT_NAME_CODEX, AGENT_TYPE_CODEX, Agent, AgentSession, Event, HookInput, HookSupport,
-    chunk_jsonl, reassemble_jsonl,
+    TranscriptAnalyzer, chunk_jsonl, reassemble_jsonl,
+};
+use crate::host::checkpoints::transcript::metadata::{
+    extract_prompts_from_transcript_bytes, extract_summary_from_transcript_bytes,
+};
+use crate::host::interactions::transcript_fragment::{
+    transcript_fragment_from_bytes, transcript_position_from_bytes,
 };
 
 use super::hooks;
@@ -15,9 +23,104 @@ use super::lifecycle;
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CodexAgent;
 
+#[derive(Debug, Deserialize)]
+struct CodexSessionIndexEntry {
+    id: String,
+    updated_at: String,
+}
+
 impl CodexAgent {
     pub(crate) fn detect_presence_at(&self, repo_root: &Path) -> bool {
         repo_root.join(".codex").is_dir() || repo_root.join(".codex/hooks.json").exists()
+    }
+
+    fn session_home_from_override_or_home(
+        override_path: Option<&str>,
+        home_dir: Option<&Path>,
+    ) -> Result<PathBuf> {
+        if let Some(override_path) = override_path
+            && !override_path.is_empty()
+        {
+            return Ok(PathBuf::from(override_path));
+        }
+
+        let home_dir = home_dir.ok_or_else(|| anyhow!("failed to get home directory"))?;
+        Ok(home_dir.join(".codex").join("sessions"))
+    }
+
+    fn session_index_path(session_dir: &str) -> Option<PathBuf> {
+        let session_dir = Path::new(session_dir);
+        session_dir
+            .parent()
+            .map(|parent| parent.join("session_index.jsonl"))
+    }
+
+    fn narrow_search_dir_from_session_index(
+        session_dir: &str,
+        agent_session_id: &str,
+    ) -> Option<PathBuf> {
+        let index_path = Self::session_index_path(session_dir)?;
+        let raw = std::fs::read_to_string(index_path).ok()?;
+        let latest = raw
+            .lines()
+            .filter_map(|line| serde_json::from_str::<CodexSessionIndexEntry>(line).ok())
+            .rev()
+            .find(|entry| entry.id == agent_session_id)?;
+        let date = latest.updated_at.get(..10)?;
+        let mut parts = date.split('-');
+        let year = parts.next()?;
+        let month = parts.next()?;
+        let day = parts.next()?;
+        Some(Path::new(session_dir).join(year).join(month).join(day))
+    }
+
+    fn is_matching_session_file(path: &Path, agent_session_id: &str) -> bool {
+        let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+            return false;
+        };
+
+        file_name == format!("{agent_session_id}.jsonl")
+            || file_name == format!("rollout-{agent_session_id}.jsonl")
+            || file_name.ends_with(&format!("-{agent_session_id}.jsonl"))
+    }
+
+    fn newest_matching_rollout(search_root: &Path, agent_session_id: &str) -> Option<PathBuf> {
+        if !search_root.exists() {
+            return None;
+        }
+
+        WalkDir::new(search_root)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_type().is_file())
+            .filter(|entry| Self::is_matching_session_file(entry.path(), agent_session_id))
+            .max_by_key(|entry| {
+                entry
+                    .metadata()
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok())
+                    .unwrap_or(SystemTime::UNIX_EPOCH)
+            })
+            .map(|entry| entry.into_path())
+    }
+
+    fn read_transcript_position(path: &str) -> Result<usize> {
+        if path.is_empty() {
+            return Ok(0);
+        }
+
+        let data = match std::fs::read(path) {
+            Ok(data) => data,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(err) => return Err(anyhow!("failed to read transcript: {err}")),
+        };
+
+        if data.is_empty() {
+            return Ok(0);
+        }
+
+        Ok(transcript_position_from_bytes(&data))
     }
 }
 
@@ -90,11 +193,42 @@ impl Agent for CodexAgent {
         Ok(reassemble_jsonl(chunks))
     }
 
+    fn get_session_dir(&self, _repo_path: &str) -> Result<String> {
+        Self::session_home_from_override_or_home(
+            std::env::var("BITLOOPS_TEST_CODEX_SESSION_DIR")
+                .ok()
+                .as_deref(),
+            std::env::var_os("HOME")
+                .or_else(|| std::env::var_os("USERPROFILE"))
+                .as_deref()
+                .map(Path::new),
+        )
+        .map(|path| path.to_string_lossy().to_string())
+    }
+
     fn resolve_session_file(&self, session_dir: &str, agent_session_id: &str) -> String {
-        Path::new(session_dir)
-            .join(format!("{agent_session_id}.jsonl"))
-            .to_string_lossy()
-            .to_string()
+        if agent_session_id.trim().is_empty() {
+            return String::new();
+        }
+
+        let session_root = Path::new(session_dir);
+        let flat_path = session_root.join(format!("{agent_session_id}.jsonl"));
+        if flat_path.is_file() {
+            return flat_path.to_string_lossy().to_string();
+        }
+
+        if let Some(day_dir) =
+            Self::narrow_search_dir_from_session_index(session_dir, agent_session_id)
+            && let Some(path) = Self::newest_matching_rollout(&day_dir, agent_session_id)
+        {
+            return path.to_string_lossy().to_string();
+        }
+
+        if let Some(path) = Self::newest_matching_rollout(session_root, agent_session_id) {
+            return path.to_string_lossy().to_string();
+        }
+
+        flat_path.to_string_lossy().to_string()
     }
 
     fn read_session(&self, input: &HookInput) -> Result<Option<AgentSession>> {
@@ -139,6 +273,42 @@ impl Agent for CodexAgent {
         } else {
             format!("codex --resume {session_id}")
         }
+    }
+}
+
+impl TranscriptAnalyzer for CodexAgent {
+    fn get_transcript_position(&self, path: &str) -> Result<usize> {
+        Self::read_transcript_position(path)
+    }
+
+    fn extract_modified_files_from_offset(
+        &self,
+        path: &str,
+        _start_offset: usize,
+    ) -> Result<(Vec<String>, usize)> {
+        Ok((Vec::new(), Self::read_transcript_position(path)?))
+    }
+
+    fn extract_prompts(&self, session_ref: &str, from_offset: usize) -> Result<Vec<String>> {
+        let data = match std::fs::read(session_ref) {
+            Ok(data) => data,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(anyhow!("failed to read transcript: {err}")),
+        };
+
+        let end_offset = transcript_position_from_bytes(&data);
+        let fragment = transcript_fragment_from_bytes(&data, from_offset, end_offset);
+        Ok(extract_prompts_from_transcript_bytes(fragment.as_bytes()))
+    }
+
+    fn extract_summary(&self, session_ref: &str) -> Result<String> {
+        let data = match std::fs::read(session_ref) {
+            Ok(data) => data,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
+            Err(err) => return Err(anyhow!("failed to read transcript: {err}")),
+        };
+
+        Ok(extract_summary_from_transcript_bytes(&data))
     }
 }
 

--- a/bitloops/src/adapters/agents/codex/agent_tests.rs
+++ b/bitloops/src/adapters/agents/codex/agent_tests.rs
@@ -4,6 +4,7 @@ use crate::host::checkpoints::lifecycle::adapters::{
     CODEX_HOOK_POST_TOOL_USE, CODEX_HOOK_PRE_TOOL_USE, CODEX_HOOK_SESSION_START, CODEX_HOOK_STOP,
     CODEX_HOOK_USER_PROMPT_SUBMIT,
 };
+use crate::test_support::process_state::with_env_var;
 
 fn init_repo(path: &std::path::Path) {
     let output = std::process::Command::new("git")
@@ -83,4 +84,40 @@ fn path_based_hooks_api_manages_hooks_without_cwd() {
 
     super::hooks::uninstall_hooks_at(dir.path()).expect("uninstall");
     assert!(!super::hooks::are_hooks_installed_at(dir.path()));
+}
+
+#[test]
+fn get_session_dir_uses_override() {
+    let agent = CodexAgent;
+    with_env_var(
+        "BITLOOPS_TEST_CODEX_SESSION_DIR",
+        Some("/tmp/codex-sessions"),
+        || {
+            let got = agent.get_session_dir("").expect("session dir");
+            assert_eq!(got, "/tmp/codex-sessions");
+        },
+    );
+}
+
+#[test]
+fn resolve_session_file_prefers_date_sharded_rollout() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let sessions_dir = root.path().join("sessions");
+    let day_dir = sessions_dir.join("2026").join("04").join("16");
+    std::fs::create_dir_all(&day_dir).expect("create session dir");
+
+    let session_id = "019d9664-2636-79c0-9658-f76bfb8af4b4";
+    let transcript_path = day_dir.join(format!("rollout-2026-04-16T16-03-59-{session_id}.jsonl"));
+    std::fs::write(&transcript_path, "{}\n").expect("write transcript");
+    std::fs::write(
+        root.path().join("session_index.jsonl"),
+        format!(
+            r#"{{"id":"{session_id}","thread_name":"Investigate checkpoint loss","updated_at":"2026-04-16T13:04:37.997446Z"}}"#
+        ),
+    )
+    .expect("write session index");
+
+    let agent = CodexAgent;
+    let resolved = agent.resolve_session_file(sessions_dir.to_string_lossy().as_ref(), session_id);
+    assert_eq!(resolved, transcript_path.to_string_lossy().to_string());
 }

--- a/bitloops/src/adapters/agents/codex/lifecycle.rs
+++ b/bitloops/src/adapters/agents/codex/lifecycle.rs
@@ -1,11 +1,15 @@
 use std::io::Read;
+use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use crate::adapters::agents::Agent;
 use crate::host::checkpoints::lifecycle::{
     LifecycleEvent, LifecycleEventType, SessionIdPolicy, apply_session_id_policy,
 };
+use crate::host::checkpoints::session::create_session_backend_or_local;
 
+use super::agent::CodexAgent;
 use super::types::{
     CodexSessionInfoRaw, CodexToolHookRaw, CodexUserPromptSubmitRaw, parse_codex_session_info,
     parse_codex_tool_hook, parse_codex_user_prompt_submit,
@@ -21,26 +25,64 @@ pub const HOOK_NAME_POST_TOOL_USE: &str =
     crate::host::checkpoints::lifecycle::adapters::CODEX_HOOK_POST_TOOL_USE;
 pub const HOOK_NAME_STOP: &str = crate::host::checkpoints::lifecycle::adapters::CODEX_HOOK_STOP;
 
+pub fn resolve_transcript_ref(session_id: &str, raw_path: Option<&str>) -> String {
+    if let Some(path) = raw_path
+        && !path.trim().is_empty()
+    {
+        return path.to_string();
+    }
+
+    let session_id = session_id.trim();
+    if session_id.is_empty()
+        || session_id == crate::host::checkpoints::lifecycle::UNKNOWN_SESSION_ID
+    {
+        return String::new();
+    }
+
+    if let Some(path) = resolve_transcript_ref_from_state(session_id) {
+        return path;
+    }
+
+    let repo_root = crate::utils::paths::repo_root().ok();
+    let repo_path = repo_root
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let agent = CodexAgent;
+    let Ok(session_dir) = agent.get_session_dir(&repo_path) else {
+        return String::new();
+    };
+    let resolved = agent.resolve_session_file(&session_dir, session_id);
+    if Path::new(&resolved).is_file() {
+        return resolved;
+    }
+
+    String::new()
+}
+
 pub fn parse_hook_event(hook_name: &str, stdin: &mut dyn Read) -> Result<Option<LifecycleEvent>> {
     match hook_name {
         HOOK_NAME_SESSION_START => {
             let raw = parse_session_info_input(stdin)?;
+            let session_id = apply_session_id_policy(&raw.session_id, SessionIdPolicy::Strict)
+                .context("codex session-start requires non-empty session_id")?;
             Ok(Some(LifecycleEvent {
                 event_type: Some(LifecycleEventType::SessionStart),
-                session_id: apply_session_id_policy(&raw.session_id, SessionIdPolicy::Strict)
-                    .context("codex session-start requires non-empty session_id")?,
-                session_ref: raw.transcript_path,
+                session_id: session_id.clone(),
+                session_ref: resolve_transcript_ref(&session_id, Some(&raw.transcript_path)),
                 model: raw.model,
                 ..LifecycleEvent::default()
             }))
         }
         HOOK_NAME_USER_PROMPT_SUBMIT => {
             let raw = parse_user_prompt_submit_input(stdin)?;
+            let session_id = apply_session_id_policy(&raw.session_id, SessionIdPolicy::Strict)
+                .context("codex user-prompt-submit requires non-empty session_id")?;
             Ok(Some(LifecycleEvent {
                 event_type: Some(LifecycleEventType::TurnStart),
-                session_id: apply_session_id_policy(&raw.session_id, SessionIdPolicy::Strict)
-                    .context("codex user-prompt-submit requires non-empty session_id")?,
-                session_ref: raw.transcript_path,
+                session_id: session_id.clone(),
+                session_ref: resolve_transcript_ref(&session_id, Some(&raw.transcript_path)),
                 prompt: raw.prompt,
                 model: raw.model,
                 ..LifecycleEvent::default()
@@ -52,13 +94,12 @@ pub fn parse_hook_event(hook_name: &str, stdin: &mut dyn Read) -> Result<Option<
         }
         HOOK_NAME_STOP => {
             let raw = parse_session_info_input(stdin)?;
+            let session_id =
+                apply_session_id_policy(&raw.session_id, SessionIdPolicy::FallbackUnknown)?;
             Ok(Some(LifecycleEvent {
                 event_type: Some(LifecycleEventType::TurnEnd),
-                session_id: apply_session_id_policy(
-                    &raw.session_id,
-                    SessionIdPolicy::FallbackUnknown,
-                )?,
-                session_ref: raw.transcript_path,
+                session_id: session_id.clone(),
+                session_ref: resolve_transcript_ref(&session_id, Some(&raw.transcript_path)),
                 model: raw.model,
                 ..LifecycleEvent::default()
             }))
@@ -89,6 +130,25 @@ fn parse_tool_hook_input(stdin: &mut dyn Read) -> Result<CodexToolHookRaw> {
         .read_to_string(&mut raw)
         .context("reading codex tool hook input")?;
     parse_codex_tool_hook(&raw)
+}
+
+fn resolve_transcript_ref_from_state(session_id: &str) -> Option<String> {
+    let repo_root = crate::utils::paths::repo_root().ok()?;
+    let backend = create_session_backend_or_local(&repo_root);
+
+    if let Ok(Some(pre_prompt)) = backend.load_pre_prompt(session_id)
+        && !pre_prompt.transcript_path.trim().is_empty()
+    {
+        return Some(pre_prompt.transcript_path);
+    }
+
+    if let Ok(Some(session)) = backend.load_session(session_id)
+        && !session.transcript_path.trim().is_empty()
+    {
+        return Some(session.transcript_path);
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/bitloops/src/adapters/agents/codex/lifecycle_tests.rs
+++ b/bitloops/src/adapters/agents/codex/lifecycle_tests.rs
@@ -1,5 +1,28 @@
 use super::*;
 use crate::host::checkpoints::lifecycle::LifecycleEventType;
+use crate::test_support::process_state::with_env_var;
+
+fn seed_date_sharded_codex_session(session_id: &str) -> (tempfile::TempDir, String, String) {
+    let root = tempfile::tempdir().expect("tempdir");
+    let sessions_dir = root.path().join("sessions");
+    let day_dir = sessions_dir.join("2026").join("04").join("16");
+    std::fs::create_dir_all(&day_dir).expect("create session dir");
+    let transcript_path = day_dir.join(format!("rollout-2026-04-16T16-03-59-{session_id}.jsonl"));
+    std::fs::write(&transcript_path, "{}\n").expect("write transcript");
+    std::fs::write(
+        root.path().join("session_index.jsonl"),
+        format!(
+            r#"{{"id":"{session_id}","thread_name":"Investigate checkpoint loss","updated_at":"2026-04-16T13:04:37.997446Z"}}"#
+        ),
+    )
+    .expect("write session index");
+
+    (
+        root,
+        sessions_dir.to_string_lossy().to_string(),
+        transcript_path.to_string_lossy().to_string(),
+    )
+}
 
 #[test]
 fn parse_unknown_hook_returns_none() {
@@ -23,6 +46,25 @@ fn parse_session_start_maps_session_start_event() {
 }
 
 #[test]
+fn parse_session_start_resolves_missing_transcript_path_from_date_sharded_store() {
+    let session_id = "019d9664-2636-79c0-9658-f76bfb8af4b4";
+    let (_root, session_dir, transcript_path) = seed_date_sharded_codex_session(session_id);
+
+    with_env_var(
+        "BITLOOPS_TEST_CODEX_SESSION_DIR",
+        Some(&session_dir),
+        || {
+            let mut input =
+                std::io::Cursor::new(format!(r#"{{"sessionId":"{session_id}"}}"#).into_bytes());
+            let parsed = parse_hook_event(HOOK_NAME_SESSION_START, &mut input)
+                .expect("parse")
+                .expect("event");
+            assert_eq!(parsed.session_ref, transcript_path);
+        },
+    );
+}
+
+#[test]
 fn parse_stop_maps_turn_end_event() {
     let mut input = std::io::Cursor::new(
         br#"{"sessionId":"codex-session-2","transcriptPath":"/tmp/codex-2.jsonl"}"#.as_slice(),
@@ -33,6 +75,25 @@ fn parse_stop_maps_turn_end_event() {
     assert_eq!(parsed.event_type, Some(LifecycleEventType::TurnEnd));
     assert_eq!(parsed.session_id, "codex-session-2");
     assert_eq!(parsed.session_ref, "/tmp/codex-2.jsonl");
+}
+
+#[test]
+fn parse_stop_resolves_missing_transcript_path_from_date_sharded_store() {
+    let session_id = "019d9664-2636-79c0-9658-f76bfb8af4b4";
+    let (_root, session_dir, transcript_path) = seed_date_sharded_codex_session(session_id);
+
+    with_env_var(
+        "BITLOOPS_TEST_CODEX_SESSION_DIR",
+        Some(&session_dir),
+        || {
+            let mut input =
+                std::io::Cursor::new(format!(r#"{{"sessionId":"{session_id}"}}"#).into_bytes());
+            let parsed = parse_hook_event(HOOK_NAME_STOP, &mut input)
+                .expect("parse")
+                .expect("event");
+            assert_eq!(parsed.session_ref, transcript_path);
+        },
+    );
 }
 
 #[test]
@@ -59,6 +120,27 @@ fn parse_user_prompt_submit_maps_turn_start_event() {
     assert_eq!(parsed.session_ref, "/tmp/codex-3.jsonl");
     assert_eq!(parsed.prompt, "Refactor tracked file");
     assert_eq!(parsed.model, "gpt-5.4-codex");
+}
+
+#[test]
+fn parse_user_prompt_submit_resolves_missing_transcript_path_from_date_sharded_store() {
+    let session_id = "019d9664-2636-79c0-9658-f76bfb8af4b4";
+    let (_root, session_dir, transcript_path) = seed_date_sharded_codex_session(session_id);
+
+    with_env_var(
+        "BITLOOPS_TEST_CODEX_SESSION_DIR",
+        Some(&session_dir),
+        || {
+            let mut input = std::io::Cursor::new(
+                format!(r#"{{"sessionId":"{session_id}","prompt":"Refactor tracked file"}}"#)
+                    .into_bytes(),
+            );
+            let parsed = parse_hook_event(HOOK_NAME_USER_PROMPT_SUBMIT, &mut input)
+                .expect("parse")
+                .expect("event");
+            assert_eq!(parsed.session_ref, transcript_path);
+        },
+    );
 }
 
 #[test]

--- a/bitloops/src/adapters/languages/go/extraction.rs
+++ b/bitloops/src/adapters/languages/go/extraction.rs
@@ -198,28 +198,26 @@ fn collect_go_nodes_recursive(
                 );
             }
         }
-        "const_spec" | "var_spec" => {
-            if is_module_scope(node) {
-                let language_kind = LanguageKind::go(
-                    GoKind::from_tree_sitter_kind(node.kind()).expect("validated go value kind"),
-                );
-                let mut cursor = node.walk();
-                for name_node in node.children_by_field_name("name", &mut cursor) {
-                    if let Some(name) = trimmed_node_text(name_node, content) {
-                        push_go_artefact(
-                            out,
-                            seen,
-                            node,
-                            content,
-                            GoArtefactDescriptor {
-                                language_kind,
-                                name: name.clone(),
-                                symbol_fqn: format!("{path}::{name}"),
-                                parent_symbol_fqn: None,
-                                modifiers: Vec::new(),
-                            },
-                        );
-                    }
+        "const_spec" | "var_spec" if is_module_scope(node) => {
+            let language_kind = LanguageKind::go(
+                GoKind::from_tree_sitter_kind(node.kind()).expect("validated go value kind"),
+            );
+            let mut cursor = node.walk();
+            for name_node in node.children_by_field_name("name", &mut cursor) {
+                if let Some(name) = trimmed_node_text(name_node, content) {
+                    push_go_artefact(
+                        out,
+                        seen,
+                        node,
+                        content,
+                        GoArtefactDescriptor {
+                            language_kind,
+                            name: name.clone(),
+                            symbol_fqn: format!("{path}::{name}"),
+                            parent_symbol_fqn: None,
+                            modifiers: Vec::new(),
+                        },
+                    );
                 }
             }
         }

--- a/bitloops/src/adapters/languages/python/test_support.rs
+++ b/bitloops/src/adapters/languages/python/test_support.rs
@@ -110,10 +110,8 @@ pub(crate) fn collect_python_suites(
     for child in root.named_children(&mut cursor) {
         let node = unwrap_python_definition(child);
         match node.kind() {
-            "function_definition" => {
-                if is_python_test_function(node, source) {
-                    module_scenarios.push(build_python_scenario(node, source));
-                }
+            "function_definition" if is_python_test_function(node, source) => {
+                module_scenarios.push(build_python_scenario(node, source));
             }
             "class_definition" => {
                 let scenarios = collect_python_class_scenarios(node, source);

--- a/bitloops/src/cli/agent_surfaces.rs
+++ b/bitloops/src/cli/agent_surfaces.rs
@@ -73,7 +73,7 @@ pub(crate) fn cleanup_project_agent_surfaces(
     for agent in configured_agents
         .iter()
         .cloned()
-        .chain(registry.installed_agents(project_root).into_iter())
+        .chain(registry.installed_agents(project_root))
     {
         if seen.insert(agent.clone()) {
             candidates.push(agent);

--- a/bitloops/src/cli/explain/branch.rs
+++ b/bitloops/src/cli/explain/branch.rs
@@ -67,7 +67,7 @@ pub fn get_associated_commits(
         }
     }
 
-    collected.sort_by(|a, b| b.0.cmp(&a.0));
+    collected.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     Ok(collected.into_iter().map(|(_, commit)| commit).collect())
 }
 
@@ -120,7 +120,7 @@ pub fn get_associated_commits_from_db(
         }
     }
 
-    collected.sort_by(|a, b| b.0.cmp(&a.0));
+    collected.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     Ok(collected.into_iter().map(|(_, commit)| commit).collect())
 }
 

--- a/bitloops/src/daemon/tasks/queue.rs
+++ b/bitloops/src/daemon/tasks/queue.rs
@@ -222,7 +222,7 @@ pub(super) fn next_runnable_task_indexes(state: &PersistedDevqlTaskQueueState) -
     }
 
     let mut selected = selected.into_values().collect::<Vec<_>>();
-    selected.sort_by(|(_, left), (_, right)| left.cmp(right));
+    selected.sort_by_key(|(_, key)| *key);
     selected.into_iter().map(|(index, _)| index).collect()
 }
 
@@ -311,7 +311,7 @@ pub(super) fn prune_terminal_tasks(tasks: &mut Vec<DevqlTaskRecord>) {
         })
         .cloned()
         .collect::<Vec<_>>();
-    terminal.sort_by(|left, right| right.updated_at_unix.cmp(&left.updated_at_unix));
+    terminal.sort_by_key(|task| std::cmp::Reverse(task.updated_at_unix));
     terminal.truncate(MAX_TERMINAL_TASKS);
 
     let terminal_ids = terminal

--- a/bitloops/src/host/checkpoints/lifecycle/adapters.rs
+++ b/bitloops/src/host/checkpoints/lifecycle/adapters.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::adapters::agents::AgentAdapterRegistry;
+use crate::adapters::agents::codex::agent::CodexAgent;
 use crate::adapters::agents::copilot::agent::CopilotCliAgent;
 use crate::adapters::agents::gemini::agent::GeminiCliAgent;
 use crate::adapters::agents::{TokenCalculator, TranscriptAnalyzer};
@@ -321,6 +322,7 @@ impl LifecycleAgentAdapter for OpenCodeLifecycleAdapter {
 }
 
 static COPILOT_AGENT_FOR_LIFECYCLE: CopilotCliAgent = CopilotCliAgent;
+static CODEX_AGENT_FOR_LIFECYCLE: CodexAgent = CodexAgent;
 
 #[derive(Default)]
 pub struct CopilotCliLifecycleAdapter;
@@ -431,6 +433,10 @@ impl LifecycleAgentAdapter for CodexLifecycleAdapter {
         } else {
             format!("codex --resume {session_id}")
         }
+    }
+
+    fn as_transcript_analyzer(&self) -> Option<&dyn TranscriptAnalyzer> {
+        Some(&CODEX_AGENT_FOR_LIFECYCLE)
     }
 }
 

--- a/bitloops/src/host/checkpoints/lifecycle/adapters_route_tests.rs
+++ b/bitloops/src/host/checkpoints/lifecycle/adapters_route_tests.rs
@@ -3,6 +3,7 @@ use crate::adapters::agents::{
     AGENT_NAME_CODEX, AGENT_NAME_COPILOT, AGENT_NAME_CURSOR, AGENT_NAME_GEMINI,
     AGENT_NAME_OPEN_CODE,
 };
+use crate::host::checkpoints::session::create_session_backend_or_local;
 use crate::host::interactions::db_store::interaction_spool_db_path;
 use crate::test_support::process_state::{git_command, with_process_state};
 use anyhow::Result;
@@ -61,6 +62,21 @@ fn assert_session_start_context_matches_builder(context: &str, agent_name: &str)
         );
     assert!(!augmentation.targeted);
     assert_eq!(context, augmentation.additional_context);
+}
+
+fn codex_response_item_line(role: &str, kind: &str, text: &str) -> String {
+    serde_json::json!({
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": role,
+            "content": [{
+                "type": kind,
+                "text": text,
+            }],
+        }
+    })
+    .to_string()
 }
 
 #[test]
@@ -221,6 +237,110 @@ fn route_codex_hooks_persist_interactions_to_event_db_when_relational_store_is_a
         assert_eq!(local_turn_count, 1);
         assert_eq!(local_event_count, 2);
         assert_eq!(queued_mutations, 0);
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn route_codex_stop_without_transcript_path_uses_saved_state_and_persists_checkpoint() -> Result<()>
+{
+    let repo = seed_repo();
+    let session_id = "codex-session-missing-stop-transcript";
+    let repo_id = crate::host::devql::resolve_repo_identity(repo.path())?.repo_id;
+    let transcript_path = repo.path().join("codex-rollout.jsonl");
+    let transcript_path_str = transcript_path.to_string_lossy().to_string();
+    std::fs::write(&transcript_path, "").expect("write transcript");
+
+    with_route_test_state(repo.path(), &[], || -> Result<()> {
+        let session_payload = serde_json::json!({
+            "session_id": session_id,
+            "transcript_path": transcript_path_str.clone(),
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_SESSION_START,
+            &session_payload,
+        )?;
+
+        let prompt_payload = serde_json::json!({
+            "sessionId": session_id,
+            "transcriptPath": transcript_path_str.clone(),
+            "prompt": "Refactor tracked.txt",
+            "model": "gpt-5.4-codex"
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_USER_PROMPT_SUBMIT,
+            &prompt_payload,
+        )?;
+
+        std::fs::write(
+            &transcript_path,
+            format!(
+                "{}\n{}\n",
+                codex_response_item_line("user", "input_text", "Refactor tracked.txt"),
+                codex_response_item_line("assistant", "output_text", "Updated tracked.txt"),
+            ),
+        )
+        .expect("write transcript payload");
+        std::fs::write(repo.path().join("tracked.txt"), "two\n").expect("modify tracked file");
+
+        let stop_payload = serde_json::json!({
+            "sessionId": session_id,
+            "transcriptPath": "",
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_STOP,
+            &stop_payload,
+        )?;
+
+        Ok(())
+    })?;
+
+    with_route_test_state(repo.path(), &[], || -> Result<()> {
+        let event_db_path = crate::config::resolve_store_backend_config_for_repo(repo.path())?
+            .events
+            .resolve_duckdb_db_path_for_repo(repo.path());
+        let duckdb = duckdb::Connection::open(&event_db_path).expect("open events duckdb");
+        let session_count: i64 = duckdb
+            .query_row(
+                "SELECT COUNT(*) FROM interaction_sessions WHERE repo_id = ?1 AND session_id = ?2",
+                duckdb::params![&repo_id, session_id],
+                |row| row.get(0),
+            )
+            .expect("count interaction sessions");
+        let turn_count: i64 = duckdb
+            .query_row(
+                "SELECT COUNT(*) FROM interaction_turns WHERE repo_id = ?1 AND session_id = ?2",
+                duckdb::params![&repo_id, session_id],
+                |row| row.get(0),
+            )
+            .expect("count interaction turns");
+        let event_count: i64 = duckdb
+            .query_row(
+                "SELECT COUNT(*) FROM interaction_events WHERE repo_id = ?1 AND session_id = ?2",
+                duckdb::params![&repo_id, session_id],
+                |row| row.get(0),
+            )
+            .expect("count interaction events");
+        assert_eq!(session_count, 1);
+        assert_eq!(turn_count, 1);
+        assert_eq!(event_count, 3);
+
+        let backend = create_session_backend_or_local(repo.path());
+        let session_state = backend
+            .load_session(session_id)?
+            .expect("session state should exist");
+        assert_eq!(session_state.pending.step_count, 1);
         Ok(())
     })?;
 

--- a/bitloops/src/host/checkpoints/lifecycle/lifecycle_tests.rs
+++ b/bitloops/src/host/checkpoints/lifecycle/lifecycle_tests.rs
@@ -108,6 +108,21 @@ fn latest_turn_end_payload(repo_root: &Path) -> serde_json::Value {
     serde_json::from_str(&payload).expect("parse turn_end payload")
 }
 
+fn codex_response_item_line(role: &str, kind: &str, text: &str) -> String {
+    serde_json::json!({
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": role,
+            "content": [{
+                "type": kind,
+                "text": text,
+            }],
+        }
+    })
+    .to_string()
+}
+
 #[test]
 fn test_apply_session_id_policy_strict_rejects_empty() {
     let err = apply_session_id_policy("  ", SessionIdPolicy::Strict).expect_err("expected error");
@@ -380,6 +395,9 @@ fn test_handle_lifecycle_turn_end_empty_transcript_ref() {
 
     let err = handle_lifecycle_turn_end(&adapter, &event).unwrap_err();
     assert!(err.to_string().contains("transcript file not specified"));
+    assert!(err.to_string().contains("hook payload transcript_path"));
+    assert!(err.to_string().contains("pre-prompt state"));
+    assert!(err.to_string().contains("session state"));
 }
 
 #[test]
@@ -461,6 +479,135 @@ fn test_handle_lifecycle_turn_end_persists_transcript_fragment() {
         assert_eq!(latest_session_model(dir.path()), "gemini-2.5-pro");
         assert_eq!(latest_turn_model(dir.path()), "gemini-2.5-pro");
     });
+}
+
+#[test]
+fn route_codex_second_turn_uses_transcript_offsets_for_fragment() -> anyhow::Result<()> {
+    let repo = tempfile::tempdir().expect("tempdir");
+    setup_git_repo(&repo);
+    let session_id = "codex-offset-session";
+    let transcript_path = repo.path().join("codex-rollout.jsonl");
+    std::fs::write(&transcript_path, "").expect("write transcript");
+
+    with_process_state(Some(repo.path()), &[], || -> anyhow::Result<()> {
+        let session_payload = serde_json::json!({
+            "sessionId": session_id,
+            "transcriptPath": transcript_path.to_string_lossy().to_string(),
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_SESSION_START,
+            &session_payload,
+        )?;
+
+        let turn_one_payload = serde_json::json!({
+            "sessionId": session_id,
+            "transcriptPath": transcript_path.to_string_lossy().to_string(),
+            "prompt": "Prompt 1",
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_USER_PROMPT_SUBMIT,
+            &turn_one_payload,
+        )?;
+        std::fs::write(
+            &transcript_path,
+            format!(
+                "{}\n{}\n{}\n",
+                serde_json::json!({
+                    "type": "session_meta",
+                    "payload": { "id": session_id }
+                }),
+                codex_response_item_line("user", "input_text", "Prompt 1"),
+                codex_response_item_line("assistant", "output_text", "Answer 1"),
+            ),
+        )
+        .expect("write first turn transcript");
+        std::fs::write(repo.path().join("tracked.txt"), "two\n").expect("modify tracked file");
+        let turn_one_stop = serde_json::json!({
+            "sessionId": session_id,
+            "transcriptPath": transcript_path.to_string_lossy().to_string(),
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_STOP,
+            &turn_one_stop,
+        )?;
+
+        let turn_two_payload = serde_json::json!({
+            "sessionId": session_id,
+            "transcriptPath": transcript_path.to_string_lossy().to_string(),
+            "prompt": "Prompt 2",
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_USER_PROMPT_SUBMIT,
+            &turn_two_payload,
+        )?;
+        std::fs::write(
+            &transcript_path,
+            format!(
+                "{}\n{}\n{}\n{}\n{}\n",
+                serde_json::json!({
+                    "type": "session_meta",
+                    "payload": { "id": session_id }
+                }),
+                codex_response_item_line("user", "input_text", "Prompt 1"),
+                codex_response_item_line("assistant", "output_text", "Answer 1"),
+                codex_response_item_line("user", "input_text", "Prompt 2"),
+                codex_response_item_line("assistant", "output_text", "Answer 2"),
+            ),
+        )
+        .expect("write second turn transcript");
+        std::fs::write(repo.path().join("tracked.txt"), "three\n").expect("modify tracked file");
+        let turn_two_stop = serde_json::json!({
+            "sessionId": session_id,
+            "transcriptPath": transcript_path.to_string_lossy().to_string(),
+        })
+        .to_string();
+        route_hook_command_to_lifecycle(
+            repo.path(),
+            AGENT_NAME_CODEX,
+            CODEX_HOOK_STOP,
+            &turn_two_stop,
+        )?;
+        Ok(())
+    })?;
+
+    with_process_state(Some(repo.path()), &[], || -> anyhow::Result<()> {
+        let conn = open_events_duckdb(repo.path());
+        let mut stmt = conn
+            .prepare(
+                "SELECT transcript_fragment FROM interaction_turns WHERE session_id = ?1 ORDER BY turn_number ASC",
+            )
+            .expect("prepare fragment query");
+        let fragments = stmt
+            .query_map([session_id], |row| row.get::<_, String>(0))
+            .expect("query fragments")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect fragments");
+        assert_eq!(fragments.len(), 2);
+        assert!(fragments[0].contains("Prompt 1"));
+        assert!(fragments[0].contains("Answer 1"));
+        assert!(!fragments[0].contains("Prompt 2"));
+        assert!(fragments[1].contains("Prompt 2"));
+        assert!(fragments[1].contains("Answer 2"));
+        assert!(
+            !fragments[1].contains("Prompt 1"),
+            "second turn fragment should exclude the first turn transcript"
+        );
+        Ok(())
+    })?;
+
+    Ok(())
 }
 
 // CLI-869

--- a/bitloops/src/host/checkpoints/lifecycle/turn_end.rs
+++ b/bitloops/src/host/checkpoints/lifecycle/turn_end.rs
@@ -35,37 +35,54 @@ pub fn handle_lifecycle_turn_end(
     agent: &dyn LifecycleAgentAdapter,
     event: &LifecycleEvent,
 ) -> Result<()> {
-    if !event.session_id.is_empty() {
-        let _canonical_request = build_phase3_canonical_request(agent.agent_name(), event)?;
-    }
-
-    if event.session_ref.is_empty() {
-        return Err(anyhow!("transcript file not specified"));
-    }
-
-    // Agents flush transcripts asynchronously; retry briefly before giving up.
-    let transcript_data = read_transcript_with_retry(&event.session_ref)?;
-
-    if crate::git::is_empty_repository()? {
-        return Err(anyhow!("empty repository"));
-    }
-
-    let repo_root = crate::utils::paths::repo_root()?;
     let session_id = apply_session_id_policy(&event.session_id, SessionIdPolicy::FallbackUnknown)?;
-
-    let transcript_ref_canon = Path::new(&event.session_ref)
-        .canonicalize()
-        .unwrap_or_else(|_| Path::new(&event.session_ref).to_path_buf());
-    let transcript_ref_str = transcript_ref_canon.to_string_lossy().to_string();
-
+    let repo_root = crate::utils::paths::repo_root()?;
     let backend = create_session_backend_or_local(&repo_root);
     let pre_prompt = backend.load_pre_prompt(&session_id).ok().flatten();
+    let session_before_capture = backend.load_session(&session_id).ok().flatten();
+    let (transcript_ref, attempted_sources) = resolve_turn_end_transcript_ref(
+        &event.session_ref,
+        pre_prompt
+            .as_ref()
+            .map(|state| state.transcript_path.as_str()),
+        session_before_capture
+            .as_ref()
+            .map(|state| state.transcript_path.as_str()),
+    );
+
+    if !event.session_id.is_empty() {
+        let mut resolved_event = event.clone();
+        resolved_event.session_ref = transcript_ref.clone();
+        let _canonical_request =
+            build_phase3_canonical_request(agent.agent_name(), &resolved_event)?;
+    }
+
     if event.source == PRE_PROMPT_SOURCE_CURSOR_SHELL
         && pre_prompt.as_ref().map(|state| state.source.as_str())
             != Some(PRE_PROMPT_SOURCE_CURSOR_SHELL)
     {
         return Ok(());
     }
+
+    if transcript_ref.is_empty() {
+        return Err(anyhow!(
+            "transcript file not specified (checked: {})",
+            attempted_sources.join(", ")
+        ));
+    }
+
+    // Agents flush transcripts asynchronously; retry briefly before giving up.
+    let transcript_data = read_transcript_with_retry(&transcript_ref)?;
+
+    if crate::git::is_empty_repository()? {
+        return Err(anyhow!("empty repository"));
+    }
+
+    let transcript_ref_canon = Path::new(&transcript_ref)
+        .canonicalize()
+        .unwrap_or_else(|_| Path::new(&transcript_ref).to_path_buf());
+    let transcript_ref_str = transcript_ref_canon.to_string_lossy().to_string();
+
     let lifecycle_pre = pre_prompt.as_ref().map(|p| PrePromptState {
         transcript_offset: p.transcript_offset as usize,
     });
@@ -115,7 +132,6 @@ pub fn handle_lifecycle_turn_end(
             .ok()
     });
 
-    let session_before_capture = backend.load_session(&session_id).ok().flatten();
     let turn_id = session_before_capture
         .as_ref()
         .map(|state| state.turn_id.clone())
@@ -131,7 +147,7 @@ pub fn handle_lifecycle_turn_end(
     let mut snapshot = SessionMetadataSnapshot::new(session_id.clone(), metadata.clone());
     snapshot.turn_id = turn_id.clone();
     snapshot.transcript_identifier = session_id.clone();
-    snapshot.transcript_path = event.session_ref.clone();
+    snapshot.transcript_path = transcript_ref.clone();
     runtime_store
         .save_session_metadata_snapshot(&snapshot)
         .context("saving lifecycle turn-end metadata snapshot")?;
@@ -143,7 +159,7 @@ pub fn handle_lifecycle_turn_end(
         deleted_files: rel_deleted,
         metadata: Some(metadata.clone()),
         commit_message,
-        transcript_path: event.session_ref.clone(),
+        transcript_path: transcript_ref.clone(),
         author_name: author.name,
         author_email: author.email,
         agent_type: agent.agent_name().to_string(),
@@ -205,7 +221,7 @@ pub fn handle_lifecycle_turn_end(
                 agent_type: ctx.agent_type.clone(),
                 model: model.clone(),
                 first_prompt: last_prompt.clone(),
-                transcript_path: event.session_ref.clone(),
+                transcript_path: transcript_ref.clone(),
                 worktree_path: repo_root.to_string_lossy().to_string(),
                 worktree_id: crate::utils::paths::get_worktree_id(&repo_root).unwrap_or_default(),
                 started_at: interaction_now.clone(),
@@ -298,6 +314,33 @@ pub fn handle_lifecycle_turn_end(
     let _ = backend.delete_pre_prompt(&session_id);
 
     Ok(())
+}
+
+fn resolve_turn_end_transcript_ref(
+    raw_path: &str,
+    pre_prompt_path: Option<&str>,
+    session_path: Option<&str>,
+) -> (String, Vec<&'static str>) {
+    let mut attempted_sources = vec!["hook payload transcript_path"];
+    if !raw_path.trim().is_empty() {
+        return (raw_path.to_string(), attempted_sources);
+    }
+
+    attempted_sources.push("pre-prompt state");
+    if let Some(path) = pre_prompt_path
+        && !path.trim().is_empty()
+    {
+        return (path.to_string(), attempted_sources);
+    }
+
+    attempted_sources.push("session state");
+    if let Some(path) = session_path
+        && !path.trim().is_empty()
+    {
+        return (path.to_string(), attempted_sources);
+    }
+
+    (String::new(), attempted_sources)
 }
 
 /// Reads the transcript file with a brief retry window to handle agents that

--- a/bitloops/src/host/checkpoints/summarize.rs
+++ b/bitloops/src/host/checkpoints/summarize.rs
@@ -395,15 +395,13 @@ fn extract_assistant_entries(line: &Line) -> Vec<Entry> {
     let mut entries = Vec::new();
     for block in msg.content {
         match block.r#type.as_str() {
-            CONTENT_TYPE_TEXT => {
-                if !block.text.is_empty() {
-                    entries.push(Entry {
-                        entry_type: EntryType::Assistant,
-                        content: block.text,
-                        tool_name: String::new(),
-                        tool_detail: String::new(),
-                    });
-                }
+            CONTENT_TYPE_TEXT if !block.text.is_empty() => {
+                entries.push(Entry {
+                    entry_type: EntryType::Assistant,
+                    content: block.text,
+                    tool_name: String::new(),
+                    tool_detail: String::new(),
+                });
             }
             CONTENT_TYPE_TOOL_USE => {
                 let input = serde_json::from_value::<ToolInput>(block.input)
@@ -464,15 +462,13 @@ fn build_condensed_transcript_from_gemini(content: &[u8]) -> Result<Vec<Entry>> 
 
     for message in transcript.messages {
         match message.message_type.as_str() {
-            "user" => {
-                if !message.content.is_empty() {
-                    entries.push(Entry {
-                        entry_type: EntryType::User,
-                        content: message.content,
-                        tool_name: String::new(),
-                        tool_detail: String::new(),
-                    });
-                }
+            "user" if !message.content.is_empty() => {
+                entries.push(Entry {
+                    entry_type: EntryType::User,
+                    content: message.content,
+                    tool_name: String::new(),
+                    tool_detail: String::new(),
+                });
             }
             "gemini" => {
                 if !message.content.is_empty() {
@@ -513,15 +509,13 @@ fn build_condensed_transcript_from_opencode(content: &[u8]) -> Vec<Entry> {
         };
 
         match message.role.as_str() {
-            "user" => {
-                if !message.content.is_empty() {
-                    entries.push(Entry {
-                        entry_type: EntryType::User,
-                        content: message.content,
-                        tool_name: String::new(),
-                        tool_detail: String::new(),
-                    });
-                }
+            "user" if !message.content.is_empty() => {
+                entries.push(Entry {
+                    entry_type: EntryType::User,
+                    content: message.content,
+                    tool_name: String::new(),
+                    tool_detail: String::new(),
+                });
             }
             "assistant" => {
                 if !message.content.is_empty() {

--- a/bitloops/src/host/checkpoints/transcript/metadata.rs
+++ b/bitloops/src/host/checkpoints/transcript/metadata.rs
@@ -175,17 +175,36 @@ pub fn extract_summary_from_jsonl(jsonl: &str) -> String {
 
 pub fn transcript_line_role(value: &serde_json::Value) -> Option<&str> {
     value
-        .get("message")
-        .and_then(|message| message.get("role"))
+        .get("payload")
+        .and_then(|payload| payload.get("type"))
+        .and_then(|kind| kind.as_str())
+        .filter(|kind| *kind == "message")
+        .and_then(|_| value.get("payload"))
+        .and_then(|payload| payload.get("role"))
         .and_then(|role| role.as_str())
+        .or_else(|| {
+            value
+                .get("message")
+                .and_then(|message| message.get("role"))
+                .and_then(|role| role.as_str())
+        })
         .or_else(|| value.get("role").and_then(|role| role.as_str()))
         .or_else(|| value.get("type").and_then(|kind| kind.as_str()))
 }
 
 pub fn transcript_line_content(value: &serde_json::Value) -> Option<&serde_json::Value> {
     let message_content = value
-        .get("message")
-        .and_then(|message| message.get("content"));
+        .get("payload")
+        .and_then(|payload| payload.get("type"))
+        .and_then(|kind| kind.as_str())
+        .filter(|kind| *kind == "message")
+        .and_then(|_| value.get("payload"))
+        .and_then(|payload| payload.get("content"))
+        .or_else(|| {
+            value
+                .get("message")
+                .and_then(|message| message.get("content"))
+        });
     if message_content.is_some() {
         return message_content;
     }
@@ -210,7 +229,11 @@ pub fn content_to_text(content: &serde_json::Value) -> String {
         serde_json::Value::Array(items) => items
             .iter()
             .filter_map(|item| {
-                if item.get("type").and_then(|kind| kind.as_str()) == Some("text") {
+                let item_type = item.get("type").and_then(|kind| kind.as_str());
+                if matches!(
+                    item_type,
+                    Some("text") | Some("input_text") | Some("output_text")
+                ) {
                     item.get("text")
                         .and_then(|text| text.as_str())
                         .map(str::to_owned)
@@ -326,5 +349,28 @@ mod tests {
         let jsonl = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"first summary"}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"final summary"},{"type":"tool_use","name":"Edit","input":{"file_path":"a.txt"}}]}}"#;
         assert_eq!(extract_summary_from_jsonl(jsonl), "final summary");
+    }
+
+    #[test]
+    fn extract_user_prompts_supports_codex_response_item_payloads() {
+        let jsonl = r#"{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"ignore developer"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Investigate checkpoint loss"}]}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Check the stop hook"}]}}
+"#;
+        assert_eq!(
+            extract_user_prompts_from_jsonl(jsonl),
+            vec![
+                "Investigate checkpoint loss".to_string(),
+                "Check the stop hook".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_summary_supports_codex_response_item_payloads() {
+        let jsonl = r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"First pass"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Final Codex summary"}]}}
+"#;
+        assert_eq!(extract_summary_from_jsonl(jsonl), "Final Codex summary");
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

This pull request significantly improves the robustness and correctness of Codex session persistence and transcript resolution in the face of missing or incomplete `transcriptPath` payloads. The Codex agent and lifecycle hooks now reliably reconstruct the correct transcript file paths by consulting saved state and the date-sharded session store, ensuring accurate event capture and continuity across session turns. Additional utility and test code has been added to validate these behaviors.

**Codex session persistence and transcript resolution improvements:**

* The Codex lifecycle hooks (`bitloops/src/adapters/agents/codex/lifecycle.rs`) now resolve transcript references by consulting saved pre-prompt/session state and searching the date-sharded `~/.codex/sessions` store if the incoming payload is missing or empty, restoring persistence of session and turn data and ensuring correct transcript scoping. [[1]](diffhunk://#diff-67bc05f95810df2033d1412ee7027647384d4a317fc91d03ca335918eee8b7d8R28-R85) [[2]](diffhunk://#diff-67bc05f95810df2033d1412ee7027647384d4a317fc91d03ca335918eee8b7d8R135-R153)
* The Codex agent (`bitloops/src/adapters/agents/codex/agent.rs`) implements robust logic to locate the correct session file, including searching date-sharded directories and using a session index, and exposes utility methods for session directory resolution and transcript analysis. [[1]](diffhunk://#diff-c91ee9ccd97e646b59b5e1546cc3fe930d54da7ac6b7fc5a9bee95865d8cf7fbR26-R124) [[2]](diffhunk://#diff-c91ee9ccd97e646b59b5e1546cc3fe930d54da7ac6b7fc5a9bee95865d8cf7fbR196-R231) [[3]](diffhunk://#diff-c91ee9ccd97e646b59b5e1546cc3fe930d54da7ac6b7fc5a9bee95865d8cf7fbR279-R314)
* New and updated tests verify that session and turn events correctly resolve transcript paths from the date-sharded store when not provided, and that session directory overrides work as intended. [[1]](diffhunk://#diff-03d85febb45f5df90ecfcb0d9bb1a6fb25c53da92f56bd54de6c1a77566d06ccR88-R123) [[2]](diffhunk://#diff-c14067c39df7133999054a02bd02b5ede85a9037ba30a777283c8594cf2a8f16R3-R25) [[3]](diffhunk://#diff-c14067c39df7133999054a02bd02b5ede85a9037ba30a777283c8594cf2a8f16R48-R66) [[4]](diffhunk://#diff-c14067c39df7133999054a02bd02b5ede85a9037ba30a777283c8594cf2a8f16R80-R98) [[5]](diffhunk://#diff-c14067c39df7133999054a02bd02b5ede85a9037ba30a777283c8594cf2a8f16R125-R145)

**General codebase enhancements:**

* The Codex agent is now registered as a static lifecycle adapter for improved integration. [[1]](diffhunk://#diff-3b26812c220fd50de6ca380232fc4b8b4355888fc0dee2644c58f089ada9017cR8) [[2]](diffhunk://#diff-3b26812c220fd50de6ca380232fc4b8b4355888fc0dee2644c58f089ada9017cR325)
* The changelog has been updated to document these fixes and improvements for Codex session persistence and checkpointing.

## Validation

- [X] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

