### PR TITLE
Prepare release v0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.0.16] - 2026-04-17
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitloops"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/bitloops/Cargo.toml
+++ b/bitloops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitloops"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2024"
 autotests = false
 


### PR DESCRIPTION
## Summary

This pull request updates the project version to `0.0.16` and documents this release in the `CHANGELOG.md` file.

Release version update:

* Updated the version in `bitloops/Cargo.toml` from `0.0.15` to `0.0.16`.

Documentation:

* Added a new section for version `0.0.16` with the release date in `CHANGELOG.md`.

