### PR TITLE
added skill command for outside sandbox execution

### DIFF
--- a/bitloops/src/host/hooks/augmentation/skill_content.rs
+++ b/bitloops/src/host/hooks/augmentation/skill_content.rs
@@ -19,4 +19,11 @@ mod tests {
         assert!(!body.starts_with("---"));
         assert!(body.contains("bitloops devql query"));
     }
+
+    #[test]
+    fn using_devql_skill_mentions_running_bitloops_devql_outside_sandbox() {
+        let body = using_devql_skill_body();
+        assert!(body.contains("outside the sandbox"));
+        assert!(body.contains("bitloops devql"));
+    }
 }

--- a/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
+++ b/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
@@ -34,6 +34,12 @@ stage `items(first: ...)`.
 3. Rerun with `artefacts(first: ...)` or the relevant stage `items(first: ...)`.
 4. Return the concrete rows. Summaries are optional follow-up, not substitutes.
 
+## Sandbox Execution
+
+- In sandboxed agent environments, run `bitloops devql ...` outside the sandbox by default.
+- These commands rely on Bitloops-managed daemon and runtime state under platform app directories, so they can fail inside a workspace-only sandbox even when DevQL is healthy.
+- If your platform requires approval or escalation for out-of-sandbox commands, request it immediately before running `bitloops devql ...`.
+
 ## Core Commands
 
 ```bash


### PR DESCRIPTION
## Summary

This PR updates the shared Bitloops `using-devql` guidance so sandboxed agents default to running `bitloops devql ...` outside the sandbox.

The motivation is that `bitloops devql` depends on Bitloops-managed daemon/runtime state under platform app directories, so sandboxed agent runs can fail before reaching the daemon even when DevQL itself is healthy. With this change, the guidance now tells agents to request approval/escalation immediately when needed instead of first failing on local runtime SQLite access.

Because this is the canonical DevQL skill, the updated guidance propagates to all managed agent surfaces that install or embed it.

## Changes

- Added a `Sandbox Execution` section to the canonical `using-devql` skill.
- Instructed sandboxed agents to run `bitloops devql ...` outside the sandbox by default.
- Clarified that agents should request approval/escalation immediately when the platform requires it.
- Added a regression test to lock in the new sandbox guidance in the shared skill body.

## Verification

- `cargo test using_devql_skill_mentions_running_bitloops_devql_outside_sandbox`
- `cargo test cursor_rule_content_uses_frontmatter_and_devql_body`


## Validation

- [ ] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

