### PR TITLE
Handle semantic backfill payload arrays in init stats

### DIFF
--- a/bitloops/src/cli/init/progress/progress_calc.rs
+++ b/bitloops/src/cli/init/progress/progress_calc.rs
@@ -212,7 +212,7 @@ pub(crate) fn lane_progress(
 
 pub(crate) fn lane_status_icon<'a>(status: &str, spinner: &'a str, tick: &'a str) -> &'a str {
     match status.to_ascii_lowercase().as_str() {
-        "completed" | "completed_with_warnings" | "warning" | "skipped" => tick,
+        "completed" | "completed_with_warnings" | "skipped" => tick,
         _ => spinner,
     }
 }
@@ -223,7 +223,7 @@ pub(crate) fn is_active_runtime_status(status: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_active_runtime_status, lane_progress};
+    use super::{is_active_runtime_status, lane_progress, lane_status_icon};
     use crate::cli::devql::graphql::{
         RuntimeInitLaneGraphqlRecord, RuntimeInitLaneProgressGraphqlRecord,
         RuntimeInitLaneQueueGraphqlRecord,
@@ -254,6 +254,11 @@ mod tests {
         assert!(is_active_runtime_status("running"));
         assert!(!is_active_runtime_status("completed"));
         assert!(!is_active_runtime_status("failed"));
+    }
+
+    #[test]
+    fn warning_lane_status_icon_uses_spinner() {
+        assert_eq!(lane_status_icon("warning", "spin", "tick"), "spin");
     }
 
     #[test]

--- a/bitloops/src/daemon/init_runtime/session_stats.rs
+++ b/bitloops/src/daemon/init_runtime/session_stats.rs
@@ -337,10 +337,7 @@ fn effective_session_summary_mailbox_item_count(
 
     match SemanticMailboxItemKind::parse(item_kind) {
         SemanticMailboxItemKind::RepoBackfill => {
-            let payload = parse_semantic_mailbox_payload_json(payload_json);
-            payload
-                .as_ref()
-                .and_then(payload_repo_backfill_artefact_ids)
+            semantic_mailbox_payload_artefact_ids(payload_json)
                 .map(|artefact_ids| {
                     summary_freshness.outstanding_work_item_count_for_artefacts(&artefact_ids)
                 })
@@ -355,10 +352,7 @@ fn effective_session_summary_mailbox_item_count(
 fn semantic_mailbox_item_work_item_count(item_kind: &str, payload_json: Option<&str>) -> u64 {
     match SemanticMailboxItemKind::parse(item_kind) {
         SemanticMailboxItemKind::RepoBackfill => {
-            let payload = parse_semantic_mailbox_payload_json(payload_json);
-            payload
-                .as_ref()
-                .and_then(payload_repo_backfill_artefact_ids)
+            semantic_mailbox_payload_artefact_ids(payload_json)
                 .map(|artefact_ids| artefact_ids.len() as u64)
                 .unwrap_or(1)
         }
@@ -368,6 +362,18 @@ fn semantic_mailbox_item_work_item_count(item_kind: &str, payload_json: Option<&
 
 fn parse_semantic_mailbox_payload_json(payload_json: Option<&str>) -> Option<serde_json::Value> {
     payload_json.and_then(|payload_json| serde_json::from_str(payload_json).ok())
+}
+
+fn semantic_mailbox_payload_artefact_ids(payload_json: Option<&str>) -> Option<Vec<String>> {
+    let payload = parse_semantic_mailbox_payload_json(payload_json)?;
+    if let Some(artefact_ids) = payload.as_array() {
+        let mut values = Vec::with_capacity(artefact_ids.len());
+        for artefact_id in artefact_ids {
+            values.push(artefact_id.as_str()?.to_string());
+        }
+        return Some(values);
+    }
+    payload_repo_backfill_artefact_ids(&payload)
 }
 
 fn load_summary_freshness_state_for_repo(

--- a/bitloops/src/daemon/init_runtime/tests.rs
+++ b/bitloops/src/daemon/init_runtime/tests.rs
@@ -268,6 +268,95 @@ fn semantic_inbox_rows_contribute_to_init_session_mailbox_counts() {
 }
 
 #[test]
+fn semantic_repo_backfill_inbox_rows_use_array_payload_sizes() {
+    let conn = Connection::open_in_memory().expect("open in-memory sqlite");
+    conn.execute_batch(
+        "CREATE TABLE semantic_summary_mailbox_items (
+             repo_id TEXT NOT NULL,
+             init_session_id TEXT,
+             status TEXT NOT NULL,
+             item_kind TEXT NOT NULL,
+             artefact_id TEXT,
+             payload_json TEXT
+         );
+         CREATE TABLE semantic_embedding_mailbox_items (
+             repo_id TEXT NOT NULL,
+             init_session_id TEXT,
+             representation_kind TEXT NOT NULL,
+             status TEXT NOT NULL,
+             item_kind TEXT NOT NULL,
+             payload_json TEXT
+         );",
+    )
+    .expect("create semantic inbox tables");
+    conn.execute(
+        "INSERT INTO semantic_summary_mailbox_items (
+             repo_id, init_session_id, status, item_kind, artefact_id, payload_json
+         ) VALUES (?1, ?2, 'failed', 'repo_backfill', NULL, ?3)",
+        (
+            "repo-1",
+            "init-session-1",
+            json!(["artefact-1", "artefact-2", "artefact-3"]).to_string(),
+        ),
+    )
+    .expect("insert failed summary inbox row");
+    conn.execute(
+        "INSERT INTO semantic_embedding_mailbox_items (
+             repo_id, init_session_id, representation_kind, status, item_kind, payload_json
+         ) VALUES (?1, ?2, 'code', 'pending', 'repo_backfill', ?3)",
+        (
+            "repo-1",
+            "init-session-1",
+            json!(["embed-1", "embed-2", "embed-3", "embed-4"]).to_string(),
+        ),
+    )
+    .expect("insert pending code embedding inbox row");
+    conn.execute(
+        "INSERT INTO semantic_embedding_mailbox_items (
+             repo_id, init_session_id, representation_kind, status, item_kind, payload_json
+         ) VALUES (?1, ?2, 'summary', 'leased', 'repo_backfill', ?3)",
+        (
+            "repo-1",
+            "init-session-1",
+            json!(["summary-1", "summary-2"]).to_string(),
+        ),
+    )
+    .expect("insert running summary embedding inbox row");
+
+    let freshness = SummaryFreshnessState {
+        eligible_artefact_ids: [
+            "artefact-1".to_string(),
+            "artefact-2".to_string(),
+            "artefact-3".to_string(),
+            "artefact-4".to_string(),
+        ]
+        .into_iter()
+        .collect(),
+        fresh_model_backed_artefact_ids: ["artefact-1".to_string()].into_iter().collect(),
+    };
+    let mut stats = SessionWorkplaneStats::default();
+
+    load_semantic_summary_session_mailbox_counts(
+        &conn,
+        &mut stats,
+        "repo-1",
+        "init-session-1",
+        &freshness,
+    )
+    .expect("load semantic summary mailbox counts");
+    load_semantic_embedding_session_mailbox_counts(&conn, &mut stats, "repo-1", "init-session-1")
+        .expect("load semantic embedding mailbox counts");
+    stats.refresh_lane_counts();
+
+    assert_eq!(stats.summary_refresh_jobs.counts.failed, 2);
+    assert_eq!(stats.code_embedding_jobs.counts.pending, 4);
+    assert_eq!(stats.summary_embedding_jobs.counts.running, 2);
+    assert_eq!(stats.summary_jobs.failed, 2);
+    assert_eq!(stats.embedding_jobs.pending, 4);
+    assert_eq!(stats.embedding_jobs.running, 2);
+}
+
+#[test]
 fn embeddings_completed_count_uses_queue_backlog_until_current_projection_catches_up() {
     let completed = derive_embeddings_completed_count(
         278,


### PR DESCRIPTION
## Summary

This pull request introduces improvements to how "repo_backfill" mailbox item payloads are handled in session statistics calculations, ensuring that array payloads are correctly interpreted as sets of artefact IDs. Additionally, it clarifies the logic for lane status icons and adds targeted tests to cover these changes.

**Enhancements to session statistics and payload parsing:**

* Refactored the handling of "repo_backfill" mailbox item payloads in `session_stats.rs` to use the new `semantic_mailbox_payload_artefact_ids` function, ensuring that array payloads are correctly interpreted as multiple artefact IDs, affecting both summary and work item count calculations. [[1]](diffhunk://#diff-baa294f7f843afc62c87166cc89fbf170cde6e089acc26b176044c5d4a97f7d4L340-R340) [[2]](diffhunk://#diff-baa294f7f843afc62c87166cc89fbf170cde6e089acc26b176044c5d4a97f7d4L358-R355)
* Added the `semantic_mailbox_payload_artefact_ids` function to extract artefact IDs from payload arrays or fallback to legacy parsing, improving robustness and correctness.

**Testing improvements:**

* Introduced a comprehensive test in `tests.rs` to verify that array payloads in "repo_backfill" inbox rows are correctly counted for summary and embedding jobs, ensuring accurate stats in multi-artefact scenarios.

**Lane status icon logic:**

* Updated the `lane_status_icon` function to treat "warning" status as using the spinner icon rather than the tick, clarifying UI feedback for warning states.
* Added a unit test to confirm that "warning" lane status uses the spinner icon as intended.

**Test code maintenance:**

* Included `lane_status_icon` in the test module imports to support the new test.

.

