### PR TITLE
Add fuzzy name support for artefact selection and enhance documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Slim `selectArtefacts` now supports typo-tolerant fuzzy artefact lookup by symbol name**: slim GraphQL requests can now select current artefacts with `by: { fuzzyName: "payLater()" }`, and the DevQL DSL now compiles `selectArtefacts(fuzzy_name:"payLater()")` to the same selector. The fuzzy matcher normalizes human-entered names from `symbol_fqn` leaf segments, preserves exact `symbolFqn` behaviour as an explicit selector, ranks matches best-first with exact/prefix/token/edit-distance signals, filters out weak matches below the fixed `0.6` threshold, and caps results at 10. The slim SDL snapshot, DevQL docs, and Bitloops-managed agent guidance/skill content now document the new selector mode.
+
 ## [0.0.17] - 2026-04-19
 
 ### Fixed

--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -91,6 +91,7 @@ type ArtefactSelection {
 
 input ArtefactSelectorInput {
 	symbolFqn: String
+	fuzzyName: String
 	path: String
 	lines: LineRangeInput
 }

--- a/bitloops/src/api/tests/devql_mutations_and_health.rs
+++ b/bitloops/src/api/tests/devql_mutations_and_health.rs
@@ -1683,6 +1683,55 @@ async fn slim_select_artefacts_resolves_project_scoped_relative_paths() {
 }
 
 #[tokio::test]
+async fn slim_select_artefacts_resolves_fuzzy_name_selection_in_project_scope() {
+    let repo = seed_graphql_monorepo_repo();
+    let schema = slim_schema_for_scope(repo.path(), Some("packages/api"));
+
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            {
+              selectArtefacts(by: { fuzzyName: "targte()" }) {
+                count
+                artefacts {
+                  path
+                  symbolFqn
+                }
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "graphql errors: {:?}",
+        response.errors
+    );
+
+    let json = response.data.into_json().expect("graphql data to json");
+    assert!(
+        json["selectArtefacts"]["count"]
+            .as_i64()
+            .unwrap_or_default()
+            >= 1
+    );
+    let artefacts = json["selectArtefacts"]["artefacts"]
+        .as_array()
+        .expect("artefacts array");
+    assert!(
+        artefacts
+            .iter()
+            .all(|artefact| artefact["path"] == "packages/api/src/target.ts"),
+        "unexpected fuzzy artefact paths: {artefacts:?}"
+    );
+    assert_eq!(
+        artefacts[0]["symbolFqn"],
+        "packages/api/src/target.ts::target"
+    );
+}
+
+#[tokio::test]
 async fn slim_select_artefacts_summary_aggregates_categories_and_deps_expose_items() {
     let repo = seed_graphql_monorepo_repo_with_duckdb_events();
     seed_graphql_clone_data(repo.path());

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -243,6 +243,7 @@ async fn devql_sdl_route_returns_schema_text() {
     assert!(body.contains("searchInteractionTurns(input: InteractionSearchInputObject!)"));
     assert!(body.contains("chatHistory"));
     assert!(body.contains("selectArtefacts(by: ArtefactSelectorInput!): ArtefactSelection!"));
+    assert!(body.contains("fuzzyName: String"));
     assert!(body.contains("asOf(input: AsOfInput!): TemporalScope!"));
     assert!(!body.contains("repo(name: String!): Repository!"));
 }

--- a/bitloops/src/graphql.rs
+++ b/bitloops/src/graphql.rs
@@ -1,5 +1,6 @@
 mod context;
 mod error;
+mod fuzzy_artefact_name;
 mod loaders;
 mod mutation_root;
 mod pack_adapter;

--- a/bitloops/src/graphql/fuzzy_artefact_name.rs
+++ b/bitloops/src/graphql/fuzzy_artefact_name.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::collections::BTreeSet;
 
 use super::types::Artefact;
 
@@ -107,8 +108,10 @@ fn jaccard_similarity(left: &[&str], right: &[&str]) -> f32 {
         return 0.0;
     }
 
-    let shared = left.iter().filter(|token| right.contains(token)).count();
-    let union = left.len() + right.len() - shared;
+    let left = left.iter().copied().collect::<BTreeSet<_>>();
+    let right = right.iter().copied().collect::<BTreeSet<_>>();
+    let shared = left.intersection(&right).count();
+    let union = left.union(&right).count();
     if union == 0 {
         0.0
     } else {
@@ -320,5 +323,12 @@ mod tests {
         let selected = select_fuzzy_named_artefacts("payLater()", artefacts);
 
         assert_eq!(selected.len(), 10);
+    }
+
+    #[test]
+    fn jaccard_similarity_uses_set_semantics_for_duplicate_tokens() {
+        let score = jaccard_similarity(&["foo", "foo"], &["foo"]);
+
+        assert_eq!(score, 1.0);
     }
 }

--- a/bitloops/src/graphql/fuzzy_artefact_name.rs
+++ b/bitloops/src/graphql/fuzzy_artefact_name.rs
@@ -1,0 +1,324 @@
+use std::cmp::Ordering;
+
+use super::types::Artefact;
+
+const DEFAULT_MIN_SCORE: f32 = 0.6;
+const DEFAULT_RESULT_LIMIT: usize = 10;
+
+#[derive(Debug, Clone)]
+struct RankedArtefact {
+    artefact: Artefact,
+    score: f32,
+}
+
+pub(crate) fn select_fuzzy_named_artefacts(query: &str, artefacts: Vec<Artefact>) -> Vec<Artefact> {
+    let normalized_query = normalize_fuzzy_name(query);
+    if normalized_query.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ranked = artefacts
+        .into_iter()
+        .filter_map(|artefact| {
+            let candidate_name = candidate_name_from_artefact(&artefact)?;
+            let score = fuzzy_name_score(&normalized_query, &candidate_name);
+            (score >= DEFAULT_MIN_SCORE).then_some(RankedArtefact { artefact, score })
+        })
+        .collect::<Vec<_>>();
+
+    ranked.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.artefact.path.cmp(&right.artefact.path))
+            .then_with(|| left.artefact.symbol_fqn.cmp(&right.artefact.symbol_fqn))
+            .then_with(|| left.artefact.id.as_str().cmp(right.artefact.id.as_str()))
+    });
+    ranked.truncate(DEFAULT_RESULT_LIMIT);
+    ranked.into_iter().map(|match_| match_.artefact).collect()
+}
+
+fn candidate_name_from_artefact(artefact: &Artefact) -> Option<String> {
+    let symbol_fqn = artefact.symbol_fqn.as_deref()?.trim();
+    if symbol_fqn.is_empty() {
+        return None;
+    }
+
+    let leaf_name = symbol_fqn.rsplit("::").next().unwrap_or(symbol_fqn);
+    let normalized = normalize_fuzzy_name(leaf_name);
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn normalize_fuzzy_name(value: &str) -> String {
+    let mut trimmed = value.trim();
+    while let Some(stripped) = trimmed.strip_suffix("()") {
+        trimmed = stripped.trim_end();
+    }
+
+    let tokens = split_identifier_tokens(trimmed);
+    if tokens.is_empty() {
+        trimmed.to_ascii_lowercase()
+    } else {
+        tokens.join("_")
+    }
+}
+
+fn fuzzy_name_score(query: &str, candidate: &str) -> f32 {
+    if query.is_empty() || candidate.is_empty() {
+        return 0.0;
+    }
+    if query == candidate {
+        return 1.0;
+    }
+
+    let prefix_score: f32 = if candidate.starts_with(query) || query.starts_with(candidate) {
+        0.92
+    } else {
+        0.0
+    };
+    let contains_score: f32 = if candidate.contains(query) || query.contains(candidate) {
+        0.84
+    } else {
+        0.0
+    };
+    let edit_score = levenshtein_similarity(query, candidate);
+    let token_score = jaccard_similarity(&query_tokens(query), &query_tokens(candidate));
+
+    prefix_score
+        .max(contains_score)
+        .max(edit_score)
+        .max((edit_score * 0.75) + (token_score * 0.25))
+}
+
+fn query_tokens(value: &str) -> Vec<&str> {
+    value
+        .split('_')
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn jaccard_similarity(left: &[&str], right: &[&str]) -> f32 {
+    if left.is_empty() && right.is_empty() {
+        return 1.0;
+    }
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+
+    let shared = left.iter().filter(|token| right.contains(token)).count();
+    let union = left.len() + right.len() - shared;
+    if union == 0 {
+        0.0
+    } else {
+        shared as f32 / union as f32
+    }
+}
+
+fn levenshtein_similarity(left: &str, right: &str) -> f32 {
+    let distance = levenshtein_distance(left, right);
+    let max_len = left.chars().count().max(right.chars().count());
+    if max_len == 0 {
+        1.0
+    } else {
+        1.0 - (distance as f32 / max_len as f32)
+    }
+}
+
+fn levenshtein_distance(left: &str, right: &str) -> usize {
+    let left = left.chars().collect::<Vec<_>>();
+    let right = right.chars().collect::<Vec<_>>();
+    if left.is_empty() {
+        return right.len();
+    }
+    if right.is_empty() {
+        return left.len();
+    }
+
+    let mut previous = (0..=right.len()).collect::<Vec<_>>();
+    let mut current = vec![0; right.len() + 1];
+
+    for (left_index, left_char) in left.iter().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_char) in right.iter().enumerate() {
+            let substitution_cost = usize::from(left_char != right_char);
+            current[right_index + 1] = (previous[right_index + 1] + 1)
+                .min(current[right_index] + 1)
+                .min(previous[right_index] + substitution_cost);
+        }
+        previous.clone_from(&current);
+    }
+
+    previous[right.len()]
+}
+
+fn split_identifier_tokens(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            current.push(ch);
+            continue;
+        }
+
+        flush_identifier_token(&mut current, &mut tokens);
+    }
+    flush_identifier_token(&mut current, &mut tokens);
+
+    tokens
+}
+
+fn flush_identifier_token(current: &mut String, tokens: &mut Vec<String>) {
+    if current.is_empty() {
+        return;
+    }
+
+    for piece in split_camel_case_word(current) {
+        let lowered = piece.trim().to_ascii_lowercase();
+        if !lowered.is_empty() {
+            tokens.push(lowered);
+        }
+    }
+
+    current.clear();
+}
+
+fn split_camel_case_word(input: &str) -> Vec<String> {
+    if input.is_empty() {
+        return Vec::new();
+    }
+
+    let chars = input.chars().collect::<Vec<_>>();
+    let mut pieces = Vec::new();
+    let mut current = String::new();
+
+    for (index, ch) in chars.iter().enumerate() {
+        if !current.is_empty() {
+            let previous = chars[index - 1];
+            let next = chars.get(index + 1).copied().unwrap_or('\0');
+            let boundary = (previous.is_ascii_lowercase() && ch.is_ascii_uppercase())
+                || (previous.is_ascii_alphabetic() && ch.is_ascii_digit())
+                || (previous.is_ascii_digit() && ch.is_ascii_alphabetic())
+                || (previous.is_ascii_uppercase()
+                    && ch.is_ascii_uppercase()
+                    && next.is_ascii_lowercase())
+                || (*ch == '_' && previous != '_');
+            if boundary {
+                let piece = current.trim_matches('_');
+                if !piece.is_empty() {
+                    pieces.push(piece.to_string());
+                }
+                current.clear();
+            }
+        }
+        current.push(*ch);
+    }
+
+    let piece = current.trim_matches('_');
+    if !piece.is_empty() {
+        pieces.push(piece.to_string());
+    }
+
+    pieces
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graphql::{DateTimeScalar, ResolverScope};
+    use async_graphql::ID;
+
+    fn sample_artefact(id: &str, path: &str, symbol_fqn: &str) -> Artefact {
+        Artefact {
+            id: ID::from(id),
+            symbol_id: format!("symbol::{id}"),
+            path: path.to_string(),
+            language: "typescript".to_string(),
+            canonical_kind: None,
+            language_kind: None,
+            symbol_fqn: Some(symbol_fqn.to_string()),
+            parent_artefact_id: None,
+            start_line: 1,
+            end_line: 5,
+            start_byte: 0,
+            end_byte: 10,
+            signature: None,
+            modifiers: Vec::new(),
+            docstring: None,
+            content_hash: None,
+            blob_sha: format!("blob::{id}"),
+            created_at: DateTimeScalar::from_rfc3339("2026-04-20T09:00:00Z")
+                .expect("valid timestamp"),
+            scope: ResolverScope::default(),
+        }
+    }
+
+    #[test]
+    fn normalize_fuzzy_name_splits_identifiers_and_strips_call_syntax() {
+        assert_eq!(normalize_fuzzy_name(" payLater() "), "pay_later");
+        assert_eq!(normalize_fuzzy_name("HTTPServer_v2"), "http_server_v_2");
+    }
+
+    #[test]
+    fn fuzzy_name_selection_prefers_best_typo_match() {
+        let selected = select_fuzzy_named_artefacts(
+            "targte()",
+            vec![
+                sample_artefact(
+                    "file-target",
+                    "packages/api/src/target.ts",
+                    "packages/api/src/target.ts",
+                ),
+                sample_artefact(
+                    "target",
+                    "packages/api/src/target.ts",
+                    "packages/api/src/target.ts::target",
+                ),
+                sample_artefact(
+                    "caller",
+                    "packages/api/src/caller.ts",
+                    "packages/api/src/caller.ts::caller",
+                ),
+            ],
+        );
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(
+            selected[0].symbol_fqn.as_deref(),
+            Some("packages/api/src/target.ts::target")
+        );
+    }
+
+    #[test]
+    fn fuzzy_name_selection_filters_weak_matches() {
+        let selected = select_fuzzy_named_artefacts(
+            "payments()",
+            vec![sample_artefact(
+                "caller",
+                "packages/api/src/caller.ts",
+                "packages/api/src/caller.ts::caller",
+            )],
+        );
+
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_name_selection_caps_results_at_ten() {
+        let artefacts = (0..12)
+            .map(|index| {
+                sample_artefact(
+                    &format!("pay-later-{index}"),
+                    &format!("src/pay-later-{index}.ts"),
+                    &format!("src/pay-later-{index}.ts::payLaterVariant{index}"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let selected = select_fuzzy_named_artefacts("payLater()", artefacts);
+
+        assert_eq!(selected.len(), 10);
+    }
+}

--- a/bitloops/src/graphql/slim_query_root.rs
+++ b/bitloops/src/graphql/slim_query_root.rs
@@ -2,6 +2,7 @@ use async_graphql::{Context, Object, Result};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 
+use crate::graphql::fuzzy_artefact_name::select_fuzzy_named_artefacts;
 use crate::graphql::pack_adapter::StageResolverAdapter;
 use crate::graphql::{DevqlGraphqlContext, backend_error, bad_cursor_error, bad_user_input_error};
 
@@ -563,6 +564,18 @@ impl SlimQueryRoot {
                             "failed to resolve selected artefacts by symbolFqn: {err:#}"
                         ))
                     })?
+            }
+            ArtefactSelectorMode::FuzzyName(fuzzy_name) => {
+                let artefacts =
+                    context
+                        .list_artefacts(None, None, &scope)
+                        .await
+                        .map_err(|err| {
+                            backend_error(format!(
+                                "failed to resolve selected artefacts by fuzzyName: {err:#}"
+                            ))
+                        })?;
+                select_fuzzy_named_artefacts(&fuzzy_name, artefacts)
             }
             ArtefactSelectorMode::Path { path, lines } => {
                 let normalized = context

--- a/bitloops/src/graphql/types/artefact_selection.rs
+++ b/bitloops/src/graphql/types/artefact_selection.rs
@@ -53,15 +53,10 @@ impl ArtefactSelectorInput {
             .filter(|value| !value.is_empty())
             .map(str::to_string);
 
-        if self.lines.is_some() && path.is_none() {
-            return Err(bad_user_input_error(
-                "`selectArtefacts(by: ...)` requires `path` when `lines` is provided",
-            ));
-        }
-
+        let path_selector_requested = path.is_some() || self.lines.is_some();
         let selector_count = usize::from(symbol_fqn.is_some())
             + usize::from(fuzzy_name.is_some())
-            + usize::from(path.is_some());
+            + usize::from(path_selector_requested);
         if selector_count == 0 {
             return Err(bad_user_input_error(
                 "`selectArtefacts(by: ...)` requires exactly one selector mode",
@@ -70,6 +65,11 @@ impl ArtefactSelectorInput {
         if selector_count > 1 {
             return Err(bad_user_input_error(
                 "`selectArtefacts(by: ...)` allows exactly one of `symbolFqn`, `fuzzyName`, or `path`/`lines`",
+            ));
+        }
+        if path_selector_requested && path.is_none() {
+            return Err(bad_user_input_error(
+                "`selectArtefacts(by: ...)` requires `path` when `lines` is provided",
             ));
         }
 
@@ -903,6 +903,32 @@ mod tests {
         }
         .selection_mode()
         .expect_err("fuzzy selector mixed with path should fail");
+        assert!(
+            err.message
+                .contains("allows exactly one of `symbolFqn`, `fuzzyName`, or `path`/`lines`")
+        );
+
+        let err = ArtefactSelectorInput {
+            symbol_fqn: None,
+            fuzzy_name: Some("payLater".to_string()),
+            path: None,
+            lines: Some(LineRangeInput { start: 20, end: 25 }),
+        }
+        .selection_mode()
+        .expect_err("fuzzy selector mixed with lines should fail");
+        assert!(
+            err.message
+                .contains("allows exactly one of `symbolFqn`, `fuzzyName`, or `path`/`lines`")
+        );
+
+        let err = ArtefactSelectorInput {
+            symbol_fqn: Some("src/main.rs::main".to_string()),
+            fuzzy_name: None,
+            path: None,
+            lines: Some(LineRangeInput { start: 20, end: 25 }),
+        }
+        .selection_mode()
+        .expect_err("symbol selector mixed with lines should fail");
         assert!(
             err.message
                 .contains("allows exactly one of `symbolFqn`, `fuzzyName`, or `path`/`lines`")

--- a/bitloops/src/graphql/types/artefact_selection.rs
+++ b/bitloops/src/graphql/types/artefact_selection.rs
@@ -14,6 +14,7 @@ use super::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ArtefactSelectorMode {
     SymbolFqn(String),
+    FuzzyName(String),
     Path {
         path: String,
         lines: Option<LineRangeInput>,
@@ -23,6 +24,7 @@ pub(crate) enum ArtefactSelectorMode {
 #[derive(Debug, Clone, InputObject)]
 pub struct ArtefactSelectorInput {
     pub symbol_fqn: Option<String>,
+    pub fuzzy_name: Option<String>,
     pub path: Option<String>,
     pub lines: Option<LineRangeInput>,
 }
@@ -35,6 +37,15 @@ impl ArtefactSelectorInput {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(str::to_string);
+        let fuzzy_name = match self.fuzzy_name.as_deref() {
+            Some(value) if value.trim().is_empty() => {
+                return Err(bad_user_input_error(
+                    "`selectArtefacts(by: ...)` requires a non-empty `fuzzyName`",
+                ));
+            }
+            Some(value) => Some(value.trim().to_string()),
+            None => None,
+        };
         let path = self
             .path
             .as_deref()
@@ -42,27 +53,41 @@ impl ArtefactSelectorInput {
             .filter(|value| !value.is_empty())
             .map(str::to_string);
 
-        match (symbol_fqn, path, self.lines.as_ref()) {
-            (Some(symbol_fqn), None, None) => Ok(ArtefactSelectorMode::SymbolFqn(symbol_fqn)),
-            (None, Some(path), lines) => {
-                if let Some(lines) = lines {
-                    lines.validate()?;
-                }
-                Ok(ArtefactSelectorMode::Path {
-                    path,
-                    lines: lines.cloned(),
-                })
-            }
-            (None, None, Some(_)) => Err(bad_user_input_error(
+        if self.lines.is_some() && path.is_none() {
+            return Err(bad_user_input_error(
                 "`selectArtefacts(by: ...)` requires `path` when `lines` is provided",
-            )),
-            (Some(_), Some(_), _) | (Some(_), None, Some(_)) => Err(bad_user_input_error(
-                "`selectArtefacts(by: ...)` allows either `symbolFqn` or `path`/`lines`, not both",
-            )),
-            (None, None, None) => Err(bad_user_input_error(
-                "`selectArtefacts(by: ...)` requires exactly one selector mode",
-            )),
+            ));
         }
+
+        let selector_count = usize::from(symbol_fqn.is_some())
+            + usize::from(fuzzy_name.is_some())
+            + usize::from(path.is_some());
+        if selector_count == 0 {
+            return Err(bad_user_input_error(
+                "`selectArtefacts(by: ...)` requires exactly one selector mode",
+            ));
+        }
+        if selector_count > 1 {
+            return Err(bad_user_input_error(
+                "`selectArtefacts(by: ...)` allows exactly one of `symbolFqn`, `fuzzyName`, or `path`/`lines`",
+            ));
+        }
+
+        if let Some(symbol_fqn) = symbol_fqn {
+            return Ok(ArtefactSelectorMode::SymbolFqn(symbol_fqn));
+        }
+        if let Some(fuzzy_name) = fuzzy_name {
+            return Ok(ArtefactSelectorMode::FuzzyName(fuzzy_name));
+        }
+
+        let path = path.expect("selector_count ensures path selector exists");
+        if let Some(lines) = self.lines.as_ref() {
+            lines.validate()?;
+        }
+        Ok(ArtefactSelectorMode::Path {
+            path,
+            lines: self.lines.clone(),
+        })
     }
 }
 
@@ -793,6 +818,7 @@ mod tests {
     fn artefact_selector_accepts_symbol_fqn_or_path_modes() {
         let symbol = ArtefactSelectorInput {
             symbol_fqn: Some("src/main.rs::main".to_string()),
+            fuzzy_name: None,
             path: None,
             lines: None,
         };
@@ -803,6 +829,7 @@ mod tests {
 
         let path = ArtefactSelectorInput {
             symbol_fqn: None,
+            fuzzy_name: None,
             path: Some("src/main.rs".to_string()),
             lines: Some(LineRangeInput { start: 20, end: 25 }),
         };
@@ -816,9 +843,25 @@ mod tests {
     }
 
     #[test]
+    fn artefact_selector_accepts_fuzzy_name_mode() {
+        let fuzzy = ArtefactSelectorInput {
+            symbol_fqn: None,
+            fuzzy_name: Some("payLater()".to_string()),
+            path: None,
+            lines: None,
+        };
+
+        assert_eq!(
+            fuzzy.selection_mode().expect("fuzzy selector"),
+            ArtefactSelectorMode::FuzzyName("payLater()".to_string())
+        );
+    }
+
+    #[test]
     fn artefact_selector_rejects_invalid_combinations() {
         let err = ArtefactSelectorInput {
             symbol_fqn: Some("src/main.rs::main".to_string()),
+            fuzzy_name: None,
             path: Some("src/main.rs".to_string()),
             lines: None,
         }
@@ -826,11 +869,12 @@ mod tests {
         .expect_err("mixed selector should fail");
         assert!(
             err.message
-                .contains("allows either `symbolFqn` or `path`/`lines`")
+                .contains("allows exactly one of `symbolFqn`, `fuzzyName`, or `path`/`lines`")
         );
 
         let err = ArtefactSelectorInput {
             symbol_fqn: None,
+            fuzzy_name: None,
             path: None,
             lines: Some(LineRangeInput { start: 20, end: 25 }),
         }
@@ -843,6 +887,30 @@ mod tests {
 
         let err = ArtefactSelectorInput {
             symbol_fqn: None,
+            fuzzy_name: Some("  ".to_string()),
+            path: None,
+            lines: None,
+        }
+        .selection_mode()
+        .expect_err("blank fuzzy selector should fail");
+        assert!(err.message.contains("non-empty `fuzzyName`"));
+
+        let err = ArtefactSelectorInput {
+            symbol_fqn: None,
+            fuzzy_name: Some("payLater".to_string()),
+            path: Some("src/main.rs".to_string()),
+            lines: None,
+        }
+        .selection_mode()
+        .expect_err("fuzzy selector mixed with path should fail");
+        assert!(
+            err.message
+                .contains("allows exactly one of `symbolFqn`, `fuzzyName`, or `path`/`lines`")
+        );
+
+        let err = ArtefactSelectorInput {
+            symbol_fqn: None,
+            fuzzy_name: None,
             path: None,
             lines: None,
         }

--- a/bitloops/src/host/devql/query/dsl_compiler/args.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/args.rs
@@ -28,6 +28,9 @@ pub(super) fn compile_select_artefacts_args(
     if let Some(symbol_fqn) = selector.symbol_fqn.as_deref() {
         fields.push(format!("symbolFqn: {}", quote_graphql_string(symbol_fqn)));
     }
+    if let Some(fuzzy_name) = selector.fuzzy_name.as_deref() {
+        fields.push(format!("fuzzyName: {}", quote_graphql_string(fuzzy_name)));
+    }
     if let Some(path) = selector.path.as_deref() {
         fields.push(format!("path: {}", quote_graphql_string(path)));
     }

--- a/bitloops/src/host/devql/query/dsl_compiler/tests.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/tests.rs
@@ -622,6 +622,40 @@ fn compile_slim_select_artefacts_fuzzy_name_selector() {
 }
 
 #[test]
+fn compile_slim_select_artefacts_rejects_fuzzy_name_mixed_with_lines() {
+    let parsed = parse_devql_query(
+        r#"selectArtefacts(fuzzy_name:"payLater()",lines:20..25)->checkpoints()"#,
+    )
+    .expect("query parses");
+
+    let err = compile_devql_to_graphql_with_mode(&parsed, GraphqlCompileMode::Slim)
+        .expect_err("invalid selector should fail");
+
+    assert!(
+        err.to_string()
+            .contains("allows exactly one of symbol_fqn:, fuzzy_name:, or path:/lines:"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn compile_slim_select_artefacts_rejects_symbol_fqn_mixed_with_lines() {
+    let parsed = parse_devql_query(
+        r#"selectArtefacts(symbol_fqn:"src/main.rs::main",lines:20..25)->checkpoints()"#,
+    )
+    .expect("query parses");
+
+    let err = compile_devql_to_graphql_with_mode(&parsed, GraphqlCompileMode::Slim)
+        .expect_err("invalid selector should fail");
+
+    assert!(
+        err.to_string()
+            .contains("allows exactly one of symbol_fqn:, fuzzy_name:, or path:/lines:"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
 fn compile_slim_select_artefacts_deps_supports_schema_projection() {
     let parsed = parse_devql_query(
         r#"selectArtefacts(symbol_fqn:"src/main.rs::main")->deps()->select(summary,schema)"#,

--- a/bitloops/src/host/devql/query/dsl_compiler/tests.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/tests.rs
@@ -602,6 +602,26 @@ fn compile_slim_select_artefacts_checkpoints_defaults_to_summary() {
 }
 
 #[test]
+fn compile_slim_select_artefacts_fuzzy_name_selector() {
+    let parsed = parse_devql_query(r#"selectArtefacts(fuzzy_name:"payLater()")->checkpoints()"#)
+        .expect("query parses");
+
+    let graphql = compile_devql_to_graphql_with_mode(&parsed, GraphqlCompileMode::Slim)
+        .expect("slim graphql compiles");
+
+    assert_eq!(
+        graphql,
+        r#"query {
+  selectArtefacts(by: { fuzzyName: "payLater()" }) {
+    checkpoints {
+      summary
+    }
+  }
+}"#
+    );
+}
+
+#[test]
 fn compile_slim_select_artefacts_deps_supports_schema_projection() {
     let parsed = parse_devql_query(
         r#"selectArtefacts(symbol_fqn:"src/main.rs::main")->deps()->select(summary,schema)"#,

--- a/bitloops/src/host/devql/query/dsl_compiler/validation.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/validation.rs
@@ -410,21 +410,39 @@ fn validate_select_artefacts_selector(selector: &SelectArtefactsFilter) -> Resul
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    let fuzzy_name = selector
+        .fuzzy_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if selector
+        .fuzzy_name
+        .as_deref()
+        .is_some_and(|value| value.trim().is_empty())
+    {
+        bail!("selectArtefacts(...) requires fuzzy_name: to be non-empty");
+    }
     let path = selector
         .path
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
 
-    match (symbol_fqn, path, selector.lines) {
-        (Some(_), None, None) => Ok(()),
-        (None, Some(_), None | Some(_)) => Ok(()),
-        (None, None, Some(_)) => {
-            bail!("selectArtefacts(...) requires path: when lines: is provided")
-        }
-        (Some(_), Some(_), _) | (Some(_), None, Some(_)) => {
-            bail!("selectArtefacts(...) allows either symbol_fqn: or path:/lines:, not both")
-        }
-        (None, None, None) => bail!("selectArtefacts(...) requires symbol_fqn: or path:"),
+    if selector.lines.is_some() && path.is_none() {
+        bail!("selectArtefacts(...) requires path: when lines: is provided");
     }
+
+    let selector_count = usize::from(symbol_fqn.is_some())
+        + usize::from(fuzzy_name.is_some())
+        + usize::from(path.is_some());
+    if selector_count == 0 {
+        bail!("selectArtefacts(...) requires symbol_fqn:, fuzzy_name:, or path:");
+    }
+    if selector_count > 1 {
+        bail!(
+            "selectArtefacts(...) allows exactly one of symbol_fqn:, fuzzy_name:, or path:/lines:"
+        );
+    }
+
+    Ok(())
 }

--- a/bitloops/src/host/devql/query/dsl_compiler/validation.rs
+++ b/bitloops/src/host/devql/query/dsl_compiler/validation.rs
@@ -428,13 +428,10 @@ fn validate_select_artefacts_selector(selector: &SelectArtefactsFilter) -> Resul
         .map(str::trim)
         .filter(|value| !value.is_empty());
 
-    if selector.lines.is_some() && path.is_none() {
-        bail!("selectArtefacts(...) requires path: when lines: is provided");
-    }
-
+    let path_selector_requested = path.is_some() || selector.lines.is_some();
     let selector_count = usize::from(symbol_fqn.is_some())
         + usize::from(fuzzy_name.is_some())
-        + usize::from(path.is_some());
+        + usize::from(path_selector_requested);
     if selector_count == 0 {
         bail!("selectArtefacts(...) requires symbol_fqn:, fuzzy_name:, or path:");
     }
@@ -442,6 +439,9 @@ fn validate_select_artefacts_selector(selector: &SelectArtefactsFilter) -> Resul
         bail!(
             "selectArtefacts(...) allows exactly one of symbol_fqn:, fuzzy_name:, or path:/lines:"
         );
+    }
+    if path_selector_requested && path.is_none() {
+        bail!("selectArtefacts(...) requires path: when lines: is provided");
     }
 
     Ok(())

--- a/bitloops/src/host/devql/query/parser.rs
+++ b/bitloops/src/host/devql/query/parser.rs
@@ -54,6 +54,7 @@ pub(crate) struct ArtefactFilter {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SelectArtefactsFilter {
     pub(crate) symbol_fqn: Option<String>,
+    pub(crate) fuzzy_name: Option<String>,
     pub(crate) path: Option<String>,
     pub(crate) lines: Option<(i32, i32)>,
 }
@@ -163,6 +164,7 @@ pub(crate) fn parse_devql_query(query: &str) -> Result<ParsedDevqlQuery> {
             }
             parsed.select_artefacts = Some(SelectArtefactsFilter {
                 symbol_fqn: args.get("symbol_fqn").cloned(),
+                fuzzy_name: args.get("fuzzy_name").cloned(),
                 path: args.get("path").cloned(),
                 lines: args
                     .get("lines")

--- a/bitloops/src/host/hooks/augmentation/devql_guidance.rs
+++ b/bitloops/src/host/hooks/augmentation/devql_guidance.rs
@@ -42,6 +42,7 @@ Use DevQL first for code understanding in this repo.\n\
 Quick-start commands:\n\
 ```bash\n\
 bitloops devql query '{ selectArtefacts(by: { path: \"<repo-relative-path>\" }) { summary } }'\n\
+bitloops devql query '{ selectArtefacts(by: { fuzzyName: \"<approx-symbol-name>\" }) { artefacts(first: 10) { path symbolFqn } } }'\n\
 bitloops devql query '{ selectArtefacts(by: { symbolFqn: \"<symbol-fqn>\" }) { summary } }'\n\
 bitloops devql schema --global\n\
 ```\n\
@@ -68,5 +69,15 @@ mod tests {
         assert!(guidance.contains("start: 1"));
         assert!(guidance.contains("end: 1"));
         assert!(!guidance.contains("<repo-relative-path>"));
+    }
+
+    #[test]
+    fn build_turn_guidance_includes_fuzzy_lookup_in_generic_guidance() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let guidance = build_turn_guidance(dir.path(), "Help me find payLatr()");
+
+        assert!(guidance.contains("fuzzyName"));
+        assert!(guidance.contains("<approx-symbol-name>"));
     }
 }

--- a/bitloops/src/host/hooks/augmentation/skill_content.rs
+++ b/bitloops/src/host/hooks/augmentation/skill_content.rs
@@ -26,4 +26,11 @@ mod tests {
         assert!(body.contains("outside the sandbox"));
         assert!(body.contains("bitloops devql"));
     }
+
+    #[test]
+    fn using_devql_skill_mentions_fuzzy_name_lookup() {
+        let body = using_devql_skill_body();
+        assert!(body.contains("fuzzyName"));
+        assert!(body.contains("<approx-symbol-name>"));
+    }
 }

--- a/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
+++ b/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
@@ -2,7 +2,8 @@
 name: using-devql
 description: >
   Use when understanding code structure, resolving artefacts by path or line
-  range, finding callers/usages/imports/tests/checkpoints/clones/dependencies,
+  range, resolving approximate symbol names with fuzzy lookup, finding
+  callers/usages/imports/tests/checkpoints/clones/dependencies,
   or answering architecture questions in a repo with DevQL enabled.
 ---
 
@@ -26,13 +27,14 @@ search or file reads.
 
 - understanding what a file, function, module, class, or symbol does
 - resolving the concrete artefacts matched by a path or line range
+- resolving a likely symbol name when the human-entered name may be approximate or misspelled
 - finding callers, usages, imports, tests, checkpoints, clones, or dependencies
 - getting a structured overview of a file or area
 - answering architecture questions
 
 ## Agent Flow
 
-1. Select the target with `symbolFqn`, `path`, or `path + lines`.
+1. Select the target with `symbolFqn`, `fuzzyName`, `path`, or `path + lines`.
 2. Ask for `summary` only if you need orientation or to discover which stage to expand.
 3. Rerun with `artefacts(first: ...)` or the relevant stage `items(first: ...)`.
 4. Return the concrete rows. Summaries are optional follow-up, not substitutes.
@@ -52,6 +54,9 @@ bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-path>" }) { 
 
 # Concrete artefacts for a known file or line range
 bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-path>", lines: { start: <start>, end: <end> } }) { artefacts(first: 20) { path symbolFqn canonicalKind startLine endLine } } }'
+
+# Fuzzy lookup when the symbol name is approximate or may be misspelled
+bitloops devql query '{ selectArtefacts(by: { fuzzyName: "<approx-symbol-name>" }) { artefacts(first: 10) { path symbolFqn canonicalKind startLine endLine } } }'
 
 # Concrete callers/usages/imports once the symbol is known
 bitloops devql query '{ selectArtefacts(by: { symbolFqn: "<symbol-fqn>" }) { deps(kind: CALLS, direction: IN, includeUnresolved: true) { items(first: 50) { edgeKind startLine endLine fromArtefact { symbolFqn path startLine endLine } toArtefact { symbolFqn path startLine endLine } toSymbolRef } } } }'

--- a/documentation/docs/concepts/devql.md
+++ b/documentation/docs/concepts/devql.md
@@ -61,6 +61,7 @@ The slim, repo-scoped GraphQL surface also exposes a selection-oriented entry po
 `selectArtefacts(by: ...)` resolves a current set of `0..n` artefacts and then lets you query analyses over that same set. Supported selectors are:
 
 - `symbolFqn`
+- `fuzzyName`
 - `path`
 - `path` plus `lines`
 

--- a/documentation/docs/guides/devql-graphql.md
+++ b/documentation/docs/guides/devql-graphql.md
@@ -178,6 +178,7 @@ When you need detail rows, query the stage directly and use `items(first: ...)`:
 Selector rules:
 
 - `symbolFqn` selects by logical artefact identity
+- `fuzzyName` selects current artefacts by normalized symbol name, including typo-tolerant matches
 - `path` selects all current artefacts in that file
 - `path` plus `lines` selects all current artefacts overlapping that range
 

--- a/documentation/docs/guides/devql-query-cookbook.md
+++ b/documentation/docs/guides/devql-query-cookbook.md
@@ -65,6 +65,17 @@ For the full selector contract and stage semantics, see [selectArtefacts](/guide
 }
 ```
 
+```graphql
+{
+  selectArtefacts(by: { fuzzyName: "payLater()" }) {
+    artefacts(first: 10) {
+      path
+      symbolFqn
+    }
+  }
+}
+```
+
 The `summary` payload includes one entry per available category, currently:
 
 - `checkpoints`

--- a/documentation/docs/guides/select-artefacts.md
+++ b/documentation/docs/guides/select-artefacts.md
@@ -44,6 +44,22 @@ Exactly one selector mode must be used.
 
 This usually resolves to `0..1` logical artefacts, but callers should treat the result as a set.
 
+### By `fuzzyName`
+
+```graphql
+{
+  selectArtefacts(by: { fuzzyName: "payLater()" }) {
+    count
+    artefacts {
+      path
+      symbolFqn
+    }
+  }
+}
+```
+
+This searches current artefacts in scope by normalized symbol name, including typo-tolerant matches such as `payLater()` or `payLatr()`. v1 returns up to 10 best-first matches and does not expose scores in the API.
+
 ### By `path` and `lines`
 
 ```graphql
@@ -80,7 +96,9 @@ This resolves all current artefacts in the file.
 
 ## Validation Rules
 
-- `symbolFqn` cannot be combined with `path` or `lines`
+- `symbolFqn` cannot be combined with `fuzzyName`, `path`, or `lines`
+- `fuzzyName` cannot be combined with `symbolFqn`, `path`, or `lines`
+- `fuzzyName` must be non-empty
 - `lines` requires `path`
 - empty selectors are rejected
 - selector paths are resolved relative to the slim request scope, including project-scoped slim requests
@@ -283,6 +301,7 @@ The DevQL DSL supports `selectArtefacts(...)` with flat selector args:
 
 ```text
 selectArtefacts(symbol_fqn:"rust-app/src/main.rs::main")->checkpoints()
+selectArtefacts(fuzzy_name:"payLater()")->checkpoints()
 selectArtefacts(path:"rust-app/src/main.rs",lines:6..10)->deps()
 selectArtefacts(path:"rust-app/src/main.rs")->tests(min_confidence:0.8)
 ```


### PR DESCRIPTION


## Summary

- Introduced `fuzzyName` selector in `ArtefactSelectorInput` and `ArtefactSelectorMode`.
- Implemented fuzzy artefact lookup in `selectArtefacts` with typo tolerance.
- Updated validation rules to enforce single selector usage.
- Enhanced documentation to include fuzzy name usage examples and guidelines.

[Ticket](https://bitloops.atlassian.net/browse/CLI-1697) 

## Validation

- [x] I ran the relevant tests locally.
- [x] Linked Jira issue(s) are updated with implementation notes and test results.
- [x] Final status transitions match the task definition of done.

