### PR TITLE
Update DevQL skill guidance and add tests stage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Bitloops-managed `using-devql` guidance now shows the zero-argument GraphQL `tests` stage and clarifies direct artefact targeting**: the shared DevQL skill/rule content now demonstrates `selectArtefacts(...){ tests { ... } }` instead of the argument-bearing `tests(linkageSource: "static_analysis")` form, trims the sample `coveringTests` payload to the most useful fields plus line spans, and clarifies that `tests` returns tests directly linked to the selected artefact so empty results remain expected for code reached only indirectly through DI wiring, helpers, or higher-level integration paths.
+
 ## [0.0.18] - 2026-04-21
 
 ### Changed

--- a/bitloops/src/host/hooks/augmentation/skill_content.rs
+++ b/bitloops/src/host/hooks/augmentation/skill_content.rs
@@ -33,4 +33,11 @@ mod tests {
         assert!(body.contains("fuzzyName"));
         assert!(body.contains("<approx-symbol-name>"));
     }
+
+    #[test]
+    fn using_devql_skill_mentions_tests_stage_example() {
+        let body = using_devql_skill_body();
+        assert!(body.contains("tests { summary"));
+        assert!(body.contains("coveringTests"));
+    }
 }

--- a/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
+++ b/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
@@ -64,6 +64,9 @@ bitloops devql query '{ selectArtefacts(by: { symbolFqn: "<symbol-fqn>" }) { dep
 # Discover the exact row fields for the chosen stage
 bitloops devql query '{ selectArtefacts(by: { symbolFqn: "<symbol-fqn>" }) { deps(kind: CALLS, direction: IN, includeUnresolved: true) { schema } } }'
 
+# Concrete tests that directly target the selected artefact
+bitloops devql query '{ selectArtefacts(by: { symbolFqn: "<symbol-fqn>" }) { tests { summary items(first: 20) { artefact { name filePath startLine endLine } coveringTests { testName suiteName filePath startLine endLine } } } } }'
+
 # use sparingly to see the whole schema
 bitloops devql schema
 ```


### PR DESCRIPTION
## Summary

Update the guidance for the Bitloops-managed `using-devql` skill to include a zero-argument GraphQL `tests` stage example. The changes clarify direct artefact targeting and enhance the sample payload for better usability. Additionally, new tests validate the inclusion of the `tests` stage in the skill's output.

## Validation

- [ ] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

