### PR TITLE
added cocrete instructions for the skills

### DIFF
--- a/bitloops/schema.slim.graphql
+++ b/bitloops/schema.slim.graphql
@@ -94,7 +94,7 @@ type ArtefactSelection {
 input ArtefactSelectorInput {
 	symbolFqn: String
 	fuzzyName: String
-	semanticQuery: String
+	naturalLanguage: String
 	path: String
 	lines: LineRangeInput
 }

--- a/bitloops/src/api/tests/devql_mutations_and_health.rs
+++ b/bitloops/src/api/tests/devql_mutations_and_health.rs
@@ -1954,7 +1954,7 @@ async fn slim_select_artefacts_resolves_semantic_query_selection_in_repo_scope()
         .execute(async_graphql::Request::new(
             r#"
             {
-              selectArtefacts(by: { semanticQuery: "render in page ts" }) {
+              selectArtefacts(by: { naturalLanguage: "render in page ts" }) {
                 count
                 artefacts {
                   path
@@ -1996,7 +1996,7 @@ async fn slim_select_artefacts_resolves_semantic_query_selection_in_project_scop
         .execute(async_graphql::Request::new(
             r#"
             {
-              selectArtefacts(by: { semanticQuery: "caller in caller ts" }) {
+              selectArtefacts(by: { naturalLanguage: "caller in caller ts" }) {
                 count
                 artefacts {
                   score
@@ -2045,7 +2045,7 @@ async fn slim_select_artefacts_resolves_semantic_query_selection_from_identity_n
         .execute(async_graphql::Request::new(
             r#"
             {
-              selectArtefacts(by: { semanticQuery: "caller in caller ts" }) {
+              selectArtefacts(by: { naturalLanguage: "caller in caller ts" }) {
                 count
                 artefacts {
                   path
@@ -2087,7 +2087,7 @@ async fn slim_select_artefacts_resolves_semantic_query_selection_from_identity_p
         .execute(async_graphql::Request::new(
             r#"
             {
-              selectArtefacts(by: { semanticQuery: "render in page ts" }) {
+              selectArtefacts(by: { naturalLanguage: "render in page ts" }) {
                 count
                 artefacts {
                   path
@@ -2242,7 +2242,7 @@ async fn slim_select_artefacts_semantic_query_drives_summary_and_deps_and_tests(
         .execute(async_graphql::Request::new(
             r#"
             {
-              selectArtefacts(by: { semanticQuery: "caller in caller ts" }) {
+              selectArtefacts(by: { naturalLanguage: "caller in caller ts" }) {
                 count
                 summary
                 deps {
@@ -2305,7 +2305,7 @@ async fn slim_select_artefacts_semantic_query_returns_empty_when_no_match_is_clo
         .execute(async_graphql::Request::new(
             r#"
             {
-              selectArtefacts(by: { semanticQuery: "unrelated zeta quaternion" }) {
+              selectArtefacts(by: { naturalLanguage: "unrelated zeta quaternion" }) {
                 count
                 artefacts {
                   path

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -244,7 +244,7 @@ async fn devql_sdl_route_returns_schema_text() {
     assert!(body.contains("chatHistory"));
     assert!(body.contains("selectArtefacts(by: ArtefactSelectorInput!): ArtefactSelection!"));
     assert!(body.contains("fuzzyName: String"));
-    assert!(body.contains("semanticQuery: String"));
+    assert!(body.contains("naturalLanguage: String"));
     assert!(body.contains("asOf(input: AsOfInput!): TemporalScope!"));
     assert!(!body.contains("repo(name: String!): Repository!"));
 }

--- a/bitloops/src/graphql/semantic_artefact_query.rs
+++ b/bitloops/src/graphql/semantic_artefact_query.rs
@@ -45,18 +45,18 @@ pub(crate) async fn select_semantic_artefacts(
     let trimmed_query = query.trim();
     if trimmed_query.is_empty() {
         return Err(bad_user_input_error(
-            "`selectArtefacts(by: ...)` requires a non-empty `semanticQuery`",
+            "`selectArtefacts(by: ...)` requires a non-empty `naturalLanguage`",
         ));
     }
 
     let repo_id = context.repo_id_for_scope(scope).map_err(|err| {
         backend_error(format!(
-            "failed to resolve repository for semanticQuery selection: {err:#}"
+            "failed to resolve repository for naturalLanguage selection: {err:#}"
         ))
     })?;
     let host = context.capability_host_arc().map_err(|err| {
         backend_error(format!(
-            "failed to resolve capability host for semanticQuery selection: {err:#}"
+            "failed to resolve capability host for naturalLanguage selection: {err:#}"
         ))
     })?;
     let config = resolve_semantic_clones_config(&host.config_view(SEMANTIC_CLONES_CAPABILITY_ID));
@@ -69,30 +69,30 @@ pub(crate) async fn select_semantic_artefacts(
     )
     .map_err(|err| {
         backend_error(format!(
-            "failed to resolve semanticQuery embeddings provider: {err:#}"
+            "failed to resolve naturalLanguage embeddings provider: {err:#}"
         ))
     })?;
     let provider = selection.provider.ok_or_else(|| {
         bad_user_input_error(
-            "`semanticQuery` requires configured semantic clone identity embeddings in `semantic_clones.inference.code_embeddings`",
+            "`naturalLanguage` requires configured semantic clone identity embeddings in `semantic_clones.inference.code_embeddings`",
         )
     })?;
     let query_setup = resolve_embedding_setup(provider.as_ref()).map_err(|err| {
         backend_error(format!(
-            "failed to resolve semanticQuery embedding setup: {err:#}"
+            "failed to resolve naturalLanguage embedding setup: {err:#}"
         ))
     })?;
     let query_embedding = provider
         .embed(trimmed_query, EmbeddingInputType::Query)
-        .map_err(|err| backend_error(format!("failed to embed semanticQuery: {err:#}")))?;
+        .map_err(|err| backend_error(format!("failed to embed naturalLanguage: {err:#}")))?;
     if query_embedding.is_empty() {
         return Err(backend_error(
-            "semanticQuery embedding provider returned an empty vector",
+            "naturalLanguage embedding provider returned an empty vector",
         ));
     }
     if query_embedding.len() != query_setup.dimension {
         return Err(bad_user_input_error(format!(
-            "`semanticQuery` embedding dimension {} did not match the configured setup dimension {}",
+            "`naturalLanguage` embedding dimension {} did not match the configured setup dimension {}",
             query_embedding.len(),
             query_setup.dimension
         )));
@@ -100,13 +100,13 @@ pub(crate) async fn select_semantic_artefacts(
 
     let repo_root = context.repo_root_for_scope(scope).map_err(|err| {
         backend_error(format!(
-            "failed to resolve repository root for semanticQuery selection: {err:#}"
+            "failed to resolve repository root for naturalLanguage selection: {err:#}"
         ))
     })?;
     let relational_store =
         DefaultRelationalStore::open_local_for_repo_root(&repo_root).map_err(|err| {
             backend_error(format!(
-                "failed to open relational store for semanticQuery selection: {err:#}"
+                "failed to open relational store for naturalLanguage selection: {err:#}"
             ))
         })?;
     let relational = relational_store.to_local_inner();
@@ -116,14 +116,14 @@ pub(crate) async fn select_semantic_artefacts(
             .await
             .map_err(|err| {
                 backend_error(format!(
-                    "failed to load active embedding setup for semanticQuery selection: {err:#}"
+                    "failed to load active embedding setup for naturalLanguage selection: {err:#}"
                 ))
             })?;
     if let Some(active_setup) = active_setup
         && active_setup.setup != query_setup
     {
         return Err(bad_user_input_error(format!(
-            "`semanticQuery` embeddings were prepared for {} but the active inference profile resolved to {}",
+            "`naturalLanguage` embeddings were prepared for {} but the active inference profile resolved to {}",
             describe_setup(&active_setup.setup),
             describe_setup(&query_setup)
         )));
@@ -133,7 +133,7 @@ pub(crate) async fn select_semantic_artefacts(
         .await
         .map_err(|err| {
             backend_error(format!(
-                "failed to load candidate artefacts for semanticQuery selection: {err:#}"
+                "failed to load candidate artefacts for naturalLanguage selection: {err:#}"
             ))
         })?;
     let compatible_candidates =
@@ -215,7 +215,7 @@ fn compatible_candidates_for_setup(
         && let Some(mismatched_setup) = mismatched_setup
     {
         return Err(format!(
-            "`semanticQuery` embeddings were prepared for {} but the active inference profile resolved to {}",
+            "`naturalLanguage` embeddings were prepared for {} but the active inference profile resolved to {}",
             describe_setup(&mismatched_setup),
             describe_setup(query_setup)
         ));
@@ -567,7 +567,7 @@ mod tests {
 
         let err = compatible_candidates_for_setup(vec![mismatched], &query_setup)
             .expect_err("mismatched setup should fail");
-        assert!(err.contains("`semanticQuery` embeddings were prepared for"));
+        assert!(err.contains("`naturalLanguage` embeddings were prepared for"));
         assert!(err.contains("provider `bitloops_embeddings_ipc`"));
         assert!(err.contains("provider `provider-a`"));
     }

--- a/bitloops/src/graphql/slim_query_root.rs
+++ b/bitloops/src/graphql/slim_query_root.rs
@@ -580,8 +580,9 @@ impl SlimQueryRoot {
                 let artefacts = select_fuzzy_named_artefacts(&fuzzy_name, artefacts);
                 ArtefactSelection::new(artefacts, Vec::new(), scope)
             }
-            ArtefactSelectorMode::SemanticQuery(semantic_query) => {
-                let artefacts = select_semantic_artefacts(context, &scope, &semantic_query).await?;
+            ArtefactSelectorMode::NaturalLanguage(natural_language) => {
+                let artefacts =
+                    select_semantic_artefacts(context, &scope, &natural_language).await?;
                 ArtefactSelection::new(artefacts, Vec::new(), scope)
             }
             ArtefactSelectorMode::Path { path, lines } => {

--- a/bitloops/src/graphql/types/artefact_selection.rs
+++ b/bitloops/src/graphql/types/artefact_selection.rs
@@ -15,7 +15,7 @@ use super::{
 pub(crate) enum ArtefactSelectorMode {
     SymbolFqn(String),
     FuzzyName(String),
-    SemanticQuery(String),
+    NaturalLanguage(String),
     Path {
         path: String,
         lines: Option<LineRangeInput>,
@@ -26,7 +26,7 @@ pub(crate) enum ArtefactSelectorMode {
 pub struct ArtefactSelectorInput {
     pub symbol_fqn: Option<String>,
     pub fuzzy_name: Option<String>,
-    pub semantic_query: Option<String>,
+    pub natural_language: Option<String>,
     pub path: Option<String>,
     pub lines: Option<LineRangeInput>,
 }
@@ -48,10 +48,10 @@ impl ArtefactSelectorInput {
             Some(value) => Some(value.trim().to_string()),
             None => None,
         };
-        let semantic_query = match self.semantic_query.as_deref() {
+        let natural_language = match self.natural_language.as_deref() {
             Some(value) if value.trim().is_empty() => {
                 return Err(bad_user_input_error(
-                    "`selectArtefacts(by: ...)` requires a non-empty `semanticQuery`",
+                    "`selectArtefacts(by: ...)` requires a non-empty `naturalLanguage`",
                 ));
             }
             Some(value) => Some(value.trim().to_string()),
@@ -67,7 +67,7 @@ impl ArtefactSelectorInput {
         let path_selector_requested = path.is_some() || self.lines.is_some();
         let selector_count = usize::from(symbol_fqn.is_some())
             + usize::from(fuzzy_name.is_some())
-            + usize::from(semantic_query.is_some())
+            + usize::from(natural_language.is_some())
             + usize::from(path_selector_requested);
         if selector_count == 0 {
             return Err(bad_user_input_error(
@@ -76,7 +76,7 @@ impl ArtefactSelectorInput {
         }
         if selector_count > 1 {
             return Err(bad_user_input_error(
-                "`selectArtefacts(by: ...)` allows exactly one of `symbolFqn`, `fuzzyName`, `semanticQuery`, or `path`/`lines`",
+                "`selectArtefacts(by: ...)` allows exactly one of `symbolFqn`, `fuzzyName`, `naturalLanguage`, or `path`/`lines`",
             ));
         }
         if path_selector_requested && path.is_none() {
@@ -91,8 +91,8 @@ impl ArtefactSelectorInput {
         if let Some(fuzzy_name) = fuzzy_name {
             return Ok(ArtefactSelectorMode::FuzzyName(fuzzy_name));
         }
-        if let Some(semantic_query) = semantic_query {
-            return Ok(ArtefactSelectorMode::SemanticQuery(semantic_query));
+        if let Some(natural_language) = natural_language {
+            return Ok(ArtefactSelectorMode::NaturalLanguage(natural_language));
         }
 
         let path = path.expect("selector_count ensures path selector exists");

--- a/bitloops/src/graphql/types/artefact_selection_tests.rs
+++ b/bitloops/src/graphql/types/artefact_selection_tests.rs
@@ -5,7 +5,7 @@ fn artefact_selector_accepts_symbol_fqn_or_path_modes() {
     let symbol = ArtefactSelectorInput {
         symbol_fqn: Some("src/main.rs::main".to_string()),
         fuzzy_name: None,
-        semantic_query: None,
+        natural_language: None,
         path: None,
         lines: None,
     };
@@ -17,7 +17,7 @@ fn artefact_selector_accepts_symbol_fqn_or_path_modes() {
     let path = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: None,
-        semantic_query: None,
+        natural_language: None,
         path: Some("src/main.rs".to_string()),
         lines: Some(LineRangeInput { start: 20, end: 25 }),
     };
@@ -35,7 +35,7 @@ fn artefact_selector_accepts_fuzzy_name_mode() {
     let fuzzy = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: Some("payLater()".to_string()),
-        semantic_query: None,
+        natural_language: None,
         path: None,
         lines: None,
     };
@@ -47,18 +47,18 @@ fn artefact_selector_accepts_fuzzy_name_mode() {
 }
 
 #[test]
-fn artefact_selector_accepts_semantic_query_mode() {
+fn artefact_selector_accepts_natural_language_mode() {
     let semantic = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: None,
-        semantic_query: Some("find invoice payload builders".to_string()),
+        natural_language: Some("find invoice payload builders".to_string()),
         path: None,
         lines: None,
     };
 
     assert_eq!(
         semantic.selection_mode().expect("semantic selector"),
-        ArtefactSelectorMode::SemanticQuery("find invoice payload builders".to_string())
+        ArtefactSelectorMode::NaturalLanguage("find invoice payload builders".to_string())
     );
 }
 
@@ -67,20 +67,20 @@ fn artefact_selector_rejects_invalid_combinations() {
     let err = ArtefactSelectorInput {
         symbol_fqn: Some("src/main.rs::main".to_string()),
         fuzzy_name: None,
-        semantic_query: None,
+        natural_language: None,
         path: Some("src/main.rs".to_string()),
         lines: None,
     }
     .selection_mode()
     .expect_err("mixed selector should fail");
     assert!(err.message.contains(
-        "allows exactly one of `symbolFqn`, `fuzzyName`, `semanticQuery`, or `path`/`lines`"
+        "allows exactly one of `symbolFqn`, `fuzzyName`, `naturalLanguage`, or `path`/`lines`"
     ));
 
     let err = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: None,
-        semantic_query: None,
+        natural_language: None,
         path: None,
         lines: Some(LineRangeInput { start: 20, end: 25 }),
     }
@@ -94,7 +94,7 @@ fn artefact_selector_rejects_invalid_combinations() {
     let err = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: Some("  ".to_string()),
-        semantic_query: None,
+        natural_language: None,
         path: None,
         lines: None,
     }
@@ -105,46 +105,46 @@ fn artefact_selector_rejects_invalid_combinations() {
     let err = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: Some("payLater".to_string()),
-        semantic_query: None,
+        natural_language: None,
         path: Some("src/main.rs".to_string()),
         lines: None,
     }
     .selection_mode()
     .expect_err("fuzzy selector mixed with path should fail");
     assert!(err.message.contains(
-        "allows exactly one of `symbolFqn`, `fuzzyName`, `semanticQuery`, or `path`/`lines`"
+        "allows exactly one of `symbolFqn`, `fuzzyName`, `naturalLanguage`, or `path`/`lines`"
     ));
 
     let err = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: Some("payLater".to_string()),
-        semantic_query: None,
+        natural_language: None,
         path: None,
         lines: Some(LineRangeInput { start: 20, end: 25 }),
     }
     .selection_mode()
     .expect_err("fuzzy selector mixed with lines should fail");
     assert!(err.message.contains(
-        "allows exactly one of `symbolFqn`, `fuzzyName`, `semanticQuery`, or `path`/`lines`"
+        "allows exactly one of `symbolFqn`, `fuzzyName`, `naturalLanguage`, or `path`/`lines`"
     ));
 
     let err = ArtefactSelectorInput {
         symbol_fqn: Some("src/main.rs::main".to_string()),
         fuzzy_name: None,
-        semantic_query: None,
+        natural_language: None,
         path: None,
         lines: Some(LineRangeInput { start: 20, end: 25 }),
     }
     .selection_mode()
     .expect_err("symbol selector mixed with lines should fail");
     assert!(err.message.contains(
-        "allows exactly one of `symbolFqn`, `fuzzyName`, `semanticQuery`, or `path`/`lines`"
+        "allows exactly one of `symbolFqn`, `fuzzyName`, `naturalLanguage`, or `path`/`lines`"
     ));
 
     let err = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: None,
-        semantic_query: None,
+        natural_language: None,
         path: None,
         lines: None,
     }
@@ -155,24 +155,24 @@ fn artefact_selector_rejects_invalid_combinations() {
     let err = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: None,
-        semantic_query: Some("  ".to_string()),
+        natural_language: Some("  ".to_string()),
         path: None,
         lines: None,
     }
     .selection_mode()
     .expect_err("blank semantic selector should fail");
-    assert!(err.message.contains("non-empty `semanticQuery`"));
+    assert!(err.message.contains("non-empty `naturalLanguage`"));
 
     let err = ArtefactSelectorInput {
         symbol_fqn: None,
         fuzzy_name: None,
-        semantic_query: Some("find invoice builders".to_string()),
+        natural_language: Some("find invoice builders".to_string()),
         path: Some("src/main.rs".to_string()),
         lines: None,
     }
     .selection_mode()
     .expect_err("semantic selector mixed with path should fail");
     assert!(err.message.contains(
-        "allows exactly one of `symbolFqn`, `fuzzyName`, `semanticQuery`, or `path`/`lines`"
+        "allows exactly one of `symbolFqn`, `fuzzyName`, `naturalLanguage`, or `path`/`lines`"
     ));
 }

--- a/bitloops/src/host/hooks/augmentation/devql_guidance.rs
+++ b/bitloops/src/host/hooks/augmentation/devql_guidance.rs
@@ -42,7 +42,7 @@ Use DevQL first for code understanding in this repo.\n\
 Quick-start commands:\n\
 ```bash\n\
 bitloops devql query '{ selectArtefacts(by: { path: \"<repo-relative-path>\" }) { summary } }'\n\
-bitloops devql query '{ selectArtefacts(by: { semanticQuery: \"<natural-language request>\" }) { artefacts(first: 10) { path symbolFqn } } }'\n\
+bitloops devql query '{ selectArtefacts(by: { naturalLanguage: \"<natural-language request>\" }) { artefacts(first: 10) { path symbolFqn } } }'\n\
 bitloops devql query '{ selectArtefacts(by: { fuzzyName: \"<approx-symbol-name>\" }) { artefacts(first: 10) { path symbolFqn } } }'\n\
 bitloops devql query '{ selectArtefacts(by: { symbolFqn: \"<symbol-fqn>\" }) { summary } }'\n\
 bitloops devql schema --global\n\
@@ -78,7 +78,7 @@ mod tests {
 
         let guidance = build_turn_guidance(dir.path(), "Help me find payLatr()");
 
-        assert!(guidance.contains("semanticQuery"));
+        assert!(guidance.contains("naturalLanguage"));
         assert!(guidance.contains("fuzzyName"));
         assert!(guidance.contains("<approx-symbol-name>"));
     }

--- a/bitloops/src/host/hooks/augmentation/skill_content.rs
+++ b/bitloops/src/host/hooks/augmentation/skill_content.rs
@@ -77,7 +77,9 @@ mod tests {
     fn using_devql_skill_explains_selector_routing() {
         let body = using_devql_skill_body();
         assert!(body.contains("Selector Routing"));
-        assert!(body.contains("Do not pass the whole conversational prompt into `naturalLanguage`"));
+        assert!(
+            body.contains("Do not pass the whole conversational prompt into `naturalLanguage`")
+        );
         assert!(body.contains("For mixed prompts, try structured lookup first"));
         assert!(body.contains("help me understand the codebase"));
     }

--- a/bitloops/src/host/hooks/augmentation/skill_content.rs
+++ b/bitloops/src/host/hooks/augmentation/skill_content.rs
@@ -35,17 +35,49 @@ mod tests {
     }
 
     #[test]
-    fn using_devql_skill_mentions_semantic_query_lookup() {
+    fn using_devql_skill_mentions_natural_language_lookup() {
         let body = using_devql_skill_body();
-        assert!(body.contains("semanticQuery"));
+        assert!(body.contains("naturalLanguage"));
         assert!(body.contains("<natural-language request>"));
+    }
+
+    #[test]
+    fn using_devql_skill_requires_summary_for_file_prompts() {
+        let body = using_devql_skill_body();
+        assert!(body.contains("If the input clearly identifies a specific file"));
+        assert!(body.contains("start with `summary`."));
+        assert!(body.contains("Once you have selected a file-level artefact"));
+        assert!(body.contains("continue"));
+        assert!(body.contains("from that summary."));
+    }
+
+    #[test]
+    fn using_devql_skill_requires_natural_language_followed_by_summary() {
+        let body = using_devql_skill_body();
+        assert!(body.contains("If the input is natural language"));
+        assert!(body.contains("always follow with `summary`"));
+        assert!(body.contains("before expanding"));
+        assert!(body.contains("stages."));
+        assert!(body.contains("resolve concrete artefacts/files first"));
+    }
+
+    #[test]
+    fn using_devql_skill_forbids_summary_for_ambiguous_path_only_selectors() {
+        let body = using_devql_skill_body();
+        assert!(body.contains("Do not use `summary` for a `path` selector"));
+        assert!(body.contains("unless the path clearly resolves"));
+        assert!(body.contains("to a specific file."));
+        assert!(body.contains("If a `path` selector may refer to a directory"));
+        assert!(body.contains("another ambiguous scope"));
+        assert!(body.contains("If the path resolves to a directory, use `entries(first: ...)`."));
+        assert!(body.contains("Once you have selected a file-level artefact"));
     }
 
     #[test]
     fn using_devql_skill_explains_selector_routing() {
         let body = using_devql_skill_body();
         assert!(body.contains("Selector Routing"));
-        assert!(body.contains("Do not pass the whole conversational prompt into `semanticQuery`"));
+        assert!(body.contains("Do not pass the whole conversational prompt into `naturalLanguage`"));
         assert!(body.contains("For mixed prompts, try structured lookup first"));
         assert!(body.contains("help me understand the codebase"));
     }

--- a/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
+++ b/bitloops/src/host/hooks/augmentation/skills/using-devql/SKILL.md
@@ -3,7 +3,7 @@ name: using-devql
 description: >
   Use when understanding code structure, resolving artefacts by path or line
   range, resolving approximate symbol names with fuzzy lookup, resolving
-  conceptual requests with semanticQuery, finding
+  conceptual requests with naturalLanguage, finding
   callers/usages/imports/tests/checkpoints/clones/dependencies,
   or answering architecture questions in a repo with DevQL enabled.
 ---
@@ -16,10 +16,21 @@ This repo has DevQL, a semantic code index. For code understanding and repo
 exploration, you MUST use DevQL first before falling back to broad repo search,
 file reads, or directory crawling.
 
-Use `summary` only for first-pass orientation when you do not yet know whether
-the selector matched anything or which stage to expand. If the artefact or
-question is already known, query concrete rows with `artefacts(first: ...)` or
-stage `items(first: ...)`.
+Use `summary` only for first-pass orientation when the selector is already
+known to resolve to a concrete file-level artefact and you do not yet know
+whether the selector matched anything or which stage to expand.
+
+- If the input clearly identifies a specific file, start with `summary`.
+- Do not use `summary` for a `path` selector unless the path clearly resolves
+  to a specific file.
+- If a `path` selector may refer to a directory or another ambiguous scope,
+  inspect what it is first.
+- If the path resolves to a directory, use `entries(first: ...)`.
+- Once you have selected a file-level artefact, run `summary` and continue
+  from that summary.
+- If the input is natural language, resolve concrete artefacts/files first
+  with `naturalLanguage`, then always follow with `summary` before expanding
+  stages.
 
 If DevQL returns no useful artefacts or stage rows, fall back to targeted repo
 search or file reads.
@@ -35,28 +46,31 @@ search or file reads.
 
 ## Agent Flow
 
-1. Select the target with `symbolFqn`, `fuzzyName`, `semanticQuery`, `path`, or `path + lines`.
-   Use `semanticQuery` when the request is conceptual rather than tied to a known file or symbol.
-2. Ask for `summary` only if you need orientation or to discover which stage to expand.
-3. Rerun with `artefacts(first: ...)` or the relevant stage `items(first: ...)`.
-4. Return the concrete rows. Summaries are optional follow-up, not substitutes.
+1. Select the target with `symbolFqn`, `fuzzyName`, `naturalLanguage`, `path`, or `path + lines`.
+   Use `naturalLanguage` as the natural-language selector when the request is conceptual rather than tied to a known file or symbol.
+2. Apply the `Prime Directive` summary rules to decide whether to start with `summary` or resolve concrete artefacts first.
+3. Rerun with `artefacts(first: ...)` or the relevant stage `items(first: ...)` only after `summary` or selector resolution tells you where to drill in.
+4. Return the concrete rows. Summaries guide drill-down; they do not replace concrete rows.
 5. If DevQL returns nothing useful, fall back to targeted repo search or file reads.
 
 ## Selector Routing
 
 - If the prompt contains a path, line range, scoped symbol, backticked identifier, function-like token, or other code-ish artefact clue, prefer a structured selector first.
 - Use `path` or `path + lines` for file references, `symbolFqn` for exact symbol references, and `fuzzyName` when the user likely named a symbol approximately or misspelled it.
-- Use `semanticQuery` for conceptual behaviour or responsibility queries such as `build invoice pdf`, `validate webhook signature`, or `render checkout summary`.
-- Do not pass the whole conversational prompt into `semanticQuery` when it contains extra wrapper text such as `can you help`, `fix this`, or `help me understand the codebase`.
+- Use `entries(first: ...)` for directory paths. Do not use `summary` on a directory path.
+- Use `naturalLanguage` for natural-language behaviour or responsibility queries such as `build invoice pdf`, `validate webhook signature`, or `render checkout summary`.
+- Do not pass the whole conversational prompt into `naturalLanguage` when it contains extra wrapper text such as `can you help`, `fix this`, or `help me understand the codebase`.
 - Distill semantic lookup into a short intent phrase instead of removing stopwords mechanically. Preserve meaningful qualifiers and drop conversational filler.
-- For mixed prompts, try structured lookup first and use `semanticQuery` as a fallback or supplement when the artefact clue is weak.
+- For mixed prompts, try structured lookup first and use `naturalLanguage` as a fallback or supplement when the artefact clue is weak.
+- After `naturalLanguage` resolves concrete artefacts/files, always follow with `summary` before drilling into `clones`, `deps`, `tests`, or `checkpoints`.
 
 Examples:
 
 - `renderInvoicePdf is broken` -> prefer `fuzzyName` or `symbolFqn`
 - `src/payments/invoice.ts:42` -> prefer `path + lines`
-- `find the code that builds invoice PDFs` -> prefer `semanticQuery`
-- `help me understand the codebase` -> do not use `semanticQuery` first; start with scoped `summary` or a concrete project/file selector
+- `src/payments` -> prefer `entries(first: ...)`, not `summary`
+- `find the code that builds invoice PDFs` -> prefer `naturalLanguage`
+- `help me understand the codebase` -> do not use `naturalLanguage` first; start with scoped `summary` or a concrete project/file selector
 
 ## Sandbox Execution
 
@@ -68,7 +82,10 @@ Examples:
 
 ```bash
 # Orientation only
-bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-path>" }) { summary } }'
+bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-file-path>" }) { summary } }'
+
+# Inspect a directory path before selecting a file-level artefact
+bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-directory-path>" }) { entries(first: 20) { path name entryKind } } }'
 
 # Concrete artefacts for a known file or line range
 bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-path>", lines: { start: <start>, end: <end> } }) { artefacts(first: 20) { path symbolFqn canonicalKind startLine endLine } } }'
@@ -76,8 +93,11 @@ bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-path>", line
 # Fuzzy lookup when the symbol name is approximate or may be misspelled
 bitloops devql query '{ selectArtefacts(by: { fuzzyName: "<approx-symbol-name>" }) { artefacts(first: 10) { path symbolFqn canonicalKind startLine endLine } } }'
 
-# Semantic lookup for free-form conceptual requests
-bitloops devql query '{ selectArtefacts(by: { semanticQuery: "<natural-language request>" }) { artefacts(first: 10) { path symbolFqn canonicalKind startLine endLine } } }'
+# Natural-language lookup for free-form conceptual requests
+bitloops devql query '{ selectArtefacts(by: { naturalLanguage: "<natural-language request>" }) { artefacts(first: 10) { path symbolFqn canonicalKind startLine endLine } } }'
+
+# After natural-language lookup resolves files/artefacts, follow with summary
+bitloops devql query '{ selectArtefacts(by: { path: "<repo-relative-path>" }) { summary } }'
 
 # Concrete callers/usages/imports once the symbol is known
 bitloops devql query '{ selectArtefacts(by: { symbolFqn: "<symbol-fqn>" }) { deps(kind: CALLS, direction: IN, includeUnresolved: true) { items(first: 50) { edgeKind startLine endLine fromArtefact { symbolFqn path startLine endLine } toArtefact { symbolFqn path startLine endLine } toSymbolRef } } } }'

--- a/documentation/docs/concepts/devql.md
+++ b/documentation/docs/concepts/devql.md
@@ -62,7 +62,7 @@ The slim, repo-scoped GraphQL surface also exposes a selection-oriented entry po
 
 - `symbolFqn`
 - `fuzzyName`
-- `semanticQuery`
+- `naturalLanguage`
 - `path`
 - `path` plus `lines`
 

--- a/documentation/docs/guides/select-artefacts.md
+++ b/documentation/docs/guides/select-artefacts.md
@@ -60,11 +60,11 @@ This usually resolves to `0..1` logical artefacts, but callers should treat the 
 
 This searches current artefacts in scope by normalized symbol name, including typo-tolerant matches such as `payLater()` or `payLatr()`. v1 returns up to 10 best-first matches and does not expose scores in the API.
 
-### By `semanticQuery`
+### By `naturalLanguage`
 
 ```graphql
 {
-  selectArtefacts(by: { semanticQuery: "find the artefacts that build invoice PDFs" }) {
+  selectArtefacts(by: { naturalLanguage: "find the artefacts that build invoice PDFs" }) {
     count
     artefacts {
       path
@@ -112,11 +112,11 @@ This resolves all current artefacts in the file.
 
 ## Validation Rules
 
-- `symbolFqn` cannot be combined with `fuzzyName`, `semanticQuery`, `path`, or `lines`
-- `fuzzyName` cannot be combined with `symbolFqn`, `semanticQuery`, `path`, or `lines`
+- `symbolFqn` cannot be combined with `fuzzyName`, `naturalLanguage`, `path`, or `lines`
+- `fuzzyName` cannot be combined with `symbolFqn`, `naturalLanguage`, `path`, or `lines`
 - `fuzzyName` must be non-empty
-- `semanticQuery` cannot be combined with `symbolFqn`, `fuzzyName`, `path`, or `lines`
-- `semanticQuery` must be non-empty
+- `naturalLanguage` cannot be combined with `symbolFqn`, `fuzzyName`, `path`, or `lines`
+- `naturalLanguage` must be non-empty
 - `lines` requires `path`
 - empty selectors are rejected
 - selector paths are resolved relative to the slim request scope, including project-scoped slim requests


### PR DESCRIPTION
## Summary

- updated the shared `using-devql` skill so agents follow a clearer selector flow:
  - specific file inputs go straight to `summary`
  - directory or ambiguous `path` inputs do not use `summary`; they inspect with `entries(first: ...)` first
  - natural-language inputs use `naturalLanguage`, then always follow with `summary` before expanding stages
- renamed the public `selectArtefacts(by: ...)` selector field from `semanticQuery` to `naturalLanguage` across the live GraphQL path, schema, tests, docs, and agent guidance
- removed duplicated summary-exception guidance from the skill and folded the rule into the main bullets/examples so the behavior is taught once, more concretely

## Test Plan

- `cargo test artefact_selector --lib`
- `cargo test using_devql_skill --lib`
- `cargo test semantic_query_setup_mismatch_returns_user_facing_error --lib`
- `cargo test devql_sdl_route_returns_schema_text`
- `cargo test slim_select_artefacts_resolves_semantic_query_selection_in_repo_scope`
- `cargo test checked_in_slim_schema_file_matches_runtime_sdl`

## Validation

- [ ] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

