### PR TITLE
Inject DevQL turn guidance for OpenCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ docs/superpowers/specs/*
 
 # Temporary add due to bitloops generating hooks there instead of /.git/hooks
 .githooks/
+.agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenCode now receives prompt-time DevQL guidance through its plugin message transform**: the generated OpenCode plugin now tracks the latest user prompt via `chat.message` and injects the shared turn-level DevQL guidance into that latest user message through `experimental.chat.messages.transform`, while keeping hook stdout augmentation disabled for OpenCode. This aligns OpenCode with the Codex and Claude DevQL reinforcement path without using system-prompt transforms.
+
 ## [0.0.19] - 2026-04-24
 
 ### Added

--- a/bitloops/src/adapters/agents/open_code/hooks.rs
+++ b/bitloops/src/adapters/agents/open_code/hooks.rs
@@ -117,15 +117,13 @@ mod tests {
             return;
         }
 
-        if !bootstrap_context.is_empty() {
-            if let Some(first_user) = messages
+        if !bootstrap_context.is_empty()
+            && let Some(first_user) = messages
                 .iter_mut()
                 .find(|message| message.role == "user" && !message.parts.is_empty())
-            {
-                if !has_text_part_containing(first_user, "EXTREMELY_IMPORTANT") {
-                    first_user.parts.insert(0, bootstrap_context);
-                }
-            }
+            && !has_text_part_containing(first_user, "EXTREMELY_IMPORTANT")
+        {
+            first_user.parts.insert(0, bootstrap_context);
         }
 
         let Some(latest_user_message_id) = latest_user_message_id else {

--- a/bitloops/src/adapters/agents/open_code/hooks.rs
+++ b/bitloops/src/adapters/agents/open_code/hooks.rs
@@ -5,7 +5,7 @@ use serde_json::to_string;
 
 use super::plugin::{
     BITLOOPS_CMD_PLACEHOLDER, BOOTSTRAP_CONTEXT_PLACEHOLDER, PLUGIN_TEMPLATE,
-    session_bootstrap_text,
+    TURN_GUIDANCE_CONTEXT_PLACEHOLDER, session_bootstrap_text, turn_guidance_text,
 };
 
 pub const PLUGIN_FILE_NAME: &str = "bitloops.ts";
@@ -30,6 +30,11 @@ pub fn render_plugin_template(repo_root: &Path, local_dev: bool) -> Result<Strin
             "plugin template missing bootstrap context placeholder"
         ));
     }
+    if !PLUGIN_TEMPLATE.contains(TURN_GUIDANCE_CONTEXT_PLACEHOLDER) {
+        return Err(anyhow!(
+            "plugin template missing turn guidance context placeholder"
+        ));
+    }
 
     let bitloops_cmd = if local_dev {
         "cargo run --"
@@ -39,10 +44,13 @@ pub fn render_plugin_template(repo_root: &Path, local_dev: bool) -> Result<Strin
 
     let bootstrap_context = to_string(&session_bootstrap_text(repo_root))
         .map_err(|err| anyhow!("failed to serialize bootstrap context: {err}"))?;
+    let turn_guidance_context = to_string(&turn_guidance_text(repo_root))
+        .map_err(|err| anyhow!("failed to serialize turn guidance context: {err}"))?;
 
     Ok(PLUGIN_TEMPLATE
         .replace(BITLOOPS_CMD_PLACEHOLDER, bitloops_cmd)
-        .replace(BOOTSTRAP_CONTEXT_PLACEHOLDER, &bootstrap_context))
+        .replace(BOOTSTRAP_CONTEXT_PLACEHOLDER, &bootstrap_context)
+        .replace(TURN_GUIDANCE_CONTEXT_PLACEHOLDER, &turn_guidance_context))
 }
 
 #[cfg(test)]
@@ -51,9 +59,103 @@ mod tests {
     use crate::adapters::agents::open_code::skills::{
         OPEN_CODE_SKILL_RELATIVE_PATH, install_repo_skill,
     };
+    use crate::host::hooks::augmentation::devql_guidance::prompt_warrants_devql;
+
+    struct RenderedMessage {
+        id: String,
+        role: String,
+        parts: Vec<String>,
+    }
 
     fn write_repo_policy(dir: &tempfile::TempDir, body: &str) {
         std::fs::write(dir.path().join(".bitloops.toml"), body).expect("write repo policy");
+    }
+
+    fn rendered_message(id: &str, role: &str, parts: &[&str]) -> RenderedMessage {
+        RenderedMessage {
+            id: id.to_string(),
+            role: role.to_string(),
+            parts: parts.iter().map(|part| part.to_string()).collect(),
+        }
+    }
+
+    fn rendered_const(rendered: &str, name: &str) -> String {
+        let prefix = format!("const {name} = ");
+        let line = rendered
+            .lines()
+            .find_map(|line| line.trim_start().strip_prefix(&prefix))
+            .unwrap_or_else(|| panic!("rendered plugin should contain {name}"));
+
+        serde_json::from_str(line).unwrap_or_else(|err| panic!("failed to parse {name}: {err}"))
+    }
+
+    fn text_from_parts(parts: &[String]) -> String {
+        parts.join("\n")
+    }
+
+    fn count_parts_containing(message: &RenderedMessage, marker: &str) -> usize {
+        message
+            .parts
+            .iter()
+            .filter(|part| part.contains(marker))
+            .count()
+    }
+
+    fn has_text_part_containing(message: &RenderedMessage, marker: &str) -> bool {
+        count_parts_containing(message, marker) > 0
+    }
+
+    fn apply_rendered_transform(
+        rendered: &str,
+        latest_user_message_id: Option<&str>,
+        latest_user_prompt: Option<&str>,
+        messages: &mut [RenderedMessage],
+    ) {
+        let bootstrap_context = rendered_const(rendered, "BOOTSTRAP_CONTEXT");
+        let turn_guidance_context = rendered_const(rendered, "TURN_GUIDANCE_CONTEXT");
+        if bootstrap_context.is_empty() && turn_guidance_context.is_empty() {
+            return;
+        }
+
+        if !bootstrap_context.is_empty() {
+            if let Some(first_user) = messages
+                .iter_mut()
+                .find(|message| message.role == "user" && !message.parts.is_empty())
+            {
+                if !has_text_part_containing(first_user, "EXTREMELY_IMPORTANT") {
+                    first_user.parts.insert(0, bootstrap_context);
+                }
+            }
+        }
+
+        let Some(latest_user_message_id) = latest_user_message_id else {
+            return;
+        };
+        if turn_guidance_context.is_empty() {
+            return;
+        }
+
+        let Some(latest_user) = messages.iter_mut().find(|message| {
+            message.id == latest_user_message_id
+                && message.role == "user"
+                && !message.parts.is_empty()
+        }) else {
+            return;
+        };
+        let prompt = latest_user_prompt
+            .map(ToString::to_string)
+            .unwrap_or_else(|| text_from_parts(&latest_user.parts));
+        if !prompt_warrants_devql(&prompt) {
+            return;
+        }
+
+        let marker = turn_guidance_context
+            .split(" when ")
+            .next()
+            .unwrap_or(&turn_guidance_context);
+        if !has_text_part_containing(latest_user, marker) {
+            latest_user.parts.insert(0, turn_guidance_context);
+        }
     }
 
     #[test]
@@ -112,6 +214,16 @@ enabled = true
             rendered.contains("await Bun.file(repoSkillPath).exists()"),
             "plugin should re-check skill presence before injecting bootstrap text"
         );
+        assert!(rendered.contains(
+            r#"const TURN_GUIDANCE_CONTEXT = "Use DevQL first for this repo-aware request"#
+        ));
+        assert!(rendered.contains("const latestUserPromptByMessageID = new Map<string, string>()"));
+        assert!(rendered.contains("\"chat.message\": async"));
+        assert!(rendered.contains("promptWarrantsDevql(prompt)"));
+        assert!(rendered.contains(
+            "latestUser.parts.unshift({ ...ref, type: \"text\", text: TURN_GUIDANCE_CONTEXT })"
+        ));
+        assert!(!rendered.contains("\"experimental.chat.system.transform\""));
     }
 
     #[test]
@@ -131,8 +243,10 @@ devql_guidance_enabled = false
 
         assert!(rendered.contains(r#"const BITLOOPS_CMD = "bitloops""#));
         assert!(rendered.contains(r#"const BOOTSTRAP_CONTEXT = ""#));
+        assert!(rendered.contains(r#"const TURN_GUIDANCE_CONTEXT = ""#));
         assert!(!rendered.contains(OPEN_CODE_SKILL_RELATIVE_PATH));
         assert!(!rendered.contains("DevQL-capable guidance surface"));
+        assert!(!rendered.contains("Use DevQL first for this repo-aware request"));
         assert!(!rendered.contains("<EXTREMELY_IMPORTANT>"));
     }
 
@@ -142,5 +256,126 @@ devql_guidance_enabled = false
         let rendered = render_plugin_template(dir.path(), true).expect("render should succeed");
 
         assert!(rendered.contains(r#"const BITLOOPS_CMD = "cargo run --""#));
+    }
+
+    #[test]
+    fn render_plugin_template_transform_injects_bootstrap_and_turn_guidance_by_message_role() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_repo_policy(
+            &dir,
+            r#"
+[capture]
+enabled = true
+"#,
+        );
+        install_repo_skill(dir.path()).expect("install skill");
+        let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
+
+        let mut messages = vec![
+            rendered_message("first-user", "user", &["Initial request"]),
+            rendered_message("assistant", "assistant", &["Assistant response"]),
+            rendered_message(
+                "latest-user",
+                "user",
+                &["Explain src/adapters/agents/open_code/plugin.rs"],
+            ),
+        ];
+
+        apply_rendered_transform(
+            &rendered,
+            Some("latest-user"),
+            Some("Explain src/adapters/agents/open_code/plugin.rs"),
+            &mut messages,
+        );
+        apply_rendered_transform(
+            &rendered,
+            Some("latest-user"),
+            Some("Explain src/adapters/agents/open_code/plugin.rs"),
+            &mut messages,
+        );
+
+        assert_eq!(
+            count_parts_containing(&messages[0], "EXTREMELY_IMPORTANT"),
+            1
+        );
+        assert_eq!(
+            count_parts_containing(&messages[2], "Use DevQL first for this repo-aware request"),
+            1
+        );
+        assert_eq!(
+            count_parts_containing(&messages[0], "Use DevQL first for this repo-aware request"),
+            0
+        );
+        assert_eq!(
+            count_parts_containing(&messages[2], "EXTREMELY_IMPORTANT"),
+            0
+        );
+    }
+
+    #[test]
+    fn render_plugin_template_transform_skips_turn_guidance_for_execution_prompts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_repo_policy(
+            &dir,
+            r#"
+[capture]
+enabled = true
+"#,
+        );
+        install_repo_skill(dir.path()).expect("install skill");
+        let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
+
+        let mut messages = vec![
+            rendered_message("first-user", "user", &["Initial request"]),
+            rendered_message("latest-user", "user", &["Run cargo fmt"]),
+        ];
+
+        apply_rendered_transform(
+            &rendered,
+            Some("latest-user"),
+            Some("Run cargo fmt"),
+            &mut messages,
+        );
+
+        assert_eq!(
+            count_parts_containing(&messages[0], "EXTREMELY_IMPORTANT"),
+            1
+        );
+        assert_eq!(
+            count_parts_containing(&messages[1], "Use DevQL first for this repo-aware request"),
+            0
+        );
+    }
+
+    #[test]
+    fn render_plugin_template_transform_disabled_guidance_injects_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_repo_policy(
+            &dir,
+            r#"
+[agents]
+supported = ["opencode"]
+devql_guidance_enabled = false
+"#,
+        );
+        install_repo_skill(dir.path()).expect("install skill");
+        let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
+        assert_eq!(rendered_const(&rendered, "BOOTSTRAP_CONTEXT"), "");
+        assert_eq!(rendered_const(&rendered, "TURN_GUIDANCE_CONTEXT"), "");
+
+        let mut messages = vec![
+            rendered_message("first-user", "user", &["Initial request"]),
+            rendered_message("latest-user", "user", &["Explain src/lib.rs"]),
+        ];
+
+        apply_rendered_transform(
+            &rendered,
+            Some("latest-user"),
+            Some("Explain src/lib.rs"),
+            &mut messages,
+        );
+
+        assert_eq!(messages[0].parts, vec!["Initial request"]);
+        assert_eq!(messages[1].parts, vec!["Explain src/lib.rs"]);
     }
 }

--- a/bitloops/src/adapters/agents/open_code/hooks.rs
+++ b/bitloops/src/adapters/agents/open_code/hooks.rs
@@ -3,9 +3,15 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, anyhow};
 use serde_json::to_string;
 
+use crate::host::hooks::augmentation::devql_guidance::{
+    DEVQL_CODE_REFERENCE_MARKERS, DEVQL_EXECUTION_TERMS, DEVQL_REPO_UNDERSTANDING_TERMS,
+};
+
 use super::plugin::{
-    BITLOOPS_CMD_PLACEHOLDER, BOOTSTRAP_CONTEXT_PLACEHOLDER, PLUGIN_TEMPLATE,
-    TURN_GUIDANCE_CONTEXT_PLACEHOLDER, session_bootstrap_text, turn_guidance_text,
+    BITLOOPS_CMD_PLACEHOLDER, BOOTSTRAP_CONTEXT_PLACEHOLDER,
+    DEVQL_CODE_REFERENCE_MARKERS_PLACEHOLDER, DEVQL_EXECUTION_TERMS_PLACEHOLDER,
+    DEVQL_REPO_UNDERSTANDING_TERMS_PLACEHOLDER, PLUGIN_TEMPLATE, TURN_GUIDANCE_CONTEXT_PLACEHOLDER,
+    session_bootstrap_text, turn_guidance_text,
 };
 
 pub const PLUGIN_FILE_NAME: &str = "bitloops.ts";
@@ -35,6 +41,21 @@ pub fn render_plugin_template(repo_root: &Path, local_dev: bool) -> Result<Strin
             "plugin template missing turn guidance context placeholder"
         ));
     }
+    if !PLUGIN_TEMPLATE.contains(DEVQL_REPO_UNDERSTANDING_TERMS_PLACEHOLDER) {
+        return Err(anyhow!(
+            "plugin template missing DevQL repo-understanding terms placeholder"
+        ));
+    }
+    if !PLUGIN_TEMPLATE.contains(DEVQL_EXECUTION_TERMS_PLACEHOLDER) {
+        return Err(anyhow!(
+            "plugin template missing DevQL execution terms placeholder"
+        ));
+    }
+    if !PLUGIN_TEMPLATE.contains(DEVQL_CODE_REFERENCE_MARKERS_PLACEHOLDER) {
+        return Err(anyhow!(
+            "plugin template missing DevQL code-reference markers placeholder"
+        ));
+    }
 
     let bitloops_cmd = if local_dev {
         "cargo run --"
@@ -46,11 +67,26 @@ pub fn render_plugin_template(repo_root: &Path, local_dev: bool) -> Result<Strin
         .map_err(|err| anyhow!("failed to serialize bootstrap context: {err}"))?;
     let turn_guidance_context = to_string(&turn_guidance_text(repo_root))
         .map_err(|err| anyhow!("failed to serialize turn guidance context: {err}"))?;
+    let repo_understanding_terms = to_string(DEVQL_REPO_UNDERSTANDING_TERMS)
+        .map_err(|err| anyhow!("failed to serialize DevQL repo-understanding terms: {err}"))?;
+    let execution_terms = to_string(DEVQL_EXECUTION_TERMS)
+        .map_err(|err| anyhow!("failed to serialize DevQL execution terms: {err}"))?;
+    let code_reference_markers = to_string(DEVQL_CODE_REFERENCE_MARKERS)
+        .map_err(|err| anyhow!("failed to serialize DevQL code-reference markers: {err}"))?;
 
     Ok(PLUGIN_TEMPLATE
         .replace(BITLOOPS_CMD_PLACEHOLDER, bitloops_cmd)
         .replace(BOOTSTRAP_CONTEXT_PLACEHOLDER, &bootstrap_context)
-        .replace(TURN_GUIDANCE_CONTEXT_PLACEHOLDER, &turn_guidance_context))
+        .replace(TURN_GUIDANCE_CONTEXT_PLACEHOLDER, &turn_guidance_context)
+        .replace(
+            DEVQL_REPO_UNDERSTANDING_TERMS_PLACEHOLDER,
+            &repo_understanding_terms,
+        )
+        .replace(DEVQL_EXECUTION_TERMS_PLACEHOLDER, &execution_terms)
+        .replace(
+            DEVQL_CODE_REFERENCE_MARKERS_PLACEHOLDER,
+            &code_reference_markers,
+        ))
 }
 
 #[cfg(test)]
@@ -87,6 +123,20 @@ mod tests {
             .unwrap_or_else(|| panic!("rendered plugin should contain {name}"));
 
         serde_json::from_str(line).unwrap_or_else(|err| panic!("failed to parse {name}: {err}"))
+    }
+
+    fn rendered_string_array(rendered: &str, name: &str) -> Vec<String> {
+        let prefix = format!("const {name} = ");
+        let line = rendered
+            .lines()
+            .find_map(|line| line.trim_start().strip_prefix(&prefix))
+            .unwrap_or_else(|| panic!("rendered plugin should contain {name}"));
+
+        serde_json::from_str(line).unwrap_or_else(|err| panic!("failed to parse {name}: {err}"))
+    }
+
+    fn expected_string_array(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
     }
 
     fn text_from_parts(parts: &[String]) -> String {
@@ -212,9 +262,12 @@ enabled = true
             rendered.contains("await Bun.file(repoSkillPath).exists()"),
             "plugin should re-check skill presence before injecting bootstrap text"
         );
-        assert!(rendered.contains(
-            r#"const TURN_GUIDANCE_CONTEXT = "Use DevQL first for this repo-aware request"#
-        ));
+        let turn_guidance_context = rendered_const(&rendered, "TURN_GUIDANCE_CONTEXT");
+        assert!(!turn_guidance_context.is_empty());
+        assert!(turn_guidance_context.contains(OPEN_CODE_SKILL_RELATIVE_PATH));
+        assert!(turn_guidance_context.contains("searchMode: LEXICAL"));
+        assert!(turn_guidance_context.contains("overview"));
+        assert!(turn_guidance_context.contains("fall back to targeted repo search or file reads"));
         assert!(rendered.contains("const latestUserPromptByMessageID = new Map<string, string>()"));
         assert!(rendered.contains("\"chat.message\": async"));
         assert!(rendered.contains("promptWarrantsDevql(prompt)"));
@@ -222,6 +275,25 @@ enabled = true
             "latestUser.parts.unshift({ ...ref, type: \"text\", text: TURN_GUIDANCE_CONTEXT })"
         ));
         assert!(!rendered.contains("\"experimental.chat.system.transform\""));
+    }
+
+    #[test]
+    fn render_plugin_template_uses_rust_devql_prompt_heuristic_terms() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
+
+        assert_eq!(
+            rendered_string_array(&rendered, "DEVQL_REPO_UNDERSTANDING_TERMS"),
+            expected_string_array(DEVQL_REPO_UNDERSTANDING_TERMS)
+        );
+        assert_eq!(
+            rendered_string_array(&rendered, "DEVQL_EXECUTION_TERMS"),
+            expected_string_array(DEVQL_EXECUTION_TERMS)
+        );
+        assert_eq!(
+            rendered_string_array(&rendered, "DEVQL_CODE_REFERENCE_MARKERS"),
+            expected_string_array(DEVQL_CODE_REFERENCE_MARKERS)
+        );
     }
 
     #[test]
@@ -240,11 +312,10 @@ devql_guidance_enabled = false
         let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
 
         assert!(rendered.contains(r#"const BITLOOPS_CMD = "bitloops""#));
-        assert!(rendered.contains(r#"const BOOTSTRAP_CONTEXT = ""#));
-        assert!(rendered.contains(r#"const TURN_GUIDANCE_CONTEXT = ""#));
+        assert_eq!(rendered_const(&rendered, "BOOTSTRAP_CONTEXT"), "");
+        assert_eq!(rendered_const(&rendered, "TURN_GUIDANCE_CONTEXT"), "");
         assert!(!rendered.contains(OPEN_CODE_SKILL_RELATIVE_PATH));
         assert!(!rendered.contains("DevQL-capable guidance surface"));
-        assert!(!rendered.contains("Use DevQL first for this repo-aware request"));
         assert!(!rendered.contains("<EXTREMELY_IMPORTANT>"));
     }
 
@@ -268,6 +339,11 @@ enabled = true
         );
         install_repo_skill(dir.path()).expect("install skill");
         let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
+        let turn_guidance_context = rendered_const(&rendered, "TURN_GUIDANCE_CONTEXT");
+        let turn_guidance_marker = turn_guidance_context
+            .split(" when ")
+            .next()
+            .expect("turn guidance should have marker");
 
         let mut messages = vec![
             rendered_message("first-user", "user", &["Initial request"]),
@@ -297,11 +373,11 @@ enabled = true
             1
         );
         assert_eq!(
-            count_parts_containing(&messages[2], "Use DevQL first for this repo-aware request"),
+            count_parts_containing(&messages[2], turn_guidance_marker),
             1
         );
         assert_eq!(
-            count_parts_containing(&messages[0], "Use DevQL first for this repo-aware request"),
+            count_parts_containing(&messages[0], turn_guidance_marker),
             0
         );
         assert_eq!(
@@ -322,6 +398,7 @@ enabled = true
         );
         install_repo_skill(dir.path()).expect("install skill");
         let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
+        let turn_guidance_context = rendered_const(&rendered, "TURN_GUIDANCE_CONTEXT");
 
         let mut messages = vec![
             rendered_message("first-user", "user", &["Initial request"]),
@@ -340,7 +417,7 @@ enabled = true
             1
         );
         assert_eq!(
-            count_parts_containing(&messages[1], "Use DevQL first for this repo-aware request"),
+            count_parts_containing(&messages[1], &turn_guidance_context),
             0
         );
     }

--- a/bitloops/src/adapters/agents/open_code/plugin.rs
+++ b/bitloops/src/adapters/agents/open_code/plugin.rs
@@ -9,6 +9,9 @@ use crate::host::hooks::augmentation::prompt_surface_presence::installed_prompt_
 pub const BITLOOPS_CMD_PLACEHOLDER: &str = "__BITLOOPS_CMD__";
 pub const BOOTSTRAP_CONTEXT_PLACEHOLDER: &str = "__BOOTSTRAP_CONTEXT__";
 pub const TURN_GUIDANCE_CONTEXT_PLACEHOLDER: &str = "__TURN_GUIDANCE_CONTEXT__";
+pub const DEVQL_REPO_UNDERSTANDING_TERMS_PLACEHOLDER: &str = "__DEVQL_REPO_UNDERSTANDING_TERMS__";
+pub const DEVQL_EXECUTION_TERMS_PLACEHOLDER: &str = "__DEVQL_EXECUTION_TERMS__";
+pub const DEVQL_CODE_REFERENCE_MARKERS_PLACEHOLDER: &str = "__DEVQL_CODE_REFERENCE_MARKERS__";
 
 pub(crate) fn session_bootstrap_text(repo_root: &Path) -> String {
     let Some(surface_path) =
@@ -42,6 +45,9 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
   const BITLOOPS_CMD = "__BITLOOPS_CMD__"
   const BOOTSTRAP_CONTEXT = __BOOTSTRAP_CONTEXT__
   const TURN_GUIDANCE_CONTEXT = __TURN_GUIDANCE_CONTEXT__
+  const DEVQL_REPO_UNDERSTANDING_TERMS = __DEVQL_REPO_UNDERSTANDING_TERMS__
+  const DEVQL_EXECUTION_TERMS = __DEVQL_EXECUTION_TERMS__
+  const DEVQL_CODE_REFERENCE_MARKERS = __DEVQL_CODE_REFERENCE_MARKERS__
   // Store transcripts in a temp directory - these are ephemeral handoff files
   // between the plugin and the hook handler. Once checkpointed, the data
   // lives on git refs and the file is disposable.
@@ -88,37 +94,9 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
   /** Decide whether a user prompt is repo-aware understanding work. */
   function promptWarrantsDevql(prompt: string): boolean {
     const lower = prompt.toLowerCase()
-    const repoUnderstandingTerms = [
-      "what does this repo do",
-      "understand",
-      "explain",
-      "architecture",
-      "where is",
-      "find",
-      "inspect",
-      "caller",
-      "usage",
-      "import",
-      "dependency",
-      "test covering",
-    ]
-    const executionTerms = [
-      "fix ",
-      "implement ",
-      "edit ",
-      "write ",
-      "run ",
-      "build ",
-      "test ",
-      "format ",
-    ]
-    const looksLikeCodeReference =
-      prompt.includes("/") ||
-      prompt.includes("::") ||
-      prompt.includes("`") ||
-      prompt.includes(":")
-    const looksLikeEditOrExecution = executionTerms.some((needle) => lower.includes(needle))
-    const looksLikeRepoUnderstanding = repoUnderstandingTerms.some((needle) => lower.includes(needle))
+    const looksLikeCodeReference = DEVQL_CODE_REFERENCE_MARKERS.some((needle) => prompt.includes(needle))
+    const looksLikeEditOrExecution = DEVQL_EXECUTION_TERMS.some((needle) => lower.includes(needle))
+    const looksLikeRepoUnderstanding = DEVQL_REPO_UNDERSTANDING_TERMS.some((needle) => lower.includes(needle))
 
     return (looksLikeCodeReference || looksLikeRepoUnderstanding) && !looksLikeEditOrExecution
   }

--- a/bitloops/src/adapters/agents/open_code/plugin.rs
+++ b/bitloops/src/adapters/agents/open_code/plugin.rs
@@ -1,11 +1,14 @@
 use std::path::Path;
 
 use crate::adapters::agents::AGENT_NAME_OPEN_CODE;
-use crate::host::hooks::augmentation::devql_guidance::build_session_bootstrap;
+use crate::host::hooks::augmentation::devql_guidance::{
+    build_session_bootstrap, build_turn_guidance,
+};
 use crate::host::hooks::augmentation::prompt_surface_presence::installed_prompt_surface_relative_path;
 
 pub const BITLOOPS_CMD_PLACEHOLDER: &str = "__BITLOOPS_CMD__";
 pub const BOOTSTRAP_CONTEXT_PLACEHOLDER: &str = "__BOOTSTRAP_CONTEXT__";
+pub const TURN_GUIDANCE_CONTEXT_PLACEHOLDER: &str = "__TURN_GUIDANCE_CONTEXT__";
 
 pub(crate) fn session_bootstrap_text(repo_root: &Path) -> String {
     let Some(surface_path) =
@@ -15,6 +18,16 @@ pub(crate) fn session_bootstrap_text(repo_root: &Path) -> String {
     };
 
     build_session_bootstrap(surface_path)
+}
+
+pub(crate) fn turn_guidance_text(repo_root: &Path) -> String {
+    let Some(surface_path) =
+        installed_prompt_surface_relative_path(repo_root, AGENT_NAME_OPEN_CODE)
+    else {
+        return String::new();
+    };
+
+    build_turn_guidance(surface_path)
 }
 
 pub const PLUGIN_TEMPLATE: &str = r##"// Bitloops CLI plugin for OpenCode
@@ -28,12 +41,15 @@ import path from "node:path"
 export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
   const BITLOOPS_CMD = "__BITLOOPS_CMD__"
   const BOOTSTRAP_CONTEXT = __BOOTSTRAP_CONTEXT__
+  const TURN_GUIDANCE_CONTEXT = __TURN_GUIDANCE_CONTEXT__
   // Store transcripts in a temp directory - these are ephemeral handoff files
   // between the plugin and the hook handler. Once checkpointed, the data
   // lives on git refs and the file is disposable.
   const sanitized = directory.replace(/[^a-zA-Z0-9]/g, "-")
   const transcriptDir = `${tmpdir()}/bitloops-opencode/${sanitized}`
   const seenUserMessages = new Set<string>()
+  const latestUserPromptByMessageID = new Map<string, string>()
+  let latestUserMessageID: string | null = null
 
   // In-memory stores - used to write transcripts without relying on the SDK API,
   // which may be unavailable during shutdown.
@@ -67,6 +83,51 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
       .filter((p: any) => p.type === "text")
       .map((p: any) => p.text ?? "")
       .join("\n")
+  }
+
+  /** Decide whether a user prompt is repo-aware understanding work. */
+  function promptWarrantsDevql(prompt: string): boolean {
+    const lower = prompt.toLowerCase()
+    const repoUnderstandingTerms = [
+      "what does this repo do",
+      "understand",
+      "explain",
+      "architecture",
+      "where is",
+      "find",
+      "inspect",
+      "caller",
+      "usage",
+      "import",
+      "dependency",
+      "test covering",
+    ]
+    const executionTerms = [
+      "fix ",
+      "implement ",
+      "edit ",
+      "write ",
+      "run ",
+      "build ",
+      "test ",
+      "format ",
+    ]
+    const looksLikeCodeReference =
+      prompt.includes("/") ||
+      prompt.includes("::") ||
+      prompt.includes("`") ||
+      prompt.includes(":")
+    const looksLikeEditOrExecution = executionTerms.some((needle) => lower.includes(needle))
+    const looksLikeRepoUnderstanding = repoUnderstandingTerms.some((needle) => lower.includes(needle))
+
+    return (looksLikeCodeReference || looksLikeRepoUnderstanding) && !looksLikeEditOrExecution
+  }
+
+  /** Check whether a message already contains a text marker. */
+  function hasTextPartContaining(message: any, marker: string): boolean {
+    return (message.parts ?? []).some(
+      (p: any) => p.type === "text" && typeof p.text === "string" && p.text.includes(marker)
+    )
   }
 
   /** Format a message object from its accumulated parts. */
@@ -184,17 +245,37 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
     },
 
     "experimental.chat.messages.transform": async (_input, output) => {
-      if (!BOOTSTRAP_CONTEXT) return
+      if (!BOOTSTRAP_CONTEXT && !TURN_GUIDANCE_CONTEXT) return
       const repoSkillPath = path.join(directory, ".opencode", "skills", "bitloops", "using-devql", "SKILL.md")
       if (!(await Bun.file(repoSkillPath).exists())) return
       if (!output.messages.length) return
-      const firstUser = output.messages.find((m: any) => m.info?.role === "user")
-      if (!firstUser || !firstUser.parts?.length) return
-      if (firstUser.parts.some((p: any) => p.type === "text" && typeof p.text === "string" && p.text.includes("EXTREMELY_IMPORTANT"))) {
-        return
+
+      if (BOOTSTRAP_CONTEXT) {
+        const firstUser = output.messages.find((m: any) => m.info?.role === "user")
+        if (firstUser?.parts?.length && !hasTextPartContaining(firstUser, "EXTREMELY_IMPORTANT")) {
+          const ref = firstUser.parts[0]
+          firstUser.parts.unshift({ ...ref, type: "text", text: BOOTSTRAP_CONTEXT })
+        }
       }
-      const ref = firstUser.parts[0]
-      firstUser.parts.unshift({ ...ref, type: "text", text: BOOTSTRAP_CONTEXT })
+
+      if (!TURN_GUIDANCE_CONTEXT || !latestUserMessageID) return
+      const latestUser = output.messages.find(
+        (m: any) => m.info?.id === latestUserMessageID && m.info?.role === "user"
+      )
+      if (!latestUser?.parts?.length) return
+      const prompt = latestUserPromptByMessageID.get(latestUserMessageID) ?? textFromParts(latestUser.parts)
+      if (!promptWarrantsDevql(prompt)) return
+      const turnGuidanceMarker = TURN_GUIDANCE_CONTEXT.split(" when ")[0]
+      if (hasTextPartContaining(latestUser, turnGuidanceMarker)) return
+      const ref = latestUser.parts[0]
+      latestUser.parts.unshift({ ...ref, type: "text", text: TURN_GUIDANCE_CONTEXT })
+    },
+
+    "chat.message": async (input, output) => {
+      const messageID = input.messageID ?? output.message?.id
+      if (!messageID) return
+      latestUserMessageID = messageID
+      latestUserPromptByMessageID.set(messageID, textFromParts(output.parts ?? []))
     },
 
     event: async ({ event }) => {
@@ -282,6 +363,8 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
             await writeExportJSON(session.id)
           }
           seenUserMessages.clear()
+          latestUserMessageID = null
+          latestUserPromptByMessageID.clear()
           messageStore.clear()
           partStore.clear()
           currentSessionID = null

--- a/bitloops/src/host/hooks/augmentation/devql_guidance.rs
+++ b/bitloops/src/host/hooks/augmentation/devql_guidance.rs
@@ -30,38 +30,43 @@ Read `{surface_path}` before broad search."
     )
 }
 
+pub const DEVQL_REPO_UNDERSTANDING_TERMS: &[&str] = &[
+    "what does this repo do",
+    "understand",
+    "explain",
+    "architecture",
+    "where is",
+    "find",
+    "inspect",
+    "caller",
+    "usage",
+    "import",
+    "dependency",
+    "test covering",
+];
+
+pub const DEVQL_EXECUTION_TERMS: &[&str] = &[
+    "fix ",
+    "implement ",
+    "edit ",
+    "write ",
+    "run ",
+    "build ",
+    "test ",
+    "format ",
+];
+
+pub const DEVQL_CODE_REFERENCE_MARKERS: &[&str] = &["/", "::", "`", ":"];
+
 pub fn prompt_warrants_devql(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
-    let repo_understanding_terms = [
-        "what does this repo do",
-        "understand",
-        "explain",
-        "architecture",
-        "where is",
-        "find",
-        "inspect",
-        "caller",
-        "usage",
-        "import",
-        "dependency",
-        "test covering",
-    ];
-    let execution_terms = [
-        "fix ",
-        "implement ",
-        "edit ",
-        "write ",
-        "run ",
-        "build ",
-        "test ",
-        "format ",
-    ];
-    let looks_like_code_reference = prompt.contains('/')
-        || prompt.contains("::")
-        || prompt.contains('`')
-        || prompt.contains(':');
-    let looks_like_edit_or_execution = execution_terms.iter().any(|needle| lower.contains(needle));
-    let looks_like_repo_understanding = repo_understanding_terms
+    let looks_like_code_reference = DEVQL_CODE_REFERENCE_MARKERS
+        .iter()
+        .any(|marker| prompt.contains(marker));
+    let looks_like_edit_or_execution = DEVQL_EXECUTION_TERMS
+        .iter()
+        .any(|needle| lower.contains(needle));
+    let looks_like_repo_understanding = DEVQL_REPO_UNDERSTANDING_TERMS
         .iter()
         .any(|needle| lower.contains(needle));
 


### PR DESCRIPTION
## Summary
- add OpenCode turn-level DevQL guidance through the generated plugin message transform
- track the latest user message with `chat.message` and inject targeted guidance into that message via `experimental.chat.messages.transform`
- keep OpenCode hook stdout augmentation disabled and add behavioral renderer tests for bootstrap/turn guidance behavior

## Root Cause
OpenCode received the repo-local skill and initial bootstrap context, but it did not receive the Codex/Claude-style per-turn DevQL reminder. The existing OpenCode hook path records lifecycle events but does not surface Bitloops hook stdout back into the model.

## Validation
- `cargo dev-fmt`
- `cargo nextest run --manifest-path bitloops/Cargo.toml -p bitloops --lib render_plugin_template route_opencode_session_start_returns_no_additional_context_stdout`
- `git diff --check -- bitloops/src/adapters/agents/open_code/plugin.rs bitloops/src/adapters/agents/open_code/hooks.rs`

## Notes
- Tested manually in OpenCode once after regenerating hooks; DevQL guidance appeared to work on the first attempt.
- `.gitignore` has an unrelated local modification and is intentionally not included in this PR.



# TLDR

Current OpenCode path after the PR:

1. `bitloops init --agent opencode` renders `.opencode/plugins/bitloops.ts` from [plugin.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/adapters/agents/open_code/plugin.rs:33).
2. Render time fills two constants:
   - `BOOTSTRAP_CONTEXT` from `build_session_bootstrap(...)`
   - `TURN_GUIDANCE_CONTEXT` from `build_turn_guidance(...)`
   via [hooks.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/adapters/agents/open_code/hooks.rs:45).
3. Runtime `config` registers `.opencode/skills` so OpenCode can see the Bitloops skill: [plugin.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/adapters/agents/open_code/plugin.rs:238).
4. Runtime `chat.message` records the latest user message id and prompt text: [plugin.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/adapters/agents/open_code/plugin.rs:274).
5. Runtime `experimental.chat.messages.transform` mutates messages before the LLM call:
   - injects bootstrap into the **first user message** once
   - injects turn guidance into the **latest user message** only when the prompt warrants DevQL
   - dedupes both injections
   - re-checks that `.opencode/skills/bitloops/using-devql/SKILL.md` exists
   See [plugin.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/adapters/agents/open_code/plugin.rs:247).

Comparison with Codex/Claude:

- **Same source of guidance text:** both paths use `build_session_bootstrap` and `build_turn_guidance`.
- **Same policy/surface gate:** both depend on `installed_prompt_surface_relative_path(...)`, so disabled DevQL guidance or missing skill means no injected context.
- **Same intent:** session bootstrap tells the model DevQL exists; turn guidance reminds it on repo-understanding prompts.
- **Different transport:**
  - Codex/Claude: Bitloops hook stdout returns JSON `additionalContext` via the lifecycle path: [adapters.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/host/checkpoints/lifecycle/adapters.rs:513).
  - OpenCode: hook stdout stays disabled because OpenCode does not surface it to the model: [builtin.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/adapters/agents/adapters/builtin.rs:397). Instead, the plugin mutates chat messages directly.
- **Turn guidance support split:**
  - Codex/Claude use Rust `build_devql_hook_augmentation(...)`, gated by `agent_supports_turn_guidance`: [builder.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/host/hooks/augmentation/builder.rs:23).
  - OpenCode mirrors the prompt heuristic in TypeScript inside the plugin: [plugin.rs](/Users/markos/code/bitloops/bitloops/bitloops/src/adapters/agents/open_code/plugin.rs:88).

So conceptually OpenCode now aligns with Codex/Claude, but through OpenCode’s model-visible plugin message transform instead of hook stdout.