### PR TITLE
Fix batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Platform embeddings now respect the hosted batch-size limit**: semantic-clones embedding backfill work now enqueues and claims 32-item batches instead of 50-item batches, matching the hosted `bge-m3` embeddings service limit. Platform-backed IPC embedding requests also split any larger caller-provided batch into supported sub-requests before reaching the gateway, preserving vector order while preventing oversized requests from being rejected and skipped by the gateway cache.
 - **SQLite sync materialisation now waits cleanly for transient writer contention**: the batched sync writer now starts `IMMEDIATE` SQLite transactions for current-state materialisation, cache-touch completion, and removed-path cleanup instead of beginning deferred transactions and upgrading later during row deletes. This fixes transient `database is locked` failures during sync materialisation when another writer briefly holds the database lock.
 - **OpenCode now receives prompt-time DevQL guidance through its plugin message transform**: the generated OpenCode plugin now tracks the latest user prompt via `chat.message` and injects the shared turn-level DevQL guidance into that latest user message through `experimental.chat.messages.transform`, while keeping hook stdout augmentation disabled for OpenCode. This aligns OpenCode with the Codex and Claude DevQL reinforcement path without using system-prompt transforms.
 

--- a/bitloops/src/capability_packs/semantic_clones/current_state/tests/cases.rs
+++ b/bitloops/src/capability_packs/semantic_clones/current_state/tests/cases.rs
@@ -241,7 +241,9 @@ async fn reconcile_clears_current_projection_rows_for_affected_paths_in_bulk() -
 async fn reconcile_large_delta_chunks_code_and_identity_embedding_jobs() -> Result<()> {
     let repo = tempdir().expect("temp repo");
     let repo_id = "repo-large-delta";
-    let artefact_upserts = (0..125)
+    let artefact_count = 125usize;
+    let expected_embedding_job_count = artefact_count.div_ceil(REPO_BACKFILL_MAILBOX_CHUNK_SIZE);
+    let artefact_upserts = (0..artefact_count)
         .map(|idx| ChangedArtefact {
             artefact_id: format!("artefact-{idx:03}"),
             symbol_id: format!("symbol-{idx:03}"),
@@ -276,8 +278,8 @@ async fn reconcile_large_delta_chunks_code_and_identity_embedding_jobs() -> Resu
         .filter(|job| job.mailbox_name == SEMANTIC_CLONES_IDENTITY_EMBEDDING_MAILBOX)
         .collect::<Vec<_>>();
 
-    assert_eq!(code_jobs.len(), 3);
-    assert_eq!(identity_jobs.len(), 3);
+    assert_eq!(code_jobs.len(), expected_embedding_job_count);
+    assert_eq!(identity_jobs.len(), expected_embedding_job_count);
     assert!(code_jobs.iter().all(|job| {
         crate::capability_packs::semantic_clones::workplane::payload_is_repo_backfill(&job.payload)
     }));
@@ -294,10 +296,16 @@ async fn reconcile_large_delta_chunks_code_and_identity_embedding_jobs() -> Resu
                 )
             })
             .sum::<u64>(),
-        125
+        artefact_count as u64
     );
-    assert_eq!(metrics["enqueued_code_embedding_jobs"], json!(3));
-    assert_eq!(metrics["enqueued_identity_embedding_jobs"], json!(3));
+    assert_eq!(
+        metrics["enqueued_code_embedding_jobs"],
+        json!(expected_embedding_job_count)
+    );
+    assert_eq!(
+        metrics["enqueued_identity_embedding_jobs"],
+        json!(expected_embedding_job_count)
+    );
     Ok(())
 }
 

--- a/bitloops/src/capability_packs/semantic_clones/workplane.rs
+++ b/bitloops/src/capability_packs/semantic_clones/workplane.rs
@@ -34,7 +34,7 @@ pub const SEMANTIC_CLONES_DEFERRED_PIPELINE_MAILBOXES: [&str; 5] = [
 ];
 
 const REPO_BACKFILL_DEDUPE_SUFFIX: &str = "repo_backfill";
-pub const REPO_BACKFILL_MAILBOX_CHUNK_SIZE: usize = 50;
+pub const REPO_BACKFILL_MAILBOX_CHUNK_SIZE: usize = 32;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/bitloops/src/daemon/enrichment/execution_tests.rs
+++ b/bitloops/src/daemon/enrichment/execution_tests.rs
@@ -23,6 +23,14 @@ use tempfile::TempDir;
 const TEST_EMBEDDINGS_DRIVER: &str = crate::host::inference::BITLOOPS_EMBEDDINGS_IPC_DRIVER;
 
 #[test]
+fn semantic_embedding_work_batches_match_platform_embedding_request_limit() {
+    assert_eq!(
+        crate::daemon::enrichment::workplane::SEMANTIC_EMBEDDING_MAILBOX_BATCH_SIZE,
+        32
+    );
+}
+
+#[test]
 fn repo_backfill_selection_distinguishes_empty_explicit_ids_from_full_repo() {
     let full_repo_items = vec![selection_test_embedding_item(None)];
     let full_repo = super::helpers::select_current_semantic_input_scope(&full_repo_items);

--- a/bitloops/src/daemon/enrichment/workplane/mailbox_claim.rs
+++ b/bitloops/src/daemon/enrichment/workplane/mailbox_claim.rs
@@ -25,7 +25,7 @@ use super::readiness::{mailbox_claim_readiness, mailbox_readiness_job};
 use super::sql::{sql_i64, sql_string_list};
 
 pub(crate) const SEMANTIC_SUMMARY_MAILBOX_BATCH_SIZE: usize = 10;
-pub(crate) const SEMANTIC_EMBEDDING_MAILBOX_BATCH_SIZE: usize = 50;
+pub(crate) const SEMANTIC_EMBEDDING_MAILBOX_BATCH_SIZE: usize = 32;
 const SEMANTIC_MAILBOX_LEASE_SECS: u64 = 300;
 pub(crate) const WORKPLANE_JOB_CLAIM_CANDIDATE_LIMIT: usize = 32;
 

--- a/bitloops/src/daemon/enrichment_tests.rs
+++ b/bitloops/src/daemon/enrichment_tests.rs
@@ -1509,7 +1509,7 @@ fn summary_mailbox_batch_claim_leases_up_to_ten_items_without_touching_embedding
 }
 
 #[test]
-fn embedding_mailbox_batch_claim_leases_up_to_fifty_items_from_embedding_inbox_only() {
+fn embedding_mailbox_batch_claim_leases_up_to_embedding_batch_size_from_embedding_inbox_only() {
     let temp = TempDir::new().expect("temp dir");
     let (coordinator, target, repo_id) = new_test_coordinator(&temp);
     configure_summary_refresh_for_repo(&target);
@@ -1563,7 +1563,10 @@ fn embedding_mailbox_batch_claim_leases_up_to_fifty_items_from_embedding_inbox_o
     .expect("claim embedding mailbox batch")
     .expect("embedding mailbox batch should be claimable");
 
-    assert_eq!(claimed.items.len(), 50);
+    assert_eq!(
+        claimed.items.len(),
+        crate::daemon::enrichment::workplane::SEMANTIC_EMBEDDING_MAILBOX_BATCH_SIZE
+    );
     assert_eq!(claimed.representation_kind.to_string(), "code");
     assert!(
         claimed
@@ -1573,11 +1576,11 @@ fn embedding_mailbox_batch_claim_leases_up_to_fifty_items_from_embedding_inbox_o
     );
     assert_eq!(
         load_embedding_mailbox_items(&coordinator, SemanticMailboxItemStatus::Leased).len(),
-        50,
+        crate::daemon::enrichment::workplane::SEMANTIC_EMBEDDING_MAILBOX_BATCH_SIZE,
     );
     assert_eq!(
         load_embedding_mailbox_items(&coordinator, SemanticMailboxItemStatus::Pending).len(),
-        5,
+        55 - crate::daemon::enrichment::workplane::SEMANTIC_EMBEDDING_MAILBOX_BATCH_SIZE,
     );
     assert_eq!(
         load_summary_mailbox_items(&coordinator, SemanticMailboxItemStatus::Pending).len(),
@@ -2861,7 +2864,10 @@ async fn enqueue_repo_backfill_embedding_jobs_chunks_large_payloads_for_parallel
                 .payload_json
                 .as_ref()
                 .and_then(serde_json::Value::as_array)
-                .is_some_and(|artefact_ids| artefact_ids.len() <= 50)
+                .is_some_and(|artefact_ids| {
+                    artefact_ids.len()
+                        <= crate::capability_packs::semantic_clones::workplane::REPO_BACKFILL_MAILBOX_CHUNK_SIZE
+                })
     }));
     assert_eq!(
         pending_items

--- a/bitloops/src/host/inference/embeddings/service.rs
+++ b/bitloops/src/host/inference/embeddings/service.rs
@@ -12,12 +12,15 @@ use super::runtime::{
 use super::session::PythonEmbeddingsSessionConfig;
 use super::shared::{SharedBitloopsEmbeddingsSession, shared_bitloops_embeddings_session_registry};
 
+const PLATFORM_EMBEDDINGS_MAX_CLIENT_BATCH_SIZE: usize = 32;
+
 pub(crate) struct BitloopsEmbeddingsIpcService {
     profile_name: String,
     model_name: String,
     output_dimension: usize,
     cache_key: String,
     shared_session: Arc<SharedBitloopsEmbeddingsSession>,
+    max_request_batch_size: Option<usize>,
 }
 
 impl BitloopsEmbeddingsIpcService {
@@ -55,6 +58,8 @@ impl BitloopsEmbeddingsIpcService {
             output_dimension,
             cache_key,
             shared_session,
+            max_request_batch_size: platform_backed
+                .then_some(PLATFORM_EMBEDDINGS_MAX_CLIENT_BATCH_SIZE),
         })
     }
 
@@ -84,6 +89,32 @@ impl BitloopsEmbeddingsIpcService {
                     )
                 })?;
             vectors.append(&mut single);
+        }
+        Ok(vectors)
+    }
+
+    fn embed_texts_in_supported_batches(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        let Some(max_request_batch_size) = self.max_request_batch_size else {
+            return match self.embed_texts(texts) {
+                Ok(vectors) => Ok(vectors),
+                Err(err) if texts.len() > 1 => {
+                    self.embed_texts_individually_after_batch_error(texts, err)
+                }
+                Err(err) => Err(err),
+            };
+        };
+
+        let mut vectors = Vec::with_capacity(texts.len());
+        for chunk in texts.chunks(max_request_batch_size) {
+            match self.embed_texts(chunk) {
+                Ok(mut chunk_vectors) => vectors.append(&mut chunk_vectors),
+                Err(err) if chunk.len() > 1 => {
+                    let mut fallback_vectors =
+                        self.embed_texts_individually_after_batch_error(chunk, err)?;
+                    vectors.append(&mut fallback_vectors);
+                }
+                Err(err) => return Err(err),
+            }
         }
         Ok(vectors)
     }
@@ -161,12 +192,6 @@ impl EmbeddingService for BitloopsEmbeddingsIpcService {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        match self.embed_texts(&texts) {
-            Ok(vectors) => Ok(vectors),
-            Err(err) if texts.len() > 1 => {
-                self.embed_texts_individually_after_batch_error(&texts, err)
-            }
-            Err(err) => Err(err),
-        }
+        self.embed_texts_in_supported_batches(&texts)
     }
 }

--- a/bitloops/src/host/inference/embeddings/tests.rs
+++ b/bitloops/src/host/inference/embeddings/tests.rs
@@ -122,6 +122,55 @@ done
     .expect("write batch rejecting fake runtime script");
 }
 
+fn write_request_recording_fake_runtime_script(script_path: &Path, request_log: &Path) {
+    fs::write(
+        script_path,
+        format!(
+            r#"launch_log="$1"
+shift
+printf '%s\n' "$$" >> "$launch_log"
+printf '%s\n' '{{"event":"ready","protocol":1,"capabilities":["embed","shutdown"]}}'
+
+while IFS= read -r line; do
+  request_id=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  case "$line" in
+    *'"cmd":"shutdown"'*)
+      printf '{{"id":"%s","ok":true}}\n' "$request_id"
+      exit 0
+      ;;
+    *'"cmd":"embed"'*)
+      case "$line" in
+        *'bitloops python embedding dimension probe'*)
+          printf '{{"id":"%s","ok":true,"vectors":[[1.0,2.0]]}}\n' "$request_id"
+          ;;
+        *)
+          document_ids=$(printf '%s' "$line" | grep -o 'platform document [0-9][0-9]' | sed 's/.* //')
+          count=$(printf '%s\n' "$document_ids" | sed '/^$/d' | wc -l | tr -d ' ')
+          printf '%s\n' "$count" >> "{request_log}"
+          vectors=""
+          for id in $document_ids; do
+            number=$(printf '%s' "$id" | sed 's/^0*//')
+            if [ -z "$number" ]; then
+              number=0
+            fi
+            if [ -n "$vectors" ]; then
+              vectors="$vectors,"
+            fi
+            vectors="$vectors[$number.0,2.0]"
+          done
+          printf '{{"id":"%s","ok":true,"vectors":[%s]}}\n' "$request_id" "$vectors"
+          ;;
+      esac
+      ;;
+  esac
+done
+"#,
+            request_log = request_log.display()
+        ),
+    )
+    .expect("write request recording fake runtime script");
+}
+
 fn fake_runtime_config(script_path: &Path, launch_log: &Path) -> InferenceRuntimeConfig {
     InferenceRuntimeConfig {
         command: "/bin/sh".to_string(),
@@ -132,6 +181,44 @@ fn fake_runtime_config(script_path: &Path, launch_log: &Path) -> InferenceRuntim
         startup_timeout_secs: 1,
         request_timeout_secs: 1,
     }
+}
+
+#[test]
+fn platform_ipc_service_splits_large_embedding_batches_into_supported_requests() {
+    let temp = TempDir::new().expect("temp dir");
+    let script_path = temp.path().join("fake_embeddings_runtime.sh");
+    let launch_log = temp.path().join("launches.log");
+    let request_log = temp.path().join("requests.log");
+    write_request_recording_fake_runtime_script(&script_path, &request_log);
+
+    let runtime = fake_runtime_config(&script_path, &launch_log);
+    let service = with_platform_runtime_auth_environment_hook(
+        |api_key_env| {
+            Ok(vec![(
+                api_key_env.to_string(),
+                "token-from-login".to_string(),
+            )])
+        },
+        || BitloopsEmbeddingsIpcService::new("platform_code", &runtime, "test-model", None, true),
+    )
+    .expect("build platform ipc service");
+
+    let inputs = (0..50)
+        .map(|index| format!("platform document {index:02}"))
+        .collect::<Vec<_>>();
+    let vectors = service
+        .embed_batch(&inputs, EmbeddingInputType::Document)
+        .expect("platform batch embed");
+
+    assert_eq!(vectors.len(), 50);
+    assert_eq!(vectors[0], vec![0.0, 2.0]);
+    assert_eq!(vectors[31], vec![31.0, 2.0]);
+    assert_eq!(vectors[32], vec![32.0, 2.0]);
+    assert_eq!(vectors[49], vec![49.0, 2.0]);
+    assert_eq!(
+        fs::read_to_string(&request_log).expect("read request log"),
+        "32\n18\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Reduced semantic-clones embedding backfill and mailbox batch sizes from 50 to 32 to match the hosted `bge-m3` embeddings service limit.
- Added a platform-backed IPC safeguard that splits larger embedding requests into 32-item sub-batches before they reach the gateway.
- Added regression coverage for 50-input platform embedding requests, preserving vector order across `32 + 18` splits.
- Updated affected batching tests and the changelog.

## Verification

- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features host::inference::embeddings::tests`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features reconcile_large_delta_chunks_code_and_identity_embedding_jobs`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features reconcile_full_reconcile_chunks_backfill_jobs_for_parallel_mailbox_work`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features enqueue_repo_backfill_embedding_jobs_chunks_large_payloads_for_parallel_workers`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features prepare_embedding_mailbox_batch_splits_repo_wide_backfill_before_hydrating_later_paths`
- `cargo fmt --all --manifest-path bitloops/Cargo.toml -- --check`
- `git diff --check`


## Validation

- [x] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

