### PR TITLE
clean up devql watche processes after exit

### DIFF
--- a/bitloops/src/api/dashboard_runtime.rs
+++ b/bitloops/src/api/dashboard_runtime.rs
@@ -249,19 +249,20 @@ pub(super) async fn run(
 
     match (transport, tls_acceptor) {
         (DashboardTransport::Https, Some(acceptor)) => {
-            serve_until_shutdown_tls(listener, acceptor, state, options.shutdown_message).await
+            serve_until_shutdown_tls(listener, acceptor, state).await
         }
-        (DashboardTransport::Http, _) => {
-            serve_until_shutdown_http(listener, state, options.shutdown_message).await
-        }
+        (DashboardTransport::Http, _) => serve_until_shutdown_http(listener, state).await,
         (DashboardTransport::Https, None) => {
             Err(anyhow!("dashboard HTTPS selected without a TLS acceptor"))
         }
     }?;
 
-    if let Some(on_shutdown) = options.on_shutdown.as_ref() {
-        on_shutdown();
-    }
+    run_shutdown_actions(
+        options.on_shutdown,
+        options.shutdown_message,
+        Duration::from_secs(5),
+    )
+    .await;
 
     Ok(())
 }
@@ -302,14 +303,13 @@ async fn serve_until_shutdown_tls(
     listener: TcpListener,
     tls_acceptor: TlsAcceptor,
     state: DashboardState,
-    shutdown_message: Option<String>,
 ) -> Result<()> {
     use hyper::server::conn::http1::Builder as Http1Builder;
     use hyper_util::rt::TokioIo;
     use hyper_util::service::TowerToHyperService;
 
     let app = router::build_dashboard_router(state);
-    serve_until_shutdown_with_handler(listener, shutdown_message, move |stream| {
+    serve_until_shutdown_with_handler(listener, move |stream| {
         let tls_acceptor = tls_acceptor.clone();
         let app = app.clone();
         async move {
@@ -342,17 +342,13 @@ async fn serve_until_shutdown_tls(
     .await
 }
 
-async fn serve_until_shutdown_http(
-    listener: TcpListener,
-    state: DashboardState,
-    shutdown_message: Option<String>,
-) -> Result<()> {
+async fn serve_until_shutdown_http(listener: TcpListener, state: DashboardState) -> Result<()> {
     use hyper::server::conn::http1::Builder as Http1Builder;
     use hyper_util::rt::TokioIo;
     use hyper_util::service::TowerToHyperService;
 
     let app = router::build_dashboard_router(state);
-    serve_until_shutdown_with_handler(listener, shutdown_message, move |stream| {
+    serve_until_shutdown_with_handler(listener, move |stream| {
         let app = app.clone();
         async move {
             let io = TokioIo::new(stream);
@@ -401,7 +397,6 @@ async fn wait_for_shutdown_signal() {
 
 async fn serve_until_shutdown_with_handler<F, Fut>(
     listener: TcpListener,
-    shutdown_message: Option<String>,
     mut on_stream: F,
 ) -> Result<()>
 where
@@ -424,11 +419,22 @@ where
     }
 
     drop(listener);
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    Ok(())
+}
+
+async fn run_shutdown_actions(
+    on_shutdown: Option<super::DashboardShutdownHook>,
+    shutdown_message: Option<String>,
+    shutdown_delay: Duration,
+) {
+    if let Some(on_shutdown) = on_shutdown.as_ref() {
+        on_shutdown();
+    }
+
+    tokio::time::sleep(shutdown_delay).await;
     if let Some(message) = shutdown_message {
         println!("{message}");
     }
-    Ok(())
 }
 
 fn clickable_url(url: &str) -> String {
@@ -524,7 +530,13 @@ pub(super) fn open_in_default_browser(url: &str) -> Result<()> {
 
 #[cfg(test)]
 mod dashboard_runtime_unit_tests {
-    use super::{clickable_url, warning_block_lines};
+    use super::{clickable_url, run_shutdown_actions, warning_block_lines};
+    use crate::api::DashboardShutdownHook;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use std::time::Duration;
 
     #[test]
     fn clickable_url_inserts_osc8_hyperlink_sequence() {
@@ -545,5 +557,28 @@ mod dashboard_runtime_unit_tests {
         assert!(lines.iter().any(|l| l.contains('⚠')));
         assert!(lines.iter().any(|l| l.contains("line one")));
         assert!(lines.iter().any(|l| l.contains("line two")));
+    }
+
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    async fn run_shutdown_actions_calls_hook_before_waiting() {
+        let called = Arc::new(AtomicBool::new(false));
+        let on_shutdown: DashboardShutdownHook = Arc::new({
+            let called = called.clone();
+            move || {
+                called.store(true, Ordering::SeqCst);
+            }
+        });
+
+        let task = tokio::spawn(run_shutdown_actions(
+            Some(on_shutdown),
+            None,
+            Duration::from_millis(50),
+        ));
+        tokio::task::yield_now().await;
+
+        assert!(called.load(Ordering::SeqCst));
+        assert!(!task.is_finished());
+        tokio::time::advance(Duration::from_millis(50)).await;
+        task.await.expect("join shutdown actions task");
     }
 }

--- a/bitloops/src/daemon/lifecycle.rs
+++ b/bitloops/src/daemon/lifecycle.rs
@@ -192,6 +192,7 @@ pub(super) async fn stop() -> Result<()> {
         let runtime = read_runtime_state(Path::new("."))?;
 
         if let Some(metadata) = service {
+            stop_current_repo_watcher_if_present();
             let supervisor_running = match supervisor_available() {
                 Ok(running) => running,
                 Err(err) => {
@@ -217,6 +218,7 @@ pub(super) async fn stop() -> Result<()> {
             if runtime_path.exists() {
                 wait_for_runtime_cleanup(&runtime_path, STOP_TIMEOUT)?;
             }
+            stop_supervisor_service_if_idle();
             log::info!("daemon stop completed for service-managed runtime");
             let _ = metadata;
             return Ok(());
@@ -229,6 +231,7 @@ pub(super) async fn stop() -> Result<()> {
             runtime.pid,
             runtime.mode
         );
+        stop_current_repo_watcher_if_present();
         terminate_process(runtime.pid)?;
         wait_for_runtime_cleanup(&runtime_state_path(Path::new(".")), STOP_TIMEOUT)?;
         log::info!("daemon stop completed");
@@ -316,6 +319,42 @@ fn current_repo_scope() -> Option<(std::path::PathBuf, crate::host::devql::RepoI
     let repo_root = crate::utils::paths::repo_root().ok()?;
     let repo = crate::host::devql::resolve_repo_identity(&repo_root).ok()?;
     Some((repo_root, repo))
+}
+
+fn stop_current_repo_watcher_if_present() {
+    let Some((repo_root, _repo)) = current_repo_scope() else {
+        return;
+    };
+    let Ok(config_root) = crate::config::resolve_bound_daemon_config_root_for_repo(&repo_root)
+    else {
+        return;
+    };
+    if let Err(err) = crate::host::devql::watch::stop_watcher(&repo_root, &config_root) {
+        log::warn!(
+            "failed to stop DevQL watcher during daemon teardown for {}: {err:#}",
+            repo_root.display()
+        );
+    }
+}
+
+fn stop_supervisor_service_if_idle() {
+    let Some(metadata) = read_supervisor_service_metadata()
+        .map_err(|err| {
+            log::warn!("failed to load daemon supervisor service metadata during stop: {err:#}");
+            err
+        })
+        .ok()
+        .flatten()
+    else {
+        return;
+    };
+    if let Err(err) = stop_configured_supervisor_service(&metadata) {
+        log::warn!("failed to stop daemon supervisor service during stop: {err:#}");
+        return;
+    }
+    if let Err(err) = delete_supervisor_runtime_state() {
+        log::warn!("failed to clear daemon supervisor runtime state during stop: {err:#}");
+    }
 }
 
 fn current_repo_init_runtime_snapshot(

--- a/bitloops/src/daemon/process.rs
+++ b/bitloops/src/daemon/process.rs
@@ -93,6 +93,73 @@ pub(super) fn terminate_process(pid: u32) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+pub(super) fn reap_terminated_child_process(pid: u32, timeout: Duration) -> Result<bool> {
+    if pid > i32::MAX as u32 {
+        return Ok(false);
+    }
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let mut status = 0;
+        let result = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+        if result == pid as libc::pid_t {
+            return Ok(true);
+        }
+        if result == 0 {
+            if Instant::now() >= deadline {
+                return Ok(false);
+            }
+            std::thread::sleep(Duration::from_millis(25));
+            continue;
+        }
+
+        let raw_os_error = std::io::Error::last_os_error().raw_os_error();
+        match raw_os_error {
+            Some(libc::ECHILD) => return Ok(false),
+            Some(libc::EINTR) => continue,
+            _ => {
+                return Err(std::io::Error::last_os_error())
+                    .context("waiting for Bitloops daemon child process");
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub(super) fn reap_terminated_child_process(_pid: u32, _timeout: Duration) -> Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
+pub(super) fn reap_terminated_child_processes() -> Result<usize> {
+    let mut reaped = 0_usize;
+    loop {
+        let mut status = 0;
+        let result = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+        if result > 0 {
+            reaped += 1;
+            continue;
+        }
+        if result == 0 {
+            return Ok(reaped);
+        }
+
+        let raw_os_error = std::io::Error::last_os_error().raw_os_error();
+        return match raw_os_error {
+            Some(libc::ECHILD) => Ok(reaped),
+            Some(libc::EINTR) => continue,
+            _ => Err(std::io::Error::last_os_error())
+                .context("reaping Bitloops daemon child processes"),
+        };
+    }
+}
+
+#[cfg(not(unix))]
+pub(super) fn reap_terminated_child_processes() -> Result<usize> {
+    Ok(0)
+}
+
 pub(super) fn wait_for_runtime_cleanup(runtime_path: &Path, timeout: Duration) -> Result<()> {
     let _ = runtime_path;
     let started = Instant::now();
@@ -201,6 +268,12 @@ mod tests {
     use super::should_accept_invalid_daemon_certs;
     #[cfg(not(windows))]
     use super::unix_kill_zero_indicates_running;
+    #[cfg(unix)]
+    use super::{process_is_running, reap_terminated_child_process};
+    #[cfg(unix)]
+    use std::process::Command;
+    #[cfg(unix)]
+    use std::time::Duration;
 
     #[test]
     fn daemon_http_client_only_relaxes_loopback_https_urls() {
@@ -221,5 +294,32 @@ mod tests {
         assert!(!unix_kill_zero_indicates_running(-1, Some(libc::ESRCH)));
         assert!(!unix_kill_zero_indicates_running(-1, Some(libc::EINVAL)));
         assert!(unix_kill_zero_indicates_running(0, None));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reaps_exited_child_process_by_pid() {
+        let child = Command::new("sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .expect("spawn short-lived child");
+        let pid = child.id();
+        drop(child);
+
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            process_is_running(pid).expect("inspect child process state before reap"),
+            "expected exited child to remain visible until it is reaped"
+        );
+
+        assert!(
+            reap_terminated_child_process(pid, Duration::from_secs(1))
+                .expect("reap child process by pid"),
+            "expected exited child to be reaped"
+        );
+        assert!(
+            !process_is_running(pid).expect("inspect child process state after reap"),
+            "expected reaped child to disappear from process table"
+        );
     }
 }

--- a/bitloops/src/daemon/server_runtime.rs
+++ b/bitloops/src/daemon/server_runtime.rs
@@ -73,6 +73,7 @@ pub(super) async fn run_server(
     let service_metadata_path = service_metadata_path(&config_root);
     let current_fingerprint = current_binary_fingerprint()?;
     let on_ready_config = daemon_config.clone();
+    let on_shutdown_config = daemon_config.clone();
     let on_ready_service_metadata_path = service_metadata_path.clone();
     let on_ready_service_name = options.service_name.clone();
     let ready_hook: DashboardReadyHook = std::sync::Arc::new(move |ready| {
@@ -110,6 +111,7 @@ pub(super) async fn run_server(
         Ok(())
     });
     let on_shutdown = std::sync::Arc::new(move || {
+        stop_bound_repo_watchers_for_daemon_shutdown(&on_shutdown_config);
         if let Err(err) = delete_runtime_state() {
             log::warn!("failed to clear daemon runtime state on shutdown: {err:#}");
         }
@@ -196,6 +198,7 @@ pub(super) fn stop_service_managed_repo_runtime() -> Result<()> {
         {
             terminate_process(state.pid)?;
             wait_for_runtime_cleanup(&runtime_state_path(Path::new(".")), STOP_TIMEOUT)?;
+            let _ = reap_terminated_child_process(state.pid, STOP_TIMEOUT);
             Ok(())
         }
         Some(state) => bail!(
@@ -290,4 +293,86 @@ pub(super) fn ensure_can_start(repo_root: &Path, allow_stopped_service: bool) ->
     }
 
     Ok(())
+}
+
+pub(super) fn stop_bound_repo_watchers_for_daemon_shutdown(daemon_config: &ResolvedDaemonConfig) {
+    let repo_roots = match bound_repo_roots_for_daemon_config(daemon_config) {
+        Ok(repo_roots) => repo_roots,
+        Err(err) => {
+            log::warn!(
+                "failed to resolve bound repo watchers for daemon shutdown (config={}): {err:#}",
+                daemon_config.config_path.display()
+            );
+            return;
+        }
+    };
+
+    for repo_root in repo_roots {
+        if let Err(err) =
+            crate::host::devql::watch::stop_watcher(&repo_root, &daemon_config.config_root)
+        {
+            log::warn!(
+                "failed to stop DevQL watcher during daemon shutdown for repo {}: {err:#}",
+                repo_root.display()
+            );
+        }
+    }
+}
+
+fn bound_repo_roots_for_daemon_config(
+    daemon_config: &ResolvedDaemonConfig,
+) -> Result<Vec<PathBuf>> {
+    let current_binding = crate::devql_transport::daemon_binding_identifier_for_config_path(
+        &daemon_config.config_path,
+    );
+    let mut repo_roots = std::collections::BTreeSet::new();
+
+    if let Some(repo_root) = repo_root_for_current_working_tree(&daemon_config.config_root)? {
+        if crate::devql_transport::repo_daemon_binding_identifier(&repo_root) == current_binding {
+            repo_roots.insert(repo_root);
+        }
+    }
+
+    let registry =
+        crate::devql_transport::load_repo_path_registry(&daemon_config.repo_registry_path)
+            .with_context(|| {
+                format!(
+                    "loading repo path registry {} during daemon shutdown",
+                    daemon_config.repo_registry_path.display()
+                )
+            })?;
+
+    for entry in registry.entries {
+        let repo_root = entry
+            .repo_root
+            .canonicalize()
+            .unwrap_or_else(|_| entry.repo_root.clone());
+        if crate::devql_transport::repo_daemon_binding_identifier(&repo_root) == current_binding {
+            repo_roots.insert(repo_root);
+        }
+    }
+
+    Ok(repo_roots.into_iter().collect())
+}
+
+fn repo_root_for_current_working_tree(cwd: &Path) -> Result<Option<PathBuf>> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .with_context(|| format!("resolving git repo root from {}", cwd.display()))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let repo_root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if repo_root.is_empty() {
+        return Ok(None);
+    }
+
+    let repo_root = PathBuf::from(repo_root);
+    Ok(Some(repo_root.canonicalize().unwrap_or(repo_root)))
 }

--- a/bitloops/src/daemon/server_runtime.rs
+++ b/bitloops/src/daemon/server_runtime.rs
@@ -327,10 +327,10 @@ fn bound_repo_roots_for_daemon_config(
     );
     let mut repo_roots = std::collections::BTreeSet::new();
 
-    if let Some(repo_root) = repo_root_for_current_working_tree(&daemon_config.config_root)? {
-        if crate::devql_transport::repo_daemon_binding_identifier(&repo_root) == current_binding {
-            repo_roots.insert(repo_root);
-        }
+    if let Some(repo_root) = repo_root_for_current_working_tree(&daemon_config.config_root)?
+        && crate::devql_transport::repo_daemon_binding_identifier(&repo_root) == current_binding
+    {
+        repo_roots.insert(repo_root);
     }
 
     let registry =

--- a/bitloops/src/daemon/supervisor_api.rs
+++ b/bitloops/src/daemon/supervisor_api.rs
@@ -28,10 +28,14 @@ pub(super) async fn run_internal_supervisor(_args: InternalDaemonSupervisorArgs)
             .with_state(SupervisorAppState {
                 operation_lock: Arc::new(Mutex::new(())),
             });
+        let child_reaper = spawn_supervisor_child_reaper();
 
         let result = axum::serve(control_listener, app)
             .with_graceful_shutdown(wait_for_shutdown_signal())
             .await;
+        if let Some(reaper) = child_reaper {
+            reaper.abort();
+        }
 
         if let Err(err) = delete_supervisor_runtime_state() {
             log::warn!("failed to clear daemon supervisor runtime state on shutdown: {err:#}");
@@ -43,6 +47,37 @@ pub(super) async fn run_internal_supervisor(_args: InternalDaemonSupervisorArgs)
         log::error!("daemon supervisor failed: {err:#}");
     }
     result
+}
+
+#[cfg(unix)]
+fn spawn_supervisor_child_reaper() -> Option<tokio::task::JoinHandle<()>> {
+    Some(tokio::spawn(async {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut sigchld = match signal(SignalKind::child()) {
+            Ok(signal) => signal,
+            Err(err) => {
+                log::warn!("failed to install SIGCHLD handler for daemon supervisor: {err:#}");
+                return;
+            }
+        };
+        while sigchld.recv().await.is_some() {
+            match reap_terminated_child_processes() {
+                Ok(count) if count > 0 => {
+                    log::debug!("daemon supervisor reaped {count} child process(es)");
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    log::warn!("failed to reap daemon supervisor child processes: {err:#}");
+                }
+            }
+        }
+    }))
+}
+
+#[cfg(not(unix))]
+fn spawn_supervisor_child_reaper() -> Option<tokio::task::JoinHandle<()>> {
+    None
 }
 
 async fn supervisor_health() -> Json<SupervisorHealthResponse> {

--- a/bitloops/src/daemon/tests.rs
+++ b/bitloops/src/daemon/tests.rs
@@ -4,6 +4,9 @@ use crate::config::{
     ENV_DAEMON_CONFIG_PATH_OVERRIDE, bootstrap_default_daemon_environment, load_daemon_settings,
     persist_dashboard_tls_hint, update_daemon_telemetry_consent,
 };
+use crate::devql_transport::{RepoPathRegistry, RepoPathRegistryEntry, persist_repo_path_registry};
+use crate::host::runtime_store::RepoSqliteRuntimeStore;
+use crate::test_support::git_fixtures::init_test_repo;
 use crate::test_support::log_capture::capture_logs_async;
 use crate::test_support::process_state::enter_process_state;
 use tempfile::TempDir;
@@ -34,6 +37,60 @@ fn write_daemon_config(config_root: &Path, content: &str) -> PathBuf {
     fs::create_dir_all(parent).expect("create config parent");
     fs::write(&config_path, content).expect("write daemon config");
     config_path
+}
+
+#[cfg(unix)]
+fn spawn_detached_long_lived_process() -> u32 {
+    let output = std::process::Command::new("sh")
+        .args(["-c", "sleep 60 >/dev/null 2>&1 & echo $!"])
+        .output()
+        .expect("spawn detached long-lived process");
+    assert!(
+        output.status.success(),
+        "failed to spawn detached long-lived process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("detached pid stdout should be utf8")
+        .trim()
+        .parse()
+        .expect("detached pid should parse")
+}
+
+#[cfg(windows)]
+fn spawn_detached_long_lived_process() -> u32 {
+    let output = std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "$p = Start-Process -FilePath ping -ArgumentList '-n 60 127.0.0.1' -WindowStyle Hidden -PassThru; $p.Id",
+        ])
+        .output()
+        .expect("spawn detached long-lived process");
+    assert!(
+        output.status.success(),
+        "failed to spawn detached long-lived process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("detached pid stdout should be utf8")
+        .trim()
+        .parse()
+        .expect("detached pid should parse")
+}
+
+fn wait_for_pid_exit(pid: u32) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if !process_is_running(pid).expect("inspect detached watcher process state") {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected detached watcher process {pid} to exit during daemon shutdown cleanup"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
 }
 
 #[tokio::test]
@@ -84,6 +141,76 @@ async fn daemon_lifecycle_logs_terminal_restart_failure() {
 #[test]
 fn supervisor_service_name_is_global_and_stable() {
     assert_eq!(GLOBAL_SUPERVISOR_SERVICE_NAME, "com.bitloops.daemon");
+}
+
+#[test]
+fn daemon_shutdown_tears_down_watchers_bound_to_the_same_daemon_config() {
+    let temp = TempDir::new().expect("temp dir");
+    let daemon_root = temp.path().join("daemon-root");
+    let repo_root = temp.path().join("repo");
+    fs::create_dir_all(&daemon_root).expect("create daemon root");
+    fs::create_dir_all(&repo_root).expect("create repo root");
+    init_test_repo(&repo_root, "main", "Bitloops Test", "bitloops@example.com");
+    fs::write(
+        repo_root.join(".bitloops.local.toml"),
+        "[capture]\nenabled = true\nstrategy = \"manual-commit\"\n",
+    )
+    .expect("write repo-local watcher policy");
+
+    let daemon_config_path = write_daemon_test_config(&daemon_root);
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(".bitloops.local.toml"),
+        &daemon_config_path,
+    )
+    .expect("write repo daemon binding");
+
+    let mut daemon_config =
+        resolve_daemon_config(Some(daemon_config_path.as_path())).expect("resolve daemon config");
+    daemon_config.repo_registry_path = temp.path().join("repo-path-registry.json");
+
+    let repo = crate::host::devql::resolve_repo_identity(&repo_root).expect("resolve repo");
+    persist_repo_path_registry(
+        &daemon_config.repo_registry_path,
+        &RepoPathRegistry {
+            version: 1,
+            entries: vec![RepoPathRegistryEntry {
+                repo_id: repo.repo_id,
+                provider: repo.provider,
+                organisation: repo.organization,
+                name: repo.name,
+                identity: repo.identity,
+                repo_root: repo_root.clone(),
+                last_branch: Some("main".to_string()),
+                git_dir_relative_path: Some(".git".to_string()),
+                updated_at_unix: 0,
+            }],
+        },
+    )
+    .expect("persist repo path registry");
+
+    let watcher_pid = spawn_detached_long_lived_process();
+    let runtime_store =
+        RepoSqliteRuntimeStore::open_for_roots(&daemon_config.config_root, &repo_root)
+            .expect("open repo runtime store");
+    runtime_store
+        .save_watcher_registration(
+            watcher_pid,
+            "shutdown-cleanup-token",
+            &repo_root,
+            crate::host::runtime_store::RepoWatcherRegistrationState::Ready,
+        )
+        .expect("seed watcher registration");
+
+    stop_bound_repo_watchers_for_daemon_shutdown(&daemon_config);
+
+    assert!(
+        runtime_store
+            .load_watcher_registration()
+            .expect("load watcher registration after shutdown cleanup")
+            .is_none(),
+        "daemon shutdown cleanup should clear watcher registration for bound repo"
+    );
+    wait_for_pid_exit(watcher_pid);
 }
 
 #[test]

--- a/bitloops/src/host/devql/watch.rs
+++ b/bitloops/src/host/devql/watch.rs
@@ -24,6 +24,9 @@ pub const DISABLE_WATCHER_AUTOSTART_ENV: &str = "BITLOOPS_DISABLE_WATCHER_AUTOST
 const WATCHER_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const WATCHER_READY_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const WATCHER_RESCAN_MIN_INTERVAL: Duration = Duration::from_secs(2);
+const WATCHER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_WATCHER_IDLE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const WATCHER_IDLE_TIMEOUT_ENV: &str = "BITLOOPS_WATCHER_IDLE_TIMEOUT_SECS";
 
 #[derive(Debug, Clone, Args)]
 pub struct WatcherProcessArgs {
@@ -164,16 +167,25 @@ pub fn ensure_watcher_running(repo_root: &Path, daemon_config_root: &Path) -> Re
 }
 
 pub fn restart_watcher(repo_root: &Path, daemon_config_root: &Path) -> Result<()> {
-    let runtime_store = RepoSqliteRuntimeStore::open_for_roots(daemon_config_root, repo_root)?;
-    if let Some(entry) = runtime_store.load_watcher_registration()?
-        && process_is_running(entry.pid)
-    {
-        kill_process(entry.pid);
-    }
-    runtime_store.clear_watcher_registration()?;
+    stop_watcher(repo_root, daemon_config_root)?;
     if crate::config::settings::is_enabled_for_hooks(repo_root) {
         ensure_watcher_running(repo_root, daemon_config_root)?;
     }
+    Ok(())
+}
+
+pub fn stop_watcher(repo_root: &Path, daemon_config_root: &Path) -> Result<()> {
+    let runtime_store = RepoSqliteRuntimeStore::open_for_roots(daemon_config_root, repo_root)?;
+    let registration = runtime_store.load_watcher_registration()?;
+    runtime_store.clear_watcher_registration()?;
+
+    if let Some(entry) = registration
+        && process_is_running(entry.pid)
+    {
+        kill_process(entry.pid);
+        let _ = wait_for_process_exit(entry.pid, WATCHER_STOP_TIMEOUT);
+    }
+
     Ok(())
 }
 
@@ -274,7 +286,7 @@ fn run_notify_loop(
         .with_context(|| format!("watching repo {}", cfg.repo_root.display()))?;
     let runtime_store =
         RepoSqliteRuntimeStore::open_for_roots(&cfg.daemon_config_root, &cfg.repo_root)?;
-    let _registration_guard = WatcherRegistrationGuard::acquire(runtime_store, &cfg.repo_root)?;
+    let registration_guard = WatcherRegistrationGuard::acquire(runtime_store, &cfg.repo_root)?;
     log::info!(
         "devql watcher started: repo_root={} daemon_config_root={}",
         cfg.repo_root.display(),
@@ -287,14 +299,40 @@ fn run_notify_loop(
     let mut last_rescan = Instant::now();
     let mut batch: BTreeSet<PathBuf> = BTreeSet::new();
     let mut window_start: Option<Instant> = None;
+    let idle_timeout = watcher_idle_timeout();
+    let mut last_external_activity = Instant::now();
 
     while !shutdown.load(Ordering::SeqCst) {
+        match evaluate_watcher_exit_reason(
+            cfg,
+            &registration_guard.runtime_store,
+            registration_guard.pid,
+            &registration_guard.restart_token,
+            last_external_activity,
+            idle_timeout,
+            !batch.is_empty() || window_start.is_some(),
+        ) {
+            Ok(Some(reason)) => {
+                log::info!(
+                    "devql watcher exiting: repo_root={} reason={}",
+                    cfg.repo_root.display(),
+                    reason.as_str()
+                );
+                return Ok(());
+            }
+            Ok(None) => {}
+            Err(err) => {
+                log::warn!("devql watcher lifecycle check failed: {err:#}");
+            }
+        }
+
         if watcher_repo_root_missing(&cfg.repo_root) {
             return Ok(());
         }
 
         match rx.recv_timeout(Duration::from_millis(100)) {
             Ok(Ok(event)) => {
+                let mut saw_relevant_path = false;
                 for path in event.paths {
                     if should_ignore_path(&cfg.repo_root, &path)
                         || is_gitignored(&cfg.repo_root, &path)
@@ -302,6 +340,10 @@ fn run_notify_loop(
                         continue;
                     }
                     batch.insert(path);
+                    saw_relevant_path = true;
+                }
+                if saw_relevant_path {
+                    last_external_activity = Instant::now();
                 }
                 if !batch.is_empty() && window_start.is_none() {
                     window_start = Some(Instant::now());
@@ -492,6 +534,82 @@ fn process_is_running(pid: u32) -> bool {
             .map(|status| status.success())
             .unwrap_or(false)
     }
+}
+
+fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !process_is_running(pid) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn watcher_idle_timeout() -> Duration {
+    watcher_idle_timeout_from_env(env::var(WATCHER_IDLE_TIMEOUT_ENV).ok().as_deref())
+}
+
+fn watcher_idle_timeout_from_env(raw: Option<&str>) -> Duration {
+    raw.and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_WATCHER_IDLE_TIMEOUT)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WatcherExitReason {
+    RepoMissing,
+    CaptureDisabled,
+    RegistrationLost,
+    Idle,
+}
+
+impl WatcherExitReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RepoMissing => "repo_missing",
+            Self::CaptureDisabled => "capture_disabled",
+            Self::RegistrationLost => "registration_lost",
+            Self::Idle => "idle_timeout",
+        }
+    }
+}
+
+fn evaluate_watcher_exit_reason(
+    cfg: &crate::host::devql::DevqlConfig,
+    runtime_store: &RepoSqliteRuntimeStore,
+    pid: u32,
+    restart_token: &str,
+    last_external_activity: Instant,
+    idle_timeout: Duration,
+    has_pending_batch: bool,
+) -> Result<Option<WatcherExitReason>> {
+    if watcher_repo_root_missing(&cfg.repo_root) {
+        return Ok(Some(WatcherExitReason::RepoMissing));
+    }
+    if !crate::config::settings::is_enabled_for_hooks(&cfg.repo_root) {
+        return Ok(Some(WatcherExitReason::CaptureDisabled));
+    }
+    if !watcher_registration_matches(runtime_store, pid, restart_token)? {
+        return Ok(Some(WatcherExitReason::RegistrationLost));
+    }
+    if !has_pending_batch && last_external_activity.elapsed() >= idle_timeout {
+        return Ok(Some(WatcherExitReason::Idle));
+    }
+    Ok(None)
+}
+
+fn watcher_registration_matches(
+    runtime_store: &RepoSqliteRuntimeStore,
+    pid: u32,
+    restart_token: &str,
+) -> Result<bool> {
+    Ok(runtime_store
+        .load_watcher_registration()?
+        .is_some_and(|entry| entry.pid == pid && entry.restart_token == restart_token))
 }
 
 struct WatcherRegistrationGuard {

--- a/bitloops/src/host/devql/watch_tests.rs
+++ b/bitloops/src/host/devql/watch_tests.rs
@@ -3,6 +3,7 @@ use crate::test_support::git_fixtures::init_test_repo;
 use crate::test_support::log_capture::capture_logs_async;
 use crate::test_support::process_state::with_env_var;
 
+use std::process::Command;
 use tempfile::TempDir;
 
 use super::*;
@@ -12,9 +13,68 @@ fn seed_runtime_store() -> (TempDir, PathBuf, RepoSqliteRuntimeStore) {
     let repo_root = dir.path().join("repo");
     fs::create_dir_all(&repo_root).expect("create repo root");
     init_test_repo(&repo_root, "main", "Bitloops Test", "bitloops@example.com");
+    fs::write(
+        repo_root.join(".bitloops.local.toml"),
+        "[capture]\nenabled = true\nstrategy = \"manual-commit\"\n",
+    )
+    .expect("write repo-local watcher policy");
     let store = RepoSqliteRuntimeStore::open_for_roots(dir.path(), &repo_root)
         .expect("open repo runtime store");
     (dir, repo_root, store)
+}
+
+#[cfg(unix)]
+fn spawn_detached_long_lived_process() -> u32 {
+    let output = Command::new("sh")
+        .args(["-c", "sleep 60 >/dev/null 2>&1 & echo $!"])
+        .output()
+        .expect("spawn detached long-lived process");
+    assert!(
+        output.status.success(),
+        "failed to spawn detached long-lived process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("detached pid stdout should be utf8")
+        .trim()
+        .parse()
+        .expect("detached pid should parse")
+}
+
+#[cfg(windows)]
+fn spawn_detached_long_lived_process() -> u32 {
+    let output = Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-Command",
+            "$p = Start-Process -FilePath ping -ArgumentList '-n 60 127.0.0.1' -WindowStyle Hidden -PassThru; $p.Id",
+        ])
+        .output()
+        .expect("spawn detached long-lived process");
+    assert!(
+        output.status.success(),
+        "failed to spawn detached long-lived process: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("detached pid stdout should be utf8")
+        .trim()
+        .parse()
+        .expect("detached pid should parse")
+}
+
+fn wait_for_pid_exit(pid: u32) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if !process_is_running(pid) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected process {pid} to exit during watcher teardown"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
 }
 
 #[test]
@@ -359,6 +419,117 @@ fn current_watcher_restart_token_hashes_the_current_binary() {
     let token = current_watcher_restart_token().expect("restart token");
     assert_eq!(token.len(), 64);
     assert!(token.chars().all(|ch| ch.is_ascii_hexdigit()));
+}
+
+#[test]
+fn stop_watcher_terminates_registered_process_and_clears_registration() {
+    let (_dir, repo_root, store) = seed_runtime_store();
+    let watcher_pid = spawn_detached_long_lived_process();
+
+    store
+        .save_watcher_registration(
+            watcher_pid,
+            "stop-token",
+            &repo_root,
+            crate::host::runtime_store::RepoWatcherRegistrationState::Ready,
+        )
+        .expect("seed watcher registration");
+
+    stop_watcher(&repo_root, _dir.path()).expect("stop watcher");
+
+    wait_for_pid_exit(watcher_pid);
+    assert!(
+        store
+            .load_watcher_registration()
+            .expect("load watcher registration after stop")
+            .is_none(),
+        "watcher stop should clear the owned registration"
+    );
+}
+
+#[test]
+fn watcher_lifecycle_exits_when_registration_is_cleared() {
+    let (_dir, repo_root, store) = seed_runtime_store();
+    let cfg = crate::host::devql::DevqlConfig::from_roots(
+        _dir.path().to_path_buf(),
+        repo_root.clone(),
+        crate::host::devql::resolve_repo_identity(&repo_root).expect("resolve repo identity"),
+    )
+    .expect("build watcher config");
+
+    assert_eq!(
+        evaluate_watcher_exit_reason(
+            &cfg,
+            &store,
+            42,
+            "missing-token",
+            Instant::now(),
+            Duration::from_secs(60),
+            false,
+        )
+        .expect("evaluate watcher lifecycle"),
+        Some(WatcherExitReason::RegistrationLost)
+    );
+}
+
+#[test]
+fn watcher_lifecycle_exits_after_idle_timeout_without_pending_batch() {
+    let (_dir, repo_root, store) = seed_runtime_store();
+    let pid = 42;
+    let token = "idle-token";
+    store
+        .save_watcher_registration(
+            pid,
+            token,
+            &repo_root,
+            crate::host::runtime_store::RepoWatcherRegistrationState::Ready,
+        )
+        .expect("seed watcher registration");
+    let cfg = crate::host::devql::DevqlConfig::from_roots(
+        _dir.path().to_path_buf(),
+        repo_root.clone(),
+        crate::host::devql::resolve_repo_identity(&repo_root).expect("resolve repo identity"),
+    )
+    .expect("build watcher config");
+
+    assert_eq!(
+        evaluate_watcher_exit_reason(
+            &cfg,
+            &store,
+            pid,
+            token,
+            Instant::now() - Duration::from_secs(5),
+            Duration::from_secs(1),
+            false,
+        )
+        .expect("evaluate watcher lifecycle"),
+        Some(WatcherExitReason::Idle)
+    );
+    assert_eq!(
+        evaluate_watcher_exit_reason(
+            &cfg,
+            &store,
+            pid,
+            token,
+            Instant::now() - Duration::from_secs(5),
+            Duration::from_secs(1),
+            true,
+        )
+        .expect("evaluate watcher lifecycle with pending batch"),
+        None
+    );
+}
+
+#[test]
+fn watcher_idle_timeout_uses_env_override_when_present() {
+    assert_eq!(
+        watcher_idle_timeout_from_env(Some("7")),
+        Duration::from_secs(7)
+    );
+    assert_eq!(
+        watcher_idle_timeout_from_env(Some("not-a-number")),
+        DEFAULT_WATCHER_IDLE_TIMEOUT
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This PR fixes Bitloops process lifecycle issues that could leave orphaned `__devql-watcher` processes and unreaped daemon children behind after task or benchmark daemons exited. In practice, those leaked processes could accumulate and contribute to shell errors like `fork failed: resource temporarily unavailable`.

## What changed

- Run daemon shutdown cleanup before the dashboard shutdown grace wait so foreground task daemons do not lose the race to external termination.
- Stop repo-scoped `__devql-watcher` processes when the bound daemon exits normally, not only when `bitloops daemon stop` is called explicitly.
- Strengthen watcher lifecycle handling in `watch.rs`, including explicit stop/registration cleanup and safer shutdown behavior for detached watchers.
- Reap exited daemon child processes in the supervisor and daemon lifecycle so `__daemon-process` children do not accumulate as zombies.
- Extend daemon lifecycle/runtime handling and add regression coverage for watcher teardown on daemon shutdown.

## Why

`__daemon-supervisor` is expected to remain as the long-lived global service, but finished task sandboxes should not leave behind repo daemons, detached watchers, or zombie children. This change makes that cleanup automatic on the Bitloops side.

## Validation

- `cargo test -p bitloops --lib dashboard_runtime_unit_tests::run_shutdown_actions_calls_hook_before_waiting -- --nocapture`
- `cargo test -p bitloops --lib daemon_shutdown_tears_down_watchers_bound_to_the_same_daemon_config -- --nocapture`
- `cargo test -p bitloops --lib stop_watcher_terminates_registered_process_and_clears_registration -- --nocapture`
- `cargo test -p bitloops reaps_exited_child_process_by_pid -- --nocapture`
- `cargo check -p bitloops --tests`
- `cargo fmt --all`

## Result

After rerunning the benchmark, Bitloops cleaned up correctly: no leftover `__devql-watcher`, no leftover repo `__daemon-process`, and no Bitloops zombie processes remained. Only the expected global `__daemon-supervisor` stayed running.


## Validation

- [ ] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

