### PR TITLE
Respect DevQL ingest policy for producer sync

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -114,7 +114,7 @@ jobs:
           shared-key: dev-ci
           cache-workspace-crates: true
       - name: Run develop gate QAT
-        run: cargo qat-develop-gate --parallel 3
+        run: cargo qat-develop-gate
 
   test-full:
     name: Full test suite

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -114,7 +114,7 @@ jobs:
           shared-key: dev-ci
           cache-workspace-crates: true
       - name: Run develop gate QAT
-        run: cargo qat-develop-gate
+        run: cargo qat-develop-gate --parallel 3
 
   test-full:
     name: Full test suite

--- a/bitloops/qat/features/devql-sync/sync_workspace.feature
+++ b/bitloops/qat/features/devql-sync/sync_workspace.feature
@@ -174,6 +174,23 @@ Feature: DevQL sync workspace reconciliation
     And I enqueue DevQL sync validate task with status in bitloops
     Then DevQL sync validation reports clean in bitloops
 
+  @devql @sync @sync_producer @sync_producer_post_merge @sync_no_ingest
+  Scenario: Post-merge sync respects init ingest disabled
+    Given I run CleanStart for flow "SyncPostMergeNoIngest"
+    And I start the daemon in bitloops
+    And I create a simple Rust project in bitloops
+    And I run InitCommit for bitloops
+    And I run bitloops producer-contract init --agent claude --sync=true in bitloops
+    Then DevQL watcher is registered and running in bitloops
+    Given I snapshot completed DevQL sync task source "post_merge" in bitloops
+    When I simulate a git pull with new changes in bitloops
+    Then a completed DevQL sync task with source "post_merge" shows work greater than 0 since snapshot in bitloops
+    And artefacts_current eventually contains path "src/utils.rs" without nudge in bitloops
+    Given I wait for the DevQL task queue to become idle in bitloops
+    Then no DevQL ingest task with source "post_merge" exists since snapshot in bitloops
+    Given I enqueue DevQL sync validate task with status in bitloops
+    Then DevQL sync validation reports clean in bitloops
+
   @devql @sync @sync_manual @sync_manual_smoke
   Scenario: Sync validate reports clean after a full sync
     Given I run CleanStart for flow "SyncValidateClean"

--- a/bitloops/qat/features/devql/context_guidance_smoke.feature
+++ b/bitloops/qat/features/devql/context_guidance_smoke.feature
@@ -11,11 +11,13 @@ Feature: DevQL context guidance smoke
     And I start the daemon in bitloops
     And I create a TypeScript project with tests and coverage in bitloops
     And I run InitCommit for bitloops
-    And I init bitloops in bitloops
+    And I run bitloops init --agent claude-code --sync=false --ingest=true in bitloops
     And I configure context guidance with fake text-generation runtime in bitloops
     And I run DevQL init in bitloops
     And I make a first change using Claude Code to bitloops
     And I committed today in bitloops
+    And I enqueue DevQL ingest task with status in bitloops
+    And I enqueue DevQL sync task with status in bitloops
     Then daemon enrichments eventually drain in bitloops
     And DevQL context guidance query for "src/services/user-service.ts" returns at least 1 item in bitloops
     And DevQL context guidance query for "src/services/user-service.ts" includes kind "qat_mocked_guidance_generation" in bitloops

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -1340,6 +1340,20 @@ fn run_init_creates_project_local_policy_and_installs_selected_agents() {
         assert!(!rendered.contains("Initialising DevQL schema"));
         assert!(!rendered.contains("Bitloops project bootstrap is ready."));
         assert!(repo.path().join(".bitloops.local.toml").exists());
+        let local_policy = std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+            .expect("read local repo policy");
+        assert!(
+            local_policy.contains("[devql]"),
+            "expected [devql] table in local policy:\n{local_policy}"
+        );
+        assert!(
+            local_policy.contains("sync_enabled = false"),
+            "expected init --sync=false to persist sync_enabled=false:\n{local_policy}"
+        );
+        assert!(
+            local_policy.contains("ingest_enabled = false"),
+            "expected init --ingest=false to persist ingest_enabled=false:\n{local_policy}"
+        );
         assert_eq!(
             crate::cli::enable::initialized_agents(repo.path()),
             vec![DEFAULT_AGENT.to_string()]
@@ -1547,7 +1561,7 @@ fn run_init_binds_repo_to_running_daemon_config() {
 }
 
 #[test]
-fn run_init_bootstraps_repo_watcher_when_capture_is_enabled() {
+fn run_init_reports_repo_watcher_disabled_when_sync_is_disabled() {
     let repo = tempfile::tempdir().expect("repo tempdir");
     let app_dirs = tempfile::tempdir().expect("app tempdir");
     let repo_root = repo.path().to_path_buf();
@@ -1559,11 +1573,11 @@ fn run_init_bootstraps_repo_watcher_when_capture_is_enabled() {
             {
                 let reconcile_count = std::rc::Rc::clone(&reconcile_count);
                 let repo_root = repo_root.clone();
-                move |actual_repo_root, capture_enabled| {
+                move |actual_repo_root, watcher_enabled| {
                     assert_eq!(actual_repo_root, repo_root.as_path());
                     assert!(
-                        capture_enabled,
-                        "init should only reconcile watchers when capture is enabled"
+                        !watcher_enabled,
+                        "init --sync=false should not reconcile/start a DevQL watcher"
                     );
                     *reconcile_count.borrow_mut() += 1;
                     Ok(())
@@ -1628,11 +1642,11 @@ fn run_init_surfaces_repo_watcher_reconcile_failures() {
         crate::cli::watcher_bootstrap::with_watcher_reconciliation_hook(
             {
                 let repo_root = repo_root.clone();
-                move |actual_repo_root, capture_enabled| {
+                move |actual_repo_root, watcher_enabled| {
                     assert_eq!(actual_repo_root, repo_root.as_path());
                     assert!(
-                        capture_enabled,
-                        "init should only reconcile watchers when capture is enabled"
+                        !watcher_enabled,
+                        "init --sync=false should surface watcher reconcile failures with watcher disabled"
                     );
                     anyhow::bail!("watcher reconcile exploded");
                 }
@@ -1681,7 +1695,7 @@ fn run_init_surfaces_repo_watcher_reconcile_failures() {
 }
 
 #[test]
-fn run_init_bootstraps_repo_watcher_from_nested_project_root() {
+fn run_init_reports_nested_repo_watcher_disabled_when_sync_is_disabled() {
     let repo = tempfile::tempdir().expect("repo tempdir");
     let app_dirs = tempfile::tempdir().expect("app tempdir");
     let project_root = repo.path().join("apps/nested-project");
@@ -1694,11 +1708,11 @@ fn run_init_bootstraps_repo_watcher_from_nested_project_root() {
             {
                 let reconcile_count = std::rc::Rc::clone(&reconcile_count);
                 let project_root = project_root.clone();
-                move |actual_repo_root, capture_enabled| {
+                move |actual_repo_root, watcher_enabled| {
                     assert_eq!(actual_repo_root, project_root.as_path());
                     assert!(
-                        capture_enabled,
-                        "nested init should reconcile watchers when nested-project capture is enabled"
+                        !watcher_enabled,
+                        "nested init --sync=false should not reconcile/start a DevQL watcher"
                     );
                     *reconcile_count.borrow_mut() += 1;
                     Ok(())
@@ -1769,7 +1783,7 @@ fn run_init_does_not_bootstrap_repo_watcher_when_repo_setup_fails() {
         crate::cli::watcher_bootstrap::with_watcher_reconciliation_hook(
             {
                 let reconcile_count = std::rc::Rc::clone(&reconcile_count);
-                move |_repo_root, _capture_enabled| {
+                move |_repo_root, _watcher_enabled| {
                     *reconcile_count.borrow_mut() += 1;
                     Ok(())
                 }

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -19,7 +19,7 @@ use crate::cli::inference::{
 };
 use crate::cli::telemetry_consent;
 use crate::config::settings::{
-    DEFAULT_STRATEGY, load_settings, set_scope_exclusions,
+    DEFAULT_STRATEGY, load_settings, set_devql_producer_settings, set_scope_exclusions,
     write_project_bootstrap_settings_with_daemon_binding_and_devql_guidance,
 };
 use crate::config::{REPO_POLICY_LOCAL_FILE_NAME, default_daemon_config_exists};
@@ -578,6 +578,7 @@ pub(crate) async fn run_for_project_root(
     }
     let should_sync = final_setup_selection.sync;
     let should_ingest = final_setup_selection.ingest;
+    set_devql_producer_settings(&local_policy_path, should_sync, should_ingest)?;
     let run_code_embeddings = should_sync && code_embeddings_selected;
     let run_summaries = should_sync && summaries_selected;
     let run_summary_embeddings = run_summaries && code_embeddings_selected;

--- a/bitloops/src/cli/watcher_bootstrap.rs
+++ b/bitloops/src/cli/watcher_bootstrap.rs
@@ -28,10 +28,11 @@ impl Drop for WatcherReconciliationHookGuard {
 
 pub(crate) fn reconcile_repo_watcher(repo_root: &Path) -> Result<()> {
     #[cfg(test)]
-    let capture_enabled = crate::config::settings::is_enabled_for_hooks(repo_root);
+    let watcher_enabled = crate::config::settings::is_enabled_for_hooks(repo_root)
+        && crate::config::settings::devql_sync_enabled(repo_root)?;
 
     #[cfg(test)]
-    if let Some(result) = maybe_reconcile_repo_watcher_via_hook(repo_root, capture_enabled) {
+    if let Some(result) = maybe_reconcile_repo_watcher_via_hook(repo_root, watcher_enabled) {
         return result;
     }
 
@@ -44,7 +45,11 @@ pub(crate) fn reconcile_repo_watcher(repo_root: &Path) -> Result<()> {
     {
         let daemon_config_root =
             crate::config::resolve_bound_daemon_config_root_for_repo(repo_root)?;
-        crate::host::devql::watch::restart_watcher(repo_root, &daemon_config_root)
+        if crate::config::settings::devql_sync_enabled(repo_root)? {
+            crate::host::devql::watch::restart_watcher(repo_root, &daemon_config_root)
+        } else {
+            crate::host::devql::watch::stop_watcher(repo_root, &daemon_config_root)
+        }
     }
 }
 
@@ -68,11 +73,11 @@ pub(crate) fn with_watcher_reconciliation_hook<T>(
 #[cfg(test)]
 fn maybe_reconcile_repo_watcher_via_hook(
     repo_root: &Path,
-    capture_enabled: bool,
+    watcher_enabled: bool,
 ) -> Option<Result<()>> {
     WATCHER_RECONCILIATION_HOOK.with(|hook: &RefCell<Option<Rc<WatcherReconciliationHook>>>| {
         hook.borrow()
             .as_ref()
-            .map(|hook| hook(repo_root, capture_enabled))
+            .map(|hook| hook(repo_root, watcher_enabled))
     })
 }

--- a/bitloops/src/config/repo_policy/discovery.rs
+++ b/bitloops/src/config/repo_policy/discovery.rs
@@ -82,6 +82,10 @@ fn discover_repo_policy_with_mode(start: &Path, strict: bool) -> Result<RepoPoli
         shared.as_ref().and_then(|value| value.watch.clone()),
         local.as_ref().and_then(|value| value.watch.clone()),
     );
+    let devql = merge_optional_values(
+        shared.as_ref().and_then(|value| value.devql.clone()),
+        local.as_ref().and_then(|value| value.devql.clone()),
+    );
     let scope = merge_scope_values(
         shared.as_ref().and_then(|value| value.scope.clone()),
         local.as_ref().and_then(|value| value.scope.clone()),
@@ -119,6 +123,7 @@ fn discover_repo_policy_with_mode(start: &Path, strict: bool) -> Result<RepoPoli
     let fingerprint = fingerprint_repo_policy(RepoPolicyFingerprintInputs {
         capture: &capture,
         watch: &watch,
+        devql: &devql,
         scope: &scope,
         scope_exclusions: &scope_exclusions,
         contexts: &contexts,
@@ -134,6 +139,7 @@ fn discover_repo_policy_with_mode(start: &Path, strict: bool) -> Result<RepoPoli
         daemon_config_path,
         capture,
         watch,
+        devql,
         scope,
         contexts,
         agents,
@@ -146,6 +152,7 @@ fn discover_repo_policy_with_mode(start: &Path, strict: bool) -> Result<RepoPoli
 fn default_repo_policy_snapshot() -> RepoPolicySnapshot {
     let capture = Value::Object(Map::new());
     let watch = Value::Object(Map::new());
+    let devql = Value::Object(Map::new());
     let scope = Value::Object(Map::new());
     let contexts = Value::Array(Vec::new());
     let agents = Value::Object(Map::new());
@@ -159,6 +166,7 @@ fn default_repo_policy_snapshot() -> RepoPolicySnapshot {
     let fingerprint = fingerprint_repo_policy(RepoPolicyFingerprintInputs {
         capture: &capture,
         watch: &watch,
+        devql: &devql,
         scope: &scope,
         scope_exclusions: &exclusions,
         contexts: &contexts,
@@ -175,6 +183,7 @@ fn default_repo_policy_snapshot() -> RepoPolicySnapshot {
         daemon_config_path: None,
         capture,
         watch,
+        devql,
         scope,
         contexts,
         agents,

--- a/bitloops/src/config/repo_policy/fingerprint.rs
+++ b/bitloops/src/config/repo_policy/fingerprint.rs
@@ -8,6 +8,7 @@ pub(super) fn fingerprint_repo_policy(inputs: RepoPolicyFingerprintInputs<'_>) -
     let RepoPolicyFingerprintInputs {
         capture,
         watch,
+        devql,
         scope,
         scope_exclusions,
         contexts,
@@ -18,6 +19,7 @@ pub(super) fn fingerprint_repo_policy(inputs: RepoPolicyFingerprintInputs<'_>) -
     let mut root = Map::new();
     root.insert("capture".into(), canonicalize_value(capture));
     root.insert("watch".into(), canonicalize_value(watch));
+    root.insert("devql".into(), canonicalize_value(devql));
     root.insert("scope".into(), canonicalize_value(scope));
     root.insert(
         "scope_exclusions".into(),

--- a/bitloops/src/config/repo_policy/types.rs
+++ b/bitloops/src/config/repo_policy/types.rs
@@ -14,6 +14,7 @@ pub struct RepoPolicySnapshot {
     pub daemon_config_path: Option<PathBuf>,
     pub capture: Value,
     pub watch: Value,
+    pub devql: Value,
     pub scope: Value,
     pub contexts: Value,
     pub agents: Value,
@@ -46,6 +47,7 @@ pub struct ImportedKnowledgeConfig {
 pub(super) struct RepoPolicyFingerprintInputs<'a> {
     pub(super) capture: &'a Value,
     pub(super) watch: &'a Value,
+    pub(super) devql: &'a Value,
     pub(super) scope: &'a Value,
     pub(super) scope_exclusions: &'a RepoPolicyScopeExclusions,
     pub(super) contexts: &'a Value,
@@ -67,6 +69,8 @@ pub(super) struct RepoPolicyTomlFile {
     pub(super) capture: Option<Value>,
     #[serde(default)]
     pub(super) watch: Option<Value>,
+    #[serde(default)]
+    pub(super) devql: Option<Value>,
     #[serde(default)]
     pub(super) scope: Option<Value>,
     #[serde(default)]

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -68,6 +68,21 @@ impl Default for BitloopsSettings {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DevqlProducerSettings {
+    pub sync_enabled: bool,
+    pub ingest_enabled: bool,
+}
+
+impl Default for DevqlProducerSettings {
+    fn default() -> Self {
+        Self {
+            sync_enabled: true,
+            ingest_enabled: true,
+        }
+    }
+}
+
 pub fn settings_path(repo_root: &Path) -> PathBuf {
     repo_root.join(SETTINGS_FILE)
 }
@@ -96,6 +111,35 @@ pub fn devql_guidance_enabled(start: &Path) -> Result<bool> {
 
 pub fn devql_guidance_enabled_or_false(start: &Path) -> bool {
     devql_guidance_enabled(start).unwrap_or(false)
+}
+
+pub fn devql_producer_settings(start: &Path) -> Result<DevqlProducerSettings> {
+    devql_producer_settings_from_policy(&discover_repo_policy_optional(start)?)
+}
+
+pub fn devql_producer_settings_from_policy(
+    policy: &super::RepoPolicySnapshot,
+) -> Result<DevqlProducerSettings> {
+    let mut settings = DevqlProducerSettings::default();
+    if let Some(raw) = policy.devql.get("sync_enabled") {
+        settings.sync_enabled = raw
+            .as_bool()
+            .ok_or_else(|| anyhow!("`[devql].sync_enabled` must be a boolean"))?;
+    }
+    if let Some(raw) = policy.devql.get("ingest_enabled") {
+        settings.ingest_enabled = raw
+            .as_bool()
+            .ok_or_else(|| anyhow!("`[devql].ingest_enabled` must be a boolean"))?;
+    }
+    Ok(settings)
+}
+
+pub fn devql_sync_enabled(start: &Path) -> Result<bool> {
+    devql_producer_settings(start).map(|settings| settings.sync_enabled)
+}
+
+pub fn devql_ingest_enabled(start: &Path) -> Result<bool> {
+    devql_producer_settings(start).map(|settings| settings.ingest_enabled)
 }
 
 pub fn agent_hook_install_options_for_policy(
@@ -341,6 +385,19 @@ pub fn set_devql_guidance_enabled(path: &Path, enabled: bool) -> Result<()> {
     })
 }
 
+pub fn set_devql_producer_settings(
+    path: &Path,
+    sync_enabled: bool,
+    ingest_enabled: bool,
+) -> Result<()> {
+    write_repo_policy_file(path, |doc| {
+        ensure_devql_table(doc);
+        doc["devql"]["sync_enabled"] = Item::Value(TomlValue::from(sync_enabled));
+        doc["devql"]["ingest_enabled"] = Item::Value(TomlValue::from(ingest_enabled));
+        Ok(())
+    })
+}
+
 fn save_repo_policy_settings(settings: &BitloopsSettings, path: &Path) -> Result<()> {
     write_repo_policy_file(path, |doc| {
         ensure_capture_table(doc);
@@ -448,6 +505,12 @@ fn ensure_daemon_table(doc: &mut DocumentMut) {
     }
 }
 
+fn ensure_devql_table(doc: &mut DocumentMut) {
+    if doc.get("devql").is_none_or(|item| !item.is_table()) {
+        doc["devql"] = Item::Table(Table::new());
+    }
+}
+
 fn string_array_item(values: &[String]) -> Item {
     let mut array = Array::new();
     for value in values {
@@ -476,6 +539,74 @@ supported = ["codex"]
         .expect("write repo policy");
 
         assert!(devql_guidance_enabled(dir.path()).expect("load devql guidance flag"));
+    }
+
+    #[test]
+    fn devql_producer_settings_default_to_enabled_when_policy_omits_table() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join(REPO_POLICY_FILE_NAME),
+            r#"
+[capture]
+enabled = true
+"#,
+        )
+        .expect("write repo policy");
+
+        let settings = devql_producer_settings(dir.path()).expect("load DevQL producer settings");
+
+        assert!(settings.sync_enabled);
+        assert!(settings.ingest_enabled);
+    }
+
+    #[test]
+    fn devql_producer_settings_read_local_policy_flags() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+            r#"
+[devql]
+sync_enabled = true
+ingest_enabled = false
+"#,
+        )
+        .expect("write local repo policy");
+
+        let settings = devql_producer_settings(dir.path()).expect("load DevQL producer settings");
+
+        assert!(settings.sync_enabled);
+        assert!(!settings.ingest_enabled);
+    }
+
+    #[test]
+    fn set_devql_producer_settings_persists_sync_and_ingest_flags() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(REPO_POLICY_LOCAL_FILE_NAME);
+
+        set_devql_producer_settings(&path, true, false).expect("write DevQL producer settings");
+
+        let content = fs::read_to_string(path).expect("read repo policy");
+        assert!(content.contains("[devql]"));
+        assert!(content.contains("sync_enabled = true"));
+        assert!(content.contains("ingest_enabled = false"));
+    }
+
+    #[test]
+    fn devql_producer_settings_reject_non_boolean_values() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+            r#"
+[devql]
+sync_enabled = "yes"
+ingest_enabled = false
+"#,
+        )
+        .expect("write local repo policy");
+
+        let err = devql_producer_settings(dir.path()).expect_err("non-bool flag should fail");
+
+        assert!(format!("{err:#}").contains("`[devql].sync_enabled` must be a boolean"));
     }
 
     #[test]

--- a/bitloops/src/daemon/server_runtime.rs
+++ b/bitloops/src/daemon/server_runtime.rs
@@ -360,6 +360,17 @@ pub(super) fn ensure_bound_repo_watchers_for_daemon_startup_with<F>(
         if !crate::config::settings::is_enabled_for_hooks(&repo_root) {
             continue;
         }
+        match crate::config::settings::devql_sync_enabled(&repo_root) {
+            Ok(true) => {}
+            Ok(false) => continue,
+            Err(err) => {
+                log::warn!(
+                    "failed to inspect DevQL sync settings during daemon startup for repo {}: {err:#}",
+                    repo_root.display()
+                );
+                continue;
+            }
+        }
         if let Err(err) = ensure_watcher_running(&repo_root, &daemon_config.config_root) {
             log::warn!(
                 "failed to start DevQL watcher during daemon startup for repo {}: {err:#}",

--- a/bitloops/src/daemon/tasks/coordinator/worker/spool.rs
+++ b/bitloops/src/daemon/tasks/coordinator/worker/spool.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::host::devql::{DevqlConfig, RepoIdentity};
 
@@ -58,6 +58,24 @@ impl DevqlTaskCoordinator {
     ) -> Result<()> {
         match &job.payload {
             crate::host::devql::ProducerSpoolJobPayload::Task { source, spec } => {
+                match spec {
+                    crate::daemon::DevqlTaskSpec::Sync(_)
+                        if !crate::config::settings::devql_sync_enabled(&job.repo_root).context(
+                            "loading DevQL sync producer policy for spooled sync task",
+                        )? =>
+                    {
+                        return Ok(());
+                    }
+                    crate::daemon::DevqlTaskSpec::Ingest(_)
+                        if !crate::config::settings::devql_ingest_enabled(&job.repo_root)
+                            .context(
+                                "loading DevQL ingest producer policy for spooled ingest task",
+                            )? =>
+                    {
+                        return Ok(());
+                    }
+                    _ => {}
+                }
                 let cfg = self.devql_config_from_producer_spool_job(job)?;
                 self.enqueue(&cfg, *source, spec.clone())?;
                 Ok(())
@@ -66,6 +84,11 @@ impl DevqlTaskCoordinator {
                 commit_sha,
                 changed_files,
             } => {
+                if !crate::config::settings::devql_sync_enabled(&job.repo_root)
+                    .context("loading DevQL sync producer policy for post-commit refresh")?
+                {
+                    return Ok(());
+                }
                 let cfg = self.devql_config_from_producer_spool_job(job)?;
                 crate::host::checkpoints::strategy::manual_commit::execute_devql_post_commit_refresh(
                     &cfg,
@@ -91,29 +114,37 @@ impl DevqlTaskCoordinator {
                 ..
             } => {
                 let cfg = self.devql_config_from_producer_spool_job(job)?;
-                let backfill =
-                    crate::host::checkpoints::strategy::manual_commit::default_post_merge_history_backfill();
-                self.enqueue(
-                    &cfg,
-                    crate::daemon::DevqlTaskSource::PostMerge,
-                    crate::daemon::DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec {
-                        backfill: Some(backfill),
-                    }),
-                )?;
-                let paths = crate::host::devql::refresh_paths_for_sync(
-                    &cfg,
-                    changed_files,
-                    "post-merge",
-                )?;
-                if !paths.is_empty() {
+                let ingest_enabled = crate::config::settings::devql_ingest_enabled(&job.repo_root)
+                    .context("loading DevQL ingest producer policy for post-merge refresh")?;
+                if ingest_enabled {
+                    let backfill =
+                        crate::host::checkpoints::strategy::manual_commit::default_post_merge_history_backfill();
                     self.enqueue(
                         &cfg,
                         crate::daemon::DevqlTaskSource::PostMerge,
-                        crate::daemon::DevqlTaskSpec::Sync(crate::daemon::SyncTaskSpec {
-                            mode: crate::daemon::SyncTaskMode::Paths { paths },
-                            post_commit_snapshot: None,
+                        crate::daemon::DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec {
+                            backfill: Some(backfill),
                         }),
                     )?;
+                }
+                let sync_enabled = crate::config::settings::devql_sync_enabled(&job.repo_root)
+                    .context("loading DevQL sync producer policy for post-merge refresh")?;
+                if sync_enabled {
+                    let paths = crate::host::devql::refresh_paths_for_sync(
+                        &cfg,
+                        changed_files,
+                        "post-merge",
+                    )?;
+                    if !paths.is_empty() {
+                        self.enqueue(
+                            &cfg,
+                            crate::daemon::DevqlTaskSource::PostMerge,
+                            crate::daemon::DevqlTaskSpec::Sync(crate::daemon::SyncTaskSpec {
+                                mode: crate::daemon::SyncTaskMode::Paths { paths },
+                                post_commit_snapshot: None,
+                            }),
+                        )?;
+                    }
                 }
                 Ok(())
             }
@@ -121,6 +152,11 @@ impl DevqlTaskCoordinator {
                 remote,
                 stdin_lines,
             } => {
+                if !crate::config::settings::devql_sync_enabled(&job.repo_root)
+                    .context("loading DevQL sync producer policy for pre-push sync")?
+                {
+                    return Ok(());
+                }
                 crate::host::checkpoints::strategy::manual_commit::execute_devql_pre_push_sync(
                     &job.repo_root,
                     remote,

--- a/bitloops/src/daemon/tasks/coordinator_tests.rs
+++ b/bitloops/src/daemon/tasks/coordinator_tests.rs
@@ -184,6 +184,82 @@ async fn producer_spool_task_job_enqueues_devql_task_and_clears_spool_row() {
 }
 
 #[tokio::test]
+async fn producer_spool_sync_task_job_skips_when_devql_sync_disabled() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_root = dir.path().join("config");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&config_root).expect("create config root");
+    std::fs::create_dir_all(&repo_root).expect("create repo root");
+
+    crate::test_support::git_fixtures::init_test_repo(
+        &repo_root,
+        "main",
+        "Bitloops Test",
+        "bitloops-test@example.com",
+    );
+    let config_path = crate::test_support::git_fixtures::write_test_daemon_config(&config_root);
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
+    crate::config::settings::set_devql_producer_settings(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        false,
+        true,
+    )
+    .expect("disable producer sync");
+
+    let repo = crate::host::devql::resolve_repo_identity(&repo_root).expect("resolve repo");
+    let cfg = DevqlConfig::from_roots(config_root.clone(), repo_root.clone(), repo.clone())
+        .expect("build devql config");
+    crate::host::devql::enqueue_spooled_sync_task(
+        &cfg,
+        DevqlTaskSource::Watcher,
+        crate::host::devql::SyncMode::Paths(vec!["src/lib.rs".to_string()]),
+    )
+    .expect("enqueue watcher sync into producer spool");
+
+    let jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs");
+    assert_eq!(jobs.len(), 1, "expected one producer spool job");
+
+    let coordinator = Arc::new(DevqlTaskCoordinator {
+        runtime_store: DaemonSqliteRuntimeStore::open_at(dir.path().join("daemon-runtime.sqlite"))
+            .expect("open daemon runtime store"),
+        lock: Mutex::new(()),
+        notify: Notify::new(),
+        worker_started: AtomicBool::new(false),
+        subscription_hub: Mutex::new(None),
+    });
+
+    Arc::clone(&coordinator)
+        .run_producer_spool_job(jobs.into_iter().next().expect("producer spool job"))
+        .await
+        .expect("process producer spool job");
+
+    let tasks = coordinator
+        .tasks(
+            Some(&cfg.repo.repo_id),
+            Some(DevqlTaskKind::Sync),
+            Some(DevqlTaskStatus::Queued),
+            None,
+        )
+        .expect("load queued tasks");
+    assert!(
+        tasks.is_empty(),
+        "producer spool task must not enqueue sync when [devql].sync_enabled=false"
+    );
+
+    let remaining_jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs after processing");
+    assert!(
+        remaining_jobs.is_empty(),
+        "policy-skipped producer spool jobs should be removed"
+    );
+}
+
+#[tokio::test]
 async fn post_merge_producer_spool_job_enqueues_visible_tasks_and_clears_spool_row() {
     let dir = TempDir::new().expect("temp dir");
     let config_root = dir.path().join("config");
@@ -287,6 +363,321 @@ async fn post_merge_producer_spool_job_enqueues_visible_tasks_and_clears_spool_r
     assert!(
         remaining_jobs.is_empty(),
         "completed producer spool jobs should be removed from the repo runtime store"
+    );
+}
+
+#[tokio::test]
+async fn post_merge_producer_spool_job_skips_ingest_when_devql_ingest_disabled() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_root = dir.path().join("config");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&config_root).expect("create config root");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create repo src dir");
+
+    crate::test_support::git_fixtures::init_test_repo(
+        &repo_root,
+        "main",
+        "Bitloops Test",
+        "bitloops-test@example.com",
+    );
+    std::fs::write(
+        repo_root.join("src/lib.rs"),
+        "pub fn qa_merge() -> i32 { 7 }\n",
+    )
+    .expect("write source file");
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["add", "."]);
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["commit", "-m", "initial"]);
+    let head_sha = crate::test_support::git_fixtures::git_ok(&repo_root, &["rev-parse", "HEAD"]);
+    let config_path = crate::test_support::git_fixtures::write_test_daemon_config(&config_root);
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
+    crate::config::settings::set_devql_producer_settings(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        true,
+        false,
+    )
+    .expect("disable producer ingest");
+
+    let repo = crate::host::devql::resolve_repo_identity(&repo_root).expect("resolve repo");
+    let cfg = DevqlConfig::from_roots(config_root.clone(), repo_root.clone(), repo.clone())
+        .expect("build devql config");
+    crate::host::devql::enqueue_spooled_post_merge_refresh(
+        &repo_root,
+        &head_sha,
+        &["src/lib.rs".to_string()],
+    )
+    .expect("enqueue post-merge producer spool job");
+
+    let jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs");
+    assert_eq!(jobs.len(), 1, "expected one post-merge producer job");
+
+    let coordinator = Arc::new(DevqlTaskCoordinator {
+        runtime_store: DaemonSqliteRuntimeStore::open_at(dir.path().join("daemon-runtime.sqlite"))
+            .expect("open daemon runtime store"),
+        lock: Mutex::new(()),
+        notify: Notify::new(),
+        worker_started: AtomicBool::new(false),
+        subscription_hub: Mutex::new(None),
+    });
+
+    Arc::clone(&coordinator)
+        .run_producer_spool_job(jobs.into_iter().next().expect("producer spool job"))
+        .await
+        .expect("process producer spool job");
+
+    let ingest_tasks = coordinator
+        .tasks(
+            Some(&cfg.repo.repo_id),
+            Some(DevqlTaskKind::Ingest),
+            Some(DevqlTaskStatus::Queued),
+            None,
+        )
+        .expect("load queued ingest tasks");
+    assert!(
+        ingest_tasks.is_empty(),
+        "post-merge must not enqueue ingest when [devql].ingest_enabled=false"
+    );
+
+    let sync_tasks = coordinator
+        .tasks(
+            Some(&cfg.repo.repo_id),
+            Some(DevqlTaskKind::Sync),
+            Some(DevqlTaskStatus::Queued),
+            None,
+        )
+        .expect("load queued sync tasks");
+    assert_eq!(
+        sync_tasks.len(),
+        1,
+        "post-merge current-state refresh should still be queued"
+    );
+    assert_eq!(sync_tasks[0].source, DevqlTaskSource::PostMerge);
+}
+
+#[tokio::test]
+async fn post_merge_producer_spool_job_skips_sync_when_devql_sync_disabled() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_root = dir.path().join("config");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&config_root).expect("create config root");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create repo src dir");
+
+    crate::test_support::git_fixtures::init_test_repo(
+        &repo_root,
+        "main",
+        "Bitloops Test",
+        "bitloops-test@example.com",
+    );
+    std::fs::write(
+        repo_root.join("src/lib.rs"),
+        "pub fn qa_merge() -> i32 { 7 }\n",
+    )
+    .expect("write source file");
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["add", "."]);
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["commit", "-m", "initial"]);
+    let head_sha = crate::test_support::git_fixtures::git_ok(&repo_root, &["rev-parse", "HEAD"]);
+    let config_path = crate::test_support::git_fixtures::write_test_daemon_config(&config_root);
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
+    crate::config::settings::set_devql_producer_settings(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        false,
+        true,
+    )
+    .expect("disable producer sync");
+
+    let repo = crate::host::devql::resolve_repo_identity(&repo_root).expect("resolve repo");
+    let cfg = DevqlConfig::from_roots(config_root.clone(), repo_root.clone(), repo.clone())
+        .expect("build devql config");
+    crate::host::devql::enqueue_spooled_post_merge_refresh(
+        &repo_root,
+        &head_sha,
+        &["src/lib.rs".to_string()],
+    )
+    .expect("enqueue post-merge producer spool job");
+
+    let jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs");
+    let coordinator = Arc::new(DevqlTaskCoordinator {
+        runtime_store: DaemonSqliteRuntimeStore::open_at(dir.path().join("daemon-runtime.sqlite"))
+            .expect("open daemon runtime store"),
+        lock: Mutex::new(()),
+        notify: Notify::new(),
+        worker_started: AtomicBool::new(false),
+        subscription_hub: Mutex::new(None),
+    });
+
+    Arc::clone(&coordinator)
+        .run_producer_spool_job(jobs.into_iter().next().expect("producer spool job"))
+        .await
+        .expect("process producer spool job");
+
+    let sync_tasks = coordinator
+        .tasks(
+            Some(&cfg.repo.repo_id),
+            Some(DevqlTaskKind::Sync),
+            Some(DevqlTaskStatus::Queued),
+            None,
+        )
+        .expect("load queued sync tasks");
+    assert!(
+        sync_tasks.is_empty(),
+        "post-merge must not enqueue sync when [devql].sync_enabled=false"
+    );
+
+    let ingest_tasks = coordinator
+        .tasks(
+            Some(&cfg.repo.repo_id),
+            Some(DevqlTaskKind::Ingest),
+            Some(DevqlTaskStatus::Queued),
+            None,
+        )
+        .expect("load queued ingest tasks");
+    assert_eq!(
+        ingest_tasks.len(),
+        1,
+        "ingest_enabled=true should still allow post-merge ingest"
+    );
+}
+
+#[tokio::test]
+async fn post_commit_producer_spool_job_skips_sync_when_devql_sync_disabled() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_root = dir.path().join("config");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&config_root).expect("create config root");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create repo src dir");
+
+    crate::test_support::git_fixtures::init_test_repo(
+        &repo_root,
+        "main",
+        "Bitloops Test",
+        "bitloops-test@example.com",
+    );
+    std::fs::write(repo_root.join("src/lib.rs"), "pub fn qa_commit() {}\n")
+        .expect("write source file");
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["add", "."]);
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["commit", "-m", "initial"]);
+    let head_sha = crate::test_support::git_fixtures::git_ok(&repo_root, &["rev-parse", "HEAD"]);
+    let config_path = crate::test_support::git_fixtures::write_test_daemon_config(&config_root);
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
+    crate::config::settings::set_devql_producer_settings(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        false,
+        true,
+    )
+    .expect("disable producer sync");
+
+    crate::host::devql::enqueue_spooled_post_commit_refresh(
+        &repo_root,
+        &head_sha,
+        &["src/lib.rs".to_string()],
+    )
+    .expect("enqueue post-commit producer spool job");
+
+    let jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs");
+    assert_eq!(jobs.len(), 1, "expected one post-commit producer job");
+    std::fs::remove_dir_all(repo_root.join(".git")).expect("remove git dir after spooling");
+
+    let coordinator = Arc::new(DevqlTaskCoordinator {
+        runtime_store: DaemonSqliteRuntimeStore::open_at(dir.path().join("daemon-runtime.sqlite"))
+            .expect("open daemon runtime store"),
+        lock: Mutex::new(()),
+        notify: Notify::new(),
+        worker_started: AtomicBool::new(false),
+        subscription_hub: Mutex::new(None),
+    });
+
+    Arc::clone(&coordinator)
+        .run_producer_spool_job(jobs.into_iter().next().expect("producer spool job"))
+        .await
+        .expect("process producer spool job");
+
+    let remaining_jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs after processing");
+    assert!(
+        remaining_jobs.is_empty(),
+        "sync-disabled post-commit producer spool job should be dropped instead of retried"
+    );
+}
+
+#[tokio::test]
+async fn pre_push_producer_spool_job_skips_sync_when_devql_sync_disabled() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_root = dir.path().join("config");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&config_root).expect("create config root");
+    std::fs::create_dir_all(repo_root.join("src")).expect("create repo src dir");
+
+    crate::test_support::git_fixtures::init_test_repo(
+        &repo_root,
+        "main",
+        "Bitloops Test",
+        "bitloops-test@example.com",
+    );
+    std::fs::write(repo_root.join("src/lib.rs"), "pub fn qa_pre_push() {}\n")
+        .expect("write source file");
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["add", "."]);
+    crate::test_support::git_fixtures::git_ok(&repo_root, &["commit", "-m", "initial"]);
+    let head_sha = crate::test_support::git_fixtures::git_ok(&repo_root, &["rev-parse", "HEAD"]);
+    let config_path = crate::test_support::git_fixtures::write_test_daemon_config(&config_root);
+    crate::config::settings::write_repo_daemon_binding(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write repo daemon binding");
+    crate::config::settings::set_devql_producer_settings(
+        &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        false,
+        true,
+    )
+    .expect("disable producer sync");
+
+    crate::host::devql::enqueue_spooled_pre_push_sync(
+        &repo_root,
+        "origin",
+        &[format!(
+            "refs/heads/main {head_sha} refs/heads/main 0000000000000000000000000000000000000000"
+        )],
+    )
+    .expect("enqueue pre-push producer spool job");
+
+    let jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs");
+    assert_eq!(jobs.len(), 1, "expected one pre-push producer job");
+    std::fs::remove_dir_all(repo_root.join(".git")).expect("remove git dir after spooling");
+
+    let coordinator = Arc::new(DevqlTaskCoordinator {
+        runtime_store: DaemonSqliteRuntimeStore::open_at(dir.path().join("daemon-runtime.sqlite"))
+            .expect("open daemon runtime store"),
+        lock: Mutex::new(()),
+        notify: Notify::new(),
+        worker_started: AtomicBool::new(false),
+        subscription_hub: Mutex::new(None),
+    });
+
+    Arc::clone(&coordinator)
+        .run_producer_spool_job(jobs.into_iter().next().expect("producer spool job"))
+        .await
+        .expect("process producer spool job");
+
+    let remaining_jobs = crate::host::devql::claim_next_producer_spool_jobs(&config_root)
+        .expect("claim producer spool jobs after processing");
+    assert!(
+        remaining_jobs.is_empty(),
+        "sync-disabled pre-push producer spool job should be dropped instead of retried"
     );
 }
 

--- a/bitloops/src/daemon/tests.rs
+++ b/bitloops/src/daemon/tests.rs
@@ -220,12 +220,14 @@ fn daemon_startup_rehydrates_enabled_bound_repo_watchers_and_continues_after_fai
     let enabled_repo = temp.path().join("enabled-repo");
     let second_enabled_repo = temp.path().join("second-enabled-repo");
     let third_enabled_repo = temp.path().join("third-enabled-repo");
+    let sync_disabled_repo = temp.path().join("sync-disabled-repo");
     let disabled_repo = temp.path().join("disabled-repo");
     let unbound_repo = temp.path().join("unbound-repo");
     for repo_root in [
         &enabled_repo,
         &second_enabled_repo,
         &third_enabled_repo,
+        &sync_disabled_repo,
         &disabled_repo,
         &unbound_repo,
     ] {
@@ -257,6 +259,11 @@ fn daemon_startup_rehydrates_enabled_bound_repo_watchers_and_continues_after_fai
         .expect("write enabled repo policy");
     }
     fs::write(
+        sync_disabled_repo.join(".bitloops.local.toml"),
+        "[capture]\nenabled = true\nstrategy = \"manual-commit\"\n[devql]\nsync_enabled = false\ningest_enabled = true\n",
+    )
+    .expect("write sync-disabled repo policy");
+    fs::write(
         disabled_repo.join(".bitloops.local.toml"),
         "[capture]\nenabled = false\nstrategy = \"manual-commit\"\n",
     )
@@ -266,6 +273,7 @@ fn daemon_startup_rehydrates_enabled_bound_repo_watchers_and_continues_after_fai
         &enabled_repo,
         &second_enabled_repo,
         &third_enabled_repo,
+        &sync_disabled_repo,
         &disabled_repo,
     ] {
         crate::config::settings::write_repo_daemon_binding(
@@ -288,6 +296,7 @@ fn daemon_startup_rehydrates_enabled_bound_repo_watchers_and_continues_after_fai
         &enabled_repo,
         &second_enabled_repo,
         &third_enabled_repo,
+        &sync_disabled_repo,
         &disabled_repo,
         &unbound_repo,
     ] {

--- a/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/post_checkout_seed.rs
+++ b/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/post_checkout_seed.rs
@@ -13,6 +13,12 @@ pub(crate) fn run_devql_post_checkout_seed(
         return Ok(());
     }
 
+    if !crate::config::settings::devql_sync_enabled(repo_root)
+        .context("loading DevQL sync producer policy for post-checkout branch seed")?
+    {
+        return Ok(());
+    }
+
     #[cfg(not(test))]
     {
         let _ = previous_head;
@@ -53,5 +59,24 @@ pub(crate) fn run_devql_post_checkout_seed(
             .build()
             .context("building tokio runtime for post-checkout DevQL seeding")?;
         runtime.block_on(seed_future)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn post_checkout_seed_sync_disabled_returns_ok_for_non_repo() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        crate::config::settings::set_devql_producer_settings(
+            &dir.path().join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+            false,
+            true,
+        )
+        .expect("disable producer sync");
+
+        run_devql_post_checkout_seed(dir.path(), "old", "new", true)
+            .expect("disabled sync should skip post-checkout seed");
     }
 }

--- a/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/post_commit_refresh.rs
+++ b/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/post_commit_refresh.rs
@@ -17,6 +17,11 @@ pub(crate) fn run_devql_post_commit_refresh(
     if should_skip_post_commit_devql_refresh() {
         return Ok(());
     }
+    if !crate::config::settings::devql_sync_enabled(repo_root)
+        .context("loading DevQL sync producer policy for post-commit refresh")?
+    {
+        return Ok(());
+    }
 
     let mut changed_files = committed_files.iter().cloned().collect::<Vec<_>>();
     changed_files.sort();
@@ -49,6 +54,12 @@ pub(crate) async fn execute_devql_post_commit_refresh(
     commit_sha: &str,
     changed_files: &[String],
 ) -> Result<()> {
+    if !crate::config::settings::devql_sync_enabled(&cfg.repo_root)
+        .context("loading DevQL sync producer policy for post-commit refresh")?
+    {
+        return Ok(());
+    }
+
     let commit_sha = commit_sha.trim();
     if commit_sha.is_empty() {
         return Ok(());
@@ -79,6 +90,11 @@ pub(crate) fn run_devql_post_commit_checkpoint_projection_refresh(
     checkpoint_id: &str,
 ) -> Result<()> {
     if should_skip_post_commit_devql_refresh() {
+        return Ok(());
+    }
+    if !crate::config::settings::devql_sync_enabled(repo_root).context(
+        "loading DevQL sync producer policy for post-commit checkpoint projection refresh",
+    )? {
         return Ok(());
     }
 

--- a/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/pre_push_sync/runtime.rs
+++ b/bitloops/src/host/checkpoints/strategy/manual_commit/strategy_impl/pre_push_sync/runtime.rs
@@ -5,6 +5,12 @@ pub(crate) fn run_devql_pre_push_sync(
     remote: &str,
     stdin_lines: &[String],
 ) -> Result<()> {
+    if !crate::config::settings::devql_sync_enabled(repo_root)
+        .context("loading DevQL sync producer policy for pre-push sync")?
+    {
+        return Ok(());
+    }
+
     #[cfg(not(test))]
     {
         crate::host::devql::enqueue_spooled_pre_push_sync(repo_root, remote, stdin_lines)
@@ -37,6 +43,12 @@ pub(crate) async fn execute_devql_pre_push_sync(
     remote: &str,
     stdin_lines: &[String],
 ) -> Result<()> {
+    if !crate::config::settings::devql_sync_enabled(repo_root)
+        .context("loading DevQL sync producer policy for pre-push sync")?
+    {
+        return Ok(());
+    }
+
     let repo = crate::host::devql::resolve_repo_identity(repo_root)
         .context("resolving repository identity for pre-push DevQL sync")?;
     let backends = crate::config::resolve_store_backend_config_for_repo(repo_root)

--- a/bitloops/src/host/devql/capture.rs
+++ b/bitloops/src/host/devql/capture.rs
@@ -17,8 +17,10 @@ pub(crate) fn capture_temporary_checkpoint_batch(
         .enable_all()
         .build()
         .context("creating watcher capture runtime")?;
-    runtime.block_on(sync_changed_paths(cfg, &changes.modified, &changes.deleted))?;
-    persist_workspace_revision(cfg, &changes.tree_hash)
+    match runtime.block_on(sync_changed_paths(cfg, &changes.modified, &changes.deleted))? {
+        SyncChangedPathsOutcome::Completed => persist_workspace_revision(cfg, &changes.tree_hash),
+        SyncChangedPathsOutcome::SkippedByPolicy => Ok(()),
+    }
 }
 
 pub(crate) fn capture_temporary_checkpoint_batch_with_handle(
@@ -29,14 +31,21 @@ pub(crate) fn capture_temporary_checkpoint_batch_with_handle(
     let Some(changes) = prepare_capture_temporary_checkpoint_batch(cfg, changed_paths)? else {
         return Ok(());
     };
-    handle.block_on(sync_changed_paths(cfg, &changes.modified, &changes.deleted))?;
-    persist_workspace_revision(cfg, &changes.tree_hash)
+    match handle.block_on(sync_changed_paths(cfg, &changes.modified, &changes.deleted))? {
+        SyncChangedPathsOutcome::Completed => persist_workspace_revision(cfg, &changes.tree_hash),
+        SyncChangedPathsOutcome::SkippedByPolicy => Ok(()),
+    }
 }
 
 struct PreparedCaptureBatch {
     modified: Vec<String>,
     deleted: Vec<String>,
     tree_hash: String,
+}
+
+enum SyncChangedPathsOutcome {
+    Completed,
+    SkippedByPolicy,
 }
 
 fn prepare_capture_temporary_checkpoint_batch(
@@ -138,7 +147,13 @@ async fn sync_changed_paths(
     cfg: &crate::host::devql::DevqlConfig,
     modified: &[String],
     deleted: &[String],
-) -> Result<()> {
+) -> Result<SyncChangedPathsOutcome> {
+    if !crate::config::settings::devql_sync_enabled(&cfg.repo_root)
+        .context("loading DevQL sync producer policy for watcher capture")?
+    {
+        return Ok(SyncChangedPathsOutcome::SkippedByPolicy);
+    }
+
     let mut paths = modified
         .iter()
         .chain(deleted.iter())
@@ -150,7 +165,7 @@ async fn sync_changed_paths(
     let paths =
         filter_paths_for_sync(cfg, &paths).context("classifying watcher capture paths for sync")?;
     if paths.is_empty() {
-        return Ok(());
+        return Ok(SyncChangedPathsOutcome::Completed);
     }
 
     #[cfg(test)]
@@ -158,14 +173,14 @@ async fn sync_changed_paths(
         crate::host::devql::run_sync_with_summary(cfg, crate::host::devql::SyncMode::Paths(paths))
             .await
             .context("running DevQL sync inline for watcher capture paths in tests")?;
-        Ok(())
+        Ok(SyncChangedPathsOutcome::Completed)
     }
 
     #[cfg(not(test))]
     {
         enqueue_spooled_sync_task_with_retry(cfg, paths)
             .context("queueing DevQL sync for watcher capture paths in repo-local spool")?;
-        Ok(())
+        Ok(SyncChangedPathsOutcome::Completed)
     }
 }
 

--- a/bitloops/src/host/devql/capture_tests.rs
+++ b/bitloops/src/host/devql/capture_tests.rs
@@ -59,6 +59,33 @@ fn devql_sqlite_path(repo_root: &std::path::Path) -> std::path::PathBuf {
         .expect("resolve configured sqlite path")
 }
 
+fn workspace_revision_count(repo_root: &std::path::Path, repo_id: &str) -> i64 {
+    let db_path = devql_sqlite_path(repo_root);
+    if !db_path.exists() {
+        return 0;
+    }
+
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let table_exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'workspace_revisions'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n > 0)
+        .unwrap_or(false);
+    if !table_exists {
+        return 0;
+    }
+
+    conn.query_row(
+        "SELECT COUNT(*) FROM workspace_revisions WHERE repo_id = ?1",
+        [repo_id],
+        |row| row.get(0),
+    )
+    .expect("count workspace_revisions")
+}
+
 #[test]
 fn capture_updates_current_devql_state_for_modified_file() {
     let dir = seed_repo();
@@ -556,6 +583,56 @@ fn prepare_capture_batch_does_not_consume_tree_hash_before_sync_handoff_succeeds
     assert!(
         second.is_some(),
         "retry should still produce a capture batch when the prior handoff never succeeded"
+    );
+}
+
+#[test]
+fn capture_sync_disabled_does_not_persist_workspace_revision() {
+    let dir = seed_repo();
+    crate::config::settings::set_devql_producer_settings(
+        &dir.path().join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        false,
+        true,
+    )
+    .expect("disable producer sync");
+    fs::write(
+        dir.path().join("src/lib.rs"),
+        "pub fn sync_disabled() -> i32 {\n    2\n}\n",
+    )
+    .expect("update file");
+
+    let repo = crate::host::devql::resolve_repo_identity(dir.path()).expect("resolve repo");
+    let cfg = crate::host::devql::DevqlConfig::from_env(dir.path().to_path_buf(), repo)
+        .expect("build devql config");
+    let target = dir.path().join("src/lib.rs");
+    capture_temporary_checkpoint_batch(&cfg, std::slice::from_ref(&target))
+        .expect("capture temporary checkpoint with sync disabled");
+
+    assert_eq!(
+        workspace_revision_count(dir.path(), &cfg.repo.repo_id),
+        0,
+        "policy-skipped sync must not persist workspace_revisions rows"
+    );
+
+    crate::config::settings::set_devql_producer_settings(
+        &dir.path().join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        true,
+        true,
+    )
+    .expect("enable producer sync");
+    let prepared = prepare_capture_temporary_checkpoint_batch(&cfg, std::slice::from_ref(&target))
+        .expect("prepare capture after re-enabling sync");
+    assert!(
+        prepared.is_some(),
+        "same tree hash must remain eligible after policy-skipped sync"
+    );
+
+    capture_temporary_checkpoint_batch(&cfg, std::slice::from_ref(&target))
+        .expect("capture temporary checkpoint after re-enabling sync");
+    assert_eq!(
+        workspace_revision_count(dir.path(), &cfg.repo.repo_id),
+        1,
+        "completed sync should persist one workspace_revisions row"
     );
 }
 

--- a/bitloops/src/host/devql/watch.rs
+++ b/bitloops/src/host/devql/watch.rs
@@ -76,6 +76,9 @@ pub fn ensure_watcher_running(repo_root: &Path, daemon_config_root: &Path) -> Re
     if watcher_autostart_disabled() {
         return Ok(());
     }
+    if !crate::config::settings::devql_sync_enabled(repo_root)? {
+        return Ok(());
+    }
 
     let restart_token = current_watcher_restart_token()?;
     let repo_root = repo_root
@@ -176,7 +179,9 @@ pub fn ensure_watcher_running(repo_root: &Path, daemon_config_root: &Path) -> Re
 
 pub fn restart_watcher(repo_root: &Path, daemon_config_root: &Path) -> Result<()> {
     stop_watcher(repo_root, daemon_config_root)?;
-    if crate::config::settings::is_enabled_for_hooks(repo_root) {
+    if crate::config::settings::is_enabled_for_hooks(repo_root)
+        && crate::config::settings::devql_sync_enabled(repo_root)?
+    {
         ensure_watcher_running(repo_root, daemon_config_root)?;
     }
     Ok(())
@@ -732,6 +737,9 @@ fn evaluate_watcher_exit_reason(
         return Ok(Some(WatcherExitReason::RepoMissing));
     }
     if !crate::config::settings::is_enabled_for_hooks(&cfg.repo_root) {
+        return Ok(Some(WatcherExitReason::CaptureDisabled));
+    }
+    if !crate::config::settings::devql_sync_enabled(&cfg.repo_root)? {
         return Ok(Some(WatcherExitReason::CaptureDisabled));
     }
     if !watcher_registration_matches(runtime_store, pid, restart_token)? {

--- a/bitloops/tests/qat_support/helpers/core.rs
+++ b/bitloops/tests/qat_support/helpers/core.rs
@@ -272,6 +272,67 @@ fn completed_sync_task_source_count(
         .count())
 }
 
+fn ingest_task_source_count(world: &QatWorld, expected_source: DevqlTaskSource) -> Result<usize> {
+    let repo_id = bitloops::host::devql::resolve_repo_id(world.repo_dir())
+        .context("resolving repo id for ingest task source count")?;
+    let store = open_scenario_daemon_runtime_store(world)?;
+    let Some(state) = store
+        .load_devql_task_queue_state()
+        .context("loading DevQL task queue state")?
+    else {
+        return Ok(0);
+    };
+
+    Ok(state
+        .tasks
+        .iter()
+        .filter(|task| {
+            task.repo_id == repo_id
+                && task.kind == DevqlTaskKind::Ingest
+                && task.source == expected_source
+        })
+        .count())
+}
+
+fn ingest_task_source_diagnostics_after_snapshot(
+    world: &QatWorld,
+    expected_source: DevqlTaskSource,
+    snapshot_count: usize,
+) -> Result<Vec<String>> {
+    let repo_id = bitloops::host::devql::resolve_repo_id(world.repo_dir())
+        .context("resolving repo id for ingest task source diagnostics")?;
+    let store = open_scenario_daemon_runtime_store(world)?;
+    let Some(state) = store
+        .load_devql_task_queue_state()
+        .context("loading DevQL task queue state")?
+    else {
+        return Ok(Vec::new());
+    };
+
+    Ok(state
+        .tasks
+        .iter()
+        .filter(|task| {
+            task.repo_id == repo_id
+                && task.kind == DevqlTaskKind::Ingest
+                && task.source == expected_source
+        })
+        .skip(snapshot_count)
+        .map(|task| {
+            format!(
+                "id={} status={:?} source={} submitted_at={} started_at={:?} updated_at={} completed_at={:?}",
+                task.task_id,
+                task.status,
+                task.source,
+                task.submitted_at_unix,
+                task.started_at_unix,
+                task.updated_at_unix,
+                task.completed_at_unix
+            )
+        })
+        .collect())
+}
+
 fn completed_sync_task_with_source_exists(
     world: &QatWorld,
     expected_source: DevqlTaskSource,
@@ -1017,6 +1078,24 @@ pub fn run_init_bitloops_with_agents(
     sync: Option<bool>,
 ) -> Result<()> {
     run_init_bitloops_with_agent_config(world, repo_name, agent_names, force, sync, None, None)
+}
+
+pub fn run_init_bitloops_with_agent_sync_ingest(
+    world: &mut QatWorld,
+    repo_name: &str,
+    agent_name: &str,
+    sync: bool,
+    ingest: bool,
+) -> Result<()> {
+    run_init_bitloops_with_agent_config(
+        world,
+        repo_name,
+        &[agent_name],
+        false,
+        Some(sync),
+        Some(ingest),
+        None,
+    )
 }
 
 pub fn run_init_bitloops_with_agent_sync_ingest_backfill(
@@ -2226,11 +2305,47 @@ pub fn snapshot_completed_sync_task_source_for_repo(
 ) -> Result<()> {
     ensure_bitloops_repo_name(repo_name)?;
     let expected_source = parse_devql_task_source(expected_source)?;
-    let count = completed_sync_task_source_count(world, expected_source)?;
+    let sync_count = completed_sync_task_source_count(world, expected_source)?;
+    let ingest_count = ingest_task_source_count(world, expected_source)?;
+    let source_key = expected_source.to_string();
     world
         .completed_sync_task_source_snapshots
-        .insert(expected_source.to_string(), count);
+        .insert(source_key.clone(), sync_count);
+    world
+        .ingest_task_source_snapshots
+        .insert(source_key, ingest_count);
     Ok(())
+}
+
+pub fn assert_no_devql_ingest_task_source_since_snapshot(
+    world: &QatWorld,
+    repo_name: &str,
+    source: &str,
+) -> Result<()> {
+    ensure_bitloops_repo_name(repo_name)?;
+    let expected_source = parse_devql_task_source(source)?;
+    let source_key = expected_source.to_string();
+    let snapshot_count = world
+        .ingest_task_source_snapshots
+        .get(&source_key)
+        .copied()
+        .ok_or_else(|| anyhow!("no DevQL ingest task source snapshot captured for `{expected_source}`"))?;
+    let current_count = ingest_task_source_count(world, expected_source)?;
+    if current_count <= snapshot_count {
+        return Ok(());
+    }
+
+    let new_tasks = ingest_task_source_diagnostics_after_snapshot(
+        world,
+        expected_source,
+        snapshot_count,
+    )?
+    .join("; ");
+    bail!(
+        "expected no new DevQL ingest task with source `{expected_source}` since snapshot count {snapshot_count}, found {}; new tasks: {}",
+        current_count - snapshot_count,
+        new_tasks
+    )
 }
 
 pub fn assert_latest_completed_sync_task_source_for_repo(
@@ -4966,6 +5081,7 @@ fn resolve_repo_id(conn: &rusqlite::Connection) -> Result<String> {
         "SELECT repo_id FROM symbol_embeddings LIMIT 1",
         "SELECT repo_id FROM artefacts_current LIMIT 1",
         "SELECT repo_id FROM current_file_state LIMIT 1",
+        "SELECT repo_id FROM commit_checkpoints ORDER BY created_at DESC LIMIT 1",
         "SELECT repo_id FROM repositories WHERE provider = 'local' ORDER BY created_at DESC LIMIT 1",
         "SELECT repo_id FROM repositories ORDER BY created_at DESC LIMIT 1",
     ] {

--- a/bitloops/tests/qat_support/helpers/tests.rs
+++ b/bitloops/tests/qat_support/helpers/tests.rs
@@ -339,6 +339,27 @@ fn build_init_bitloops_args_with_backfill_enables_ingest_and_sets_window() {
 }
 
 #[test]
+fn build_init_bitloops_args_supports_explicit_ingest_choice() {
+    let args = build_init_bitloops_args_with_options(
+        &["claude-code"],
+        false,
+        Some(false),
+        Some(true),
+        None,
+    );
+    assert_eq!(
+        args,
+        vec![
+            "init",
+            "--agent",
+            "claude-code",
+            "--sync=false",
+            "--ingest=true",
+        ]
+    );
+}
+
+#[test]
 fn build_init_bitloops_args_supports_repeated_agent_flags() {
     let args =
         build_init_bitloops_args_with_options(&["claude-code", "codex"], false, None, None, None);

--- a/bitloops/tests/qat_support/steps/given.rs
+++ b/bitloops/tests/qat_support/steps/given.rs
@@ -171,6 +171,28 @@ pub(super) fn given_init_bitloops_with_agent_sync_true(
     })
 }
 
+pub(super) fn given_init_bitloops_with_agent_sync_ingest(
+    world: &mut QatWorld,
+    ctx: cucumber::step::Context,
+) -> LocalBoxFuture<'_, ()> {
+    Box::pin(async move {
+        let agent_name = ctx.matches[1].1.clone();
+        let sync = ctx.matches[2].1.parse::<bool>().expect("parse sync bool");
+        let ingest = ctx.matches[3].1.parse::<bool>().expect("parse ingest bool");
+        let repo_name = ctx.matches[4].1.clone();
+        run_step(
+            "I run bitloops init --agent --sync --ingest",
+            helpers::run_init_bitloops_with_agent_sync_ingest(
+                world,
+                &repo_name,
+                &agent_name,
+                sync,
+                ingest,
+            ),
+        );
+    })
+}
+
 pub(super) fn given_init_bitloops_producer_contract(
     world: &mut QatWorld,
     ctx: cucumber::step::Context,

--- a/bitloops/tests/qat_support/steps/mod.rs
+++ b/bitloops/tests/qat_support/steps/mod.rs
@@ -68,6 +68,11 @@ pub fn collection() -> Collection<QatWorld> {
         )
         .given(
             None,
+            regex(r"^I run bitloops init --agent (\S+) --sync=(true|false) --ingest=(true|false) in (\S+)$"),
+            step_fn(given_init_bitloops_with_agent_sync_ingest),
+        )
+        .given(
+            None,
             regex(r"^I run bitloops producer-contract init --agent (\S+) --sync=(true|false) in (\S+)$"),
             step_fn(given_init_bitloops_producer_contract),
         )
@@ -1168,6 +1173,11 @@ pub fn collection() -> Collection<QatWorld> {
             None,
             regex(r#"^a completed DevQL sync task with source \"([^\"]+)\" shows (work|added|changed|removed|unchanged|cache hits|cache misses|parse errors) greater than (\d+) since snapshot in (\S+)$"#),
             step_fn(then_completed_sync_task_source_summary_field_greater_than_since_snapshot),
+        )
+        .then(
+            None,
+            regex(r#"^no DevQL ingest task with source \"([^\"]+)\" exists since snapshot in (\S+)$"#),
+            step_fn(then_no_devql_ingest_task_source_since_snapshot),
         )
         .then(
             None,

--- a/bitloops/tests/qat_support/steps/then.rs
+++ b/bitloops/tests/qat_support/steps/then.rs
@@ -1629,6 +1629,20 @@ pub(super) fn then_completed_sync_task_source_summary_field_greater_than_since_s
     })
 }
 
+pub(super) fn then_no_devql_ingest_task_source_since_snapshot(
+    world: &mut QatWorld,
+    ctx: cucumber::step::Context,
+) -> LocalBoxFuture<'_, ()> {
+    Box::pin(async move {
+        let source = ctx.matches[1].1.clone();
+        let repo_name = ctx.matches[2].1.clone();
+        run_step(
+            "no DevQL ingest task with source exists since snapshot",
+            helpers::assert_no_devql_ingest_task_source_since_snapshot(world, &repo_name, &source),
+        );
+    })
+}
+
 pub(super) fn then_latest_completed_sync_task_source_matches(
     world: &mut QatWorld,
     ctx: cucumber::step::Context,

--- a/bitloops/tests/qat_support/world.rs
+++ b/bitloops/tests/qat_support/world.rs
@@ -111,6 +111,7 @@ pub struct QatWorld {
     pub semantic_clone_progress_observation: Option<SemanticCloneProgressObservation>,
     pub current_file_state_content_id_snapshots: HashMap<String, Option<String>>,
     pub completed_sync_task_source_snapshots: HashMap<String, usize>,
+    pub ingest_task_source_snapshots: HashMap<String, usize>,
     pub knowledge_items_by_url: HashMap<String, String>,
     pub knowledge_versions_by_ref: HashMap<String, usize>,
     pub knowledge_fixture_urls: HashMap<String, String>,
@@ -169,6 +170,7 @@ impl QatWorld {
         self.semantic_clone_progress_observation = None;
         self.current_file_state_content_id_snapshots = HashMap::new();
         self.completed_sync_task_source_snapshots = HashMap::new();
+        self.ingest_task_source_snapshots = HashMap::new();
         self.knowledge_items_by_url = HashMap::new();
         self.knowledge_versions_by_ref = HashMap::new();
         self.knowledge_fixture_urls = HashMap::new();


### PR DESCRIPTION
## Summary
- persist repo-local DevQL sync/ingest policy from `bitloops init`
- gate daemon/watch/hook producer paths so sync and ingest respect the configured policy independently
- add QAT coverage for sync-enabled / ingest-disabled post-merge behavior and fix QAT helper repo resolution for checkpoint-only state

## Root cause
`--ingest=false` was only treated as init-time behavior. Later producer paths could still enqueue ingest work, so a repo initialized with sync enabled and ingest disabled could ingest after hook/daemon events such as post-merge.

The checkpoint QAT failure was a separate test helper bug: it resolved `repo_id` from ingest/sync tables and ignored `commit_checkpoints`, incorrectly coupling checkpoint assertions to ingest.

## Validation
- `cargo dev-fmt-check`
- `CUCUMBER_FILTER_TAGS=@develop_gate cargo qat-agent-smoke`
- `CUCUMBER_FILTER_TAGS=@develop_gate cargo qat-agents-checkpoints`
- `CUCUMBER_FILTER_TAGS=@develop_gate cargo qat-devql-capabilities`
- `cargo qat-develop-gate`
- `cargo dev-loop`
- manual axum post-merge check with `--sync=true --ingest=false`: post-merge sync completed, no post-merge ingest task, `sync --validate` clean

## Notes
- The unrelated local edit to `documentation/contributors/architecture/diagrams/02-container-view.md` is not included.
- The default installed daemon stack overflow observed during manual QA remains a separate issue.