### PR TITLE
Fix semantic summary freshness drift caused by embedding hash mismatch

### DIFF
--- a/bitloops/src/capability_packs/semantic_clones/features.rs
+++ b/bitloops/src/capability_packs/semantic_clones/features.rs
@@ -1,16 +1,18 @@
 #[path = "features/semantic_features.rs"]
 mod core;
 
+pub(crate) use core::HashedFeatureRows;
 pub use core::SymbolSemanticsRow;
 pub(crate) use core::synthesize_deterministic_summary;
 pub use core::{
     DeterministicFallbackSummaryProvider, DocstringOnlySummaryProvider,
     NoopSemanticSummaryProvider, PreStageArtefactRow, PreStageDependencyRow,
-    SemanticFeatureIndexState, SemanticFeatureIngestionStats, SemanticFeatureInput,
-    SemanticFeatureRows, SemanticSummaryCandidate, SemanticSummaryProvider,
-    build_semantic_feature_input_hash, build_semantic_feature_inputs_from_artefacts,
+    SemanticFeatureHashKey, SemanticFeatureIndexState, SemanticFeatureIngestionStats,
+    SemanticFeatureInput, SemanticFeatureRows, SemanticSummaryCandidate, SemanticSummaryProvider,
+    SymbolFeatureRowsWithHash, build_semantic_feature_hash_key, build_semantic_feature_input_hash,
+    build_semantic_feature_input_hash_for_hash_key, build_semantic_feature_inputs_from_artefacts,
     build_semantic_feature_inputs_from_artefacts_with_dependencies, build_semantic_feature_rows,
-    is_semantic_enrichment_candidate, semantic_features_require_reindex,
+    build_symbol_feature_rows, is_semantic_enrichment_candidate, semantic_features_require_reindex,
     summary_provider_from_service,
 };
 pub(crate) use core::{build_dependency_context_signal, render_dependency_context};

--- a/bitloops/src/capability_packs/semantic_clones/features/semantic_features.rs
+++ b/bitloops/src/capability_packs/semantic_clones/features/semantic_features.rs
@@ -97,6 +97,60 @@ pub struct SemanticFeatureRows {
     pub semantic_features_input_hash: String,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SymbolFeatureRowsWithHash {
+    pub features: SymbolFeaturesRow,
+    pub semantic_features_input_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticFeatureHashKey {
+    summary_provider_cache_key: String,
+}
+
+impl SemanticFeatureHashKey {
+    pub fn for_summary_provider(summary_provider: &dyn SemanticSummaryProvider) -> Self {
+        Self {
+            summary_provider_cache_key: summary_provider.cache_key(),
+        }
+    }
+
+    pub fn from_summary_provider_cache_key(cache_key: impl Into<String>) -> Self {
+        Self {
+            summary_provider_cache_key: cache_key.into(),
+        }
+    }
+
+    fn summary_provider_cache_key(&self) -> &str {
+        &self.summary_provider_cache_key
+    }
+}
+
+pub(crate) trait HashedFeatureRows {
+    fn features_row(&self) -> &SymbolFeaturesRow;
+    fn semantic_features_input_hash(&self) -> &str;
+}
+
+impl HashedFeatureRows for SemanticFeatureRows {
+    fn features_row(&self) -> &SymbolFeaturesRow {
+        &self.features
+    }
+
+    fn semantic_features_input_hash(&self) -> &str {
+        &self.semantic_features_input_hash
+    }
+}
+
+impl HashedFeatureRows for SymbolFeatureRowsWithHash {
+    fn features_row(&self) -> &SymbolFeaturesRow {
+        &self.features
+    }
+
+    fn semantic_features_input_hash(&self) -> &str {
+        &self.semantic_features_input_hash
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SemanticFeatureIndexState {
     pub semantics_hash: Option<String>,
@@ -260,19 +314,48 @@ pub fn build_semantic_feature_rows(
     input: &SemanticFeatureInput,
     summary_provider: &dyn SemanticSummaryProvider,
 ) -> SemanticFeatureRows {
+    let hash_key = build_semantic_feature_hash_key(summary_provider);
+    let feature_rows = build_symbol_feature_rows(input, &hash_key);
     let semantics = build_semantics_row(input, summary_provider);
-    let features = build_features_row(input);
-    let semantic_features_input_hash = build_semantic_feature_input_hash(input, summary_provider);
     SemanticFeatureRows {
         semantics,
+        features: feature_rows.features,
+        semantic_features_input_hash: feature_rows.semantic_features_input_hash,
+    }
+}
+
+pub fn build_symbol_feature_rows(
+    input: &SemanticFeatureInput,
+    hash_key: &SemanticFeatureHashKey,
+) -> SymbolFeatureRowsWithHash {
+    let features = build_features_row(input);
+    let semantic_features_input_hash =
+        build_semantic_feature_input_hash_for_hash_key(input, hash_key);
+    SymbolFeatureRowsWithHash {
         features,
         semantic_features_input_hash,
     }
 }
 
+pub fn build_semantic_feature_hash_key(
+    summary_provider: &dyn SemanticSummaryProvider,
+) -> SemanticFeatureHashKey {
+    SemanticFeatureHashKey::for_summary_provider(summary_provider)
+}
+
 pub fn build_semantic_feature_input_hash(
     input: &SemanticFeatureInput,
     summary_provider: &dyn SemanticSummaryProvider,
+) -> String {
+    build_semantic_feature_input_hash_for_hash_key(
+        input,
+        &build_semantic_feature_hash_key(summary_provider),
+    )
+}
+
+pub fn build_semantic_feature_input_hash_for_hash_key(
+    input: &SemanticFeatureInput,
+    hash_key: &SemanticFeatureHashKey,
 ) -> String {
     let mut normalized_modifiers = input
         .modifiers
@@ -307,7 +390,7 @@ pub fn build_semantic_feature_input_hash(
             "parent_kind": input.parent_kind.as_deref().map(|value| value.to_ascii_lowercase()),
             "dependency_signals": &input.dependency_signals,
             "content_hash": &input.content_hash,
-            "summary_provider": summary_provider.cache_key(),
+            "summary_provider": hash_key.summary_provider_cache_key(),
         })
         .to_string(),
     )
@@ -477,6 +560,40 @@ mod tests {
         assert_ne!(
             build_semantic_feature_input_hash(&input, &HashTestProvider { key: "provider=a" }),
             build_semantic_feature_input_hash(&input, &HashTestProvider { key: "provider=b" })
+        );
+    }
+
+    #[test]
+    fn symbol_feature_rows_share_hash_contract_with_semantic_rows() {
+        let input = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "src/services/user.ts".to_string(),
+            language: "typescript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function".to_string(),
+            symbol_fqn: "src/services/user.ts::normalizeEmail".to_string(),
+            name: "normalizeEmail".to_string(),
+            signature: Some("export function normalizeEmail(email: string): string {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return email.trim().toLowerCase();".to_string(),
+            docstring: Some("Normalize email addresses.".to_string()),
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec!["calls:email::trim".to_string()],
+            content_hash: Some("hash-1".to_string()),
+        };
+        let provider = HashTestProvider { key: "provider=a" };
+        let hash_key = build_semantic_feature_hash_key(&provider);
+
+        let symbol_rows = build_symbol_feature_rows(&input, &hash_key);
+        let semantic_rows = build_semantic_feature_rows(&input, &provider);
+
+        assert_eq!(symbol_rows.features, semantic_rows.features);
+        assert_eq!(
+            symbol_rows.semantic_features_input_hash,
+            semantic_rows.semantic_features_input_hash
         );
     }
 

--- a/bitloops/src/capability_packs/semantic_clones/stage_semantic_features/persistence.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_semantic_features/persistence.rs
@@ -311,7 +311,7 @@ pub(super) async fn persist_current_semantic_feature_rows_for_matching_input(
 pub(super) async fn persist_current_symbol_feature_rows_for_matching_input(
     relational: &RelationalStorage,
     input: &semantic::SemanticFeatureInput,
-    rows: &semantic::SemanticFeatureRows,
+    rows: &impl semantic::HashedFeatureRows,
 ) -> Result<()> {
     match relational
         .exec_serialized(&build_conditional_current_symbol_feature_persist_rows_sql(
@@ -356,7 +356,7 @@ async fn persist_current_symbol_feature_rows(
     symbol_id: Option<&str>,
     path: &str,
     content_id: &str,
-    rows: &semantic::SemanticFeatureRows,
+    rows: &impl semantic::HashedFeatureRows,
 ) -> Result<()> {
     relational
         .exec_serialized(&build_current_symbol_feature_persist_rows_sql(

--- a/bitloops/src/capability_packs/semantic_clones/stage_semantic_features/storage/persistence_sql.rs
+++ b/bitloops/src/capability_packs/semantic_clones/stage_semantic_features/storage/persistence_sql.rs
@@ -125,10 +125,10 @@ fn semantic_generated_at_now_sql(dialect: RelationalDialect) -> &'static str {
 }
 
 pub(crate) fn build_symbol_feature_persist_rows_sql(
-    rows: &semantic::SemanticFeatureRows,
+    rows: &impl semantic::HashedFeatureRows,
     dialect: RelationalDialect,
 ) -> Result<String> {
-    let features = &rows.features;
+    let features = rows.features_row();
     let normalized_signature_expr = sql_optional_string(features.normalized_signature.as_deref());
     let parent_kind_expr = sql_optional_string(features.parent_kind.as_deref());
     let modifiers_expr = sql_json_string_for_dialect(&features.modifiers, dialect)?;
@@ -144,7 +144,7 @@ ON CONFLICT (artefact_id) DO UPDATE SET repo_id = EXCLUDED.repo_id, blob_sha = E
         features_artefact_id = esc_pg(&features.artefact_id),
         features_repo_id = esc_pg(&features.repo_id),
         features_blob_sha = esc_pg(&features.blob_sha),
-        features_input_hash = esc_pg(&rows.semantic_features_input_hash),
+        features_input_hash = esc_pg(rows.semantic_features_input_hash()),
         normalized_name = esc_pg(&features.normalized_name),
         normalized_signature = normalized_signature_expr,
         modifiers = modifiers_expr,
@@ -157,13 +157,13 @@ ON CONFLICT (artefact_id) DO UPDATE SET repo_id = EXCLUDED.repo_id, blob_sha = E
 }
 
 pub(crate) fn build_current_symbol_feature_persist_rows_sql(
-    rows: &semantic::SemanticFeatureRows,
+    rows: &impl semantic::HashedFeatureRows,
     symbol_id: Option<&str>,
     path: &str,
     content_id: &str,
     dialect: RelationalDialect,
 ) -> Result<String> {
-    let features = &rows.features;
+    let features = rows.features_row();
     let symbol_id_expr = sql_optional_string(symbol_id);
     let normalized_signature_expr = sql_optional_string(features.normalized_signature.as_deref());
     let parent_kind_expr = sql_optional_string(features.parent_kind.as_deref());
@@ -182,7 +182,7 @@ ON CONFLICT (artefact_id) DO UPDATE SET repo_id = EXCLUDED.repo_id, path = EXCLU
         path = esc_pg(path),
         content_id = esc_pg(content_id),
         symbol_id = symbol_id_expr,
-        features_input_hash = esc_pg(&rows.semantic_features_input_hash),
+        features_input_hash = esc_pg(rows.semantic_features_input_hash()),
         normalized_name = esc_pg(&features.normalized_name),
         normalized_signature = normalized_signature_expr,
         modifiers = modifiers_expr,
@@ -195,11 +195,11 @@ ON CONFLICT (artefact_id) DO UPDATE SET repo_id = EXCLUDED.repo_id, path = EXCLU
 }
 
 pub(crate) fn build_conditional_current_symbol_feature_persist_rows_sql(
-    rows: &semantic::SemanticFeatureRows,
+    rows: &impl semantic::HashedFeatureRows,
     input: &semantic::SemanticFeatureInput,
     dialect: RelationalDialect,
 ) -> Result<String> {
-    let features = &rows.features;
+    let features = rows.features_row();
     let normalized_signature_expr = sql_optional_string(features.normalized_signature.as_deref());
     let parent_kind_expr = sql_optional_string(features.parent_kind.as_deref());
     let modifiers_expr = sql_json_string_for_dialect(&features.modifiers, dialect)?;
@@ -216,7 +216,7 @@ FROM ({target_select}) target \
 WHERE 1 = 1 \
 ON CONFLICT (artefact_id) DO UPDATE SET repo_id = EXCLUDED.repo_id, path = EXCLUDED.path, content_id = EXCLUDED.content_id, symbol_id = EXCLUDED.symbol_id, semantic_features_input_hash = EXCLUDED.semantic_features_input_hash, normalized_name = EXCLUDED.normalized_name, normalized_signature = EXCLUDED.normalized_signature, modifiers = EXCLUDED.modifiers, identifier_tokens = EXCLUDED.identifier_tokens, normalized_body_tokens = EXCLUDED.normalized_body_tokens, parent_kind = EXCLUDED.parent_kind, context_tokens = EXCLUDED.context_tokens, generated_at = {generated_at}",
         target_select = target_select,
-        features_input_hash = esc_pg(&rows.semantic_features_input_hash),
+        features_input_hash = esc_pg(rows.semantic_features_input_hash()),
         normalized_name = esc_pg(&features.normalized_name),
         normalized_signature = normalized_signature_expr,
         modifiers = modifiers_expr,

--- a/bitloops/src/daemon/enrichment/execution/mailbox_embedding.rs
+++ b/bitloops/src/daemon/enrichment/execution/mailbox_embedding.rs
@@ -12,10 +12,11 @@ use crate::capability_packs::semantic_clones::embeddings::{
     resolve_embedding_setup, symbol_embeddings_require_reindex,
 };
 use crate::capability_packs::semantic_clones::features::{
-    NoopSemanticSummaryProvider, build_semantic_feature_rows,
+    SemanticFeatureHashKey, build_symbol_feature_rows,
 };
 use crate::capability_packs::semantic_clones::runtime_config::{
-    EmbeddingProviderMode, resolve_embedding_provider, resolve_semantic_clones_config,
+    EmbeddingProviderMode, SummaryProviderMode, resolve_embedding_provider,
+    resolve_semantic_clones_config, resolve_summary_provider,
 };
 use crate::capability_packs::semantic_clones::types::SEMANTIC_CLONES_CLONE_REBUILD_MAILBOX;
 use crate::capability_packs::semantic_clones::{
@@ -72,11 +73,12 @@ pub(crate) async fn prepare_embedding_mailbox_batch(
     let relational =
         RelationalStorage::connect(&cfg, &backends.relational, "semantic embedding batch").await?;
     let capability_host = build_capability_host(&batch.repo_root, cfg.repo.clone())?;
+    let inference = capability_host.inference_for_capability(SEMANTIC_CLONES_CAPABILITY_ID);
     let config =
         resolve_semantic_clones_config(&capability_host.config_view(SEMANTIC_CLONES_CAPABILITY_ID));
     let selection = resolve_embedding_provider(
         &config,
-        &capability_host.inference_for_capability(SEMANTIC_CLONES_CAPABILITY_ID),
+        &inference,
         batch.representation_kind,
         EmbeddingProviderMode::ConfiguredStrict,
     )?;
@@ -87,6 +89,17 @@ pub(crate) async fn prepare_embedding_mailbox_batch(
         );
     };
     let setup = resolve_embedding_setup(provider.as_ref())?;
+    let code_feature_hash_provider = if batch.representation_kind
+        == EmbeddingRepresentationKind::Code
+    {
+        Some(SemanticFeatureHashKey::from_summary_provider_cache_key(
+            resolve_summary_provider(&config, &inference, SummaryProviderMode::ConfiguredStrict)?
+                .provider
+                .cache_key(),
+        ))
+    } else {
+        None
+    };
     let config_ms = elapsed_ms(config_started);
 
     let input_started = Instant::now();
@@ -228,10 +241,15 @@ pub(crate) async fn prepare_embedding_mailbox_batch(
     let mut embedding_statements = Vec::new();
     let mut repaired_feature_projection = false;
     if batch.representation_kind == EmbeddingRepresentationKind::Code {
+        let feature_hash_provider = code_feature_hash_provider
+            .as_ref()
+            .expect("code embedding batches resolve a feature hash key")
+            .clone();
         for input in &expanded_inputs {
             let input_for_rows = input.clone();
+            let hash_key_for_rows = feature_hash_provider.clone();
             let rows = tokio::task::spawn_blocking(move || {
-                build_semantic_feature_rows(&input_for_rows, &NoopSemanticSummaryProvider)
+                build_symbol_feature_rows(&input_for_rows, &hash_key_for_rows)
             })
             .await
             .context("building code embedding feature rows on blocking worker")?;

--- a/bitloops/src/daemon/enrichment/execution_tests.rs
+++ b/bitloops/src/daemon/enrichment/execution_tests.rs
@@ -1836,6 +1836,92 @@ async fn prepare_embedding_mailbox_batch_repairs_current_feature_projection_for_
 }
 
 #[tokio::test]
+async fn prepare_embedding_mailbox_batch_keeps_current_feature_hash_aligned_with_summary_hash() {
+    let (repo, _first_sha, _second_sha) = seed_daemon_embedding_repo();
+    let (cfg, _relational, inputs, input_hashes) = seed_current_state_and_semantics(
+        repo.path(),
+        "alpha",
+        TEST_EMBEDDINGS_DRIVER,
+        "feature-repair-model",
+        "3",
+    )
+    .await;
+    let requested_inputs = inputs.iter().take(2).cloned().collect::<Vec<_>>();
+    let requested_ids = requested_inputs
+        .iter()
+        .map(|input| input.artefact_id.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(requested_ids.len(), 2, "fixture should include two inputs");
+
+    let batch = super::super::workplane::ClaimedEmbeddingMailboxBatch {
+        repo_id: cfg.repo.repo_id.clone(),
+        repo_root: cfg.repo_root.clone(),
+        config_root: cfg.daemon_config_root.clone(),
+        representation_kind:
+            crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code,
+        lease_token: "feature-hash-alignment-code-embedding-lease".to_string(),
+        items: vec![SemanticEmbeddingMailboxItemRecord {
+            item_id: "feature-hash-alignment-code-embedding-item".to_string(),
+            repo_id: cfg.repo.repo_id.clone(),
+            repo_root: cfg.repo_root.clone(),
+            config_root: cfg.daemon_config_root.clone(),
+            init_session_id: None,
+            representation_kind:
+                crate::capability_packs::semantic_clones::embeddings::EmbeddingRepresentationKind::Code
+                    .to_string(),
+            item_kind: SemanticMailboxItemKind::RepoBackfill,
+            artefact_id: None,
+            payload_json: Some(serde_json::json!(requested_ids)),
+            dedupe_key: Some(
+                crate::capability_packs::semantic_clones::workplane::repo_backfill_dedupe_key(
+                    crate::capability_packs::semantic_clones::types::SEMANTIC_CLONES_CODE_EMBEDDING_MAILBOX,
+                ),
+            ),
+            status: SemanticMailboxItemStatus::Leased,
+            attempts: 0,
+            available_at_unix: 1,
+            submitted_at_unix: 1,
+            leased_at_unix: Some(1),
+            lease_expires_at_unix: Some(301),
+            lease_token: Some("feature-hash-alignment-code-embedding-lease".to_string()),
+            updated_at_unix: 1,
+            last_error: None,
+        }],
+    };
+
+    let prepared = prepare_embedding_mailbox_batch(&batch)
+        .await
+        .expect("prepare embedding batch");
+
+    let repair_sql = prepared.commit.embedding_statements.join("\n");
+    assert!(
+        repair_sql.contains("symbol_features_current"),
+        "expected the embedding batch to repair current feature rows"
+    );
+    for input in &requested_inputs {
+        let expected_hash = input_hashes
+            .get(&input.artefact_id)
+            .expect("expected summary-backed input hash");
+        let noop_hash =
+            crate::capability_packs::semantic_clones::features::build_semantic_feature_input_hash(
+                input,
+                &crate::capability_packs::semantic_clones::features::NoopSemanticSummaryProvider,
+            );
+
+        assert!(
+            repair_sql.contains(expected_hash),
+            "code embedding repairs should preserve the summary-backed feature hash for {}",
+            input.artefact_id
+        );
+        assert!(
+            !repair_sql.contains(&noop_hash),
+            "code embedding repairs should not stamp the noop summary hash for {}",
+            input.artefact_id
+        );
+    }
+}
+
+#[tokio::test]
 async fn prepare_summary_mailbox_batch_with_explicit_repo_backfill_ids_skips_unrelated_current_paths()
  {
     let (repo, _first_sha, _second_sha) = seed_daemon_embedding_repo();


### PR DESCRIPTION
## Summary

We found and fixed a real summary freshness bug in Bitloops semantic clones.

`Problem`

The summary lane wrote semantic hashes using the real summary provider identity.

The code-embedding repair path later rewrote current feature hashes using a noop summary provider identity.

Because the summary freshness fingerprint includes the provider cache key, the two hashes diverged for some artefacts.

`User-visible symptoms`

Summary progress could appear stuck below 100% even after the run drained successfully.

Valid summaries could be treated as stale on rerun.

Cached reruns became slower than expected because some summaries were unnecessarily refreshed.

`Root cause`

The shared feature-row builder had the wrong boundary: callers could pass different provider identities and still write the shared current feature projection.

`Fix implemented`

Introduced a canonical hash boundary for semantic feature rows.

Added explicit hash-key plumbing so both summary and embedding paths use the same summary hash contract.

Updated the embedding worker to stop repairing current feature rows with a noop-provider hash.

Kept the intended behavior where a real summary provider change still invalidates stale summaries.

`Verification`

Added unit coverage for the shared hash contract.

Added regression coverage for the embedding worker path.

Confirmed provider-change invalidation behavior still passes.


## Validation

- [ ] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

