### PR TITLE
Minor fix bitloops skill path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- **DevQL guidance no longer writes a shared canonical skill copy**: init and agent guidance installation now write only the native agent prompt surfaces.
+- **DevQL guidance no longer writes a shared canonical skill copy in .bitloops path**: init and agent guidance installation now write only the native agent prompt surfaces.
 
 ## [0.0.21] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **DevQL guidance no longer writes a shared canonical skill copy**: init and agent guidance installation now write only the native agent prompt surfaces.
+
 ## [0.0.21] - 2026-05-07
 
 ### Added

--- a/bitloops/src/adapters/agents/claude_code/skills.rs
+++ b/bitloops/src/adapters/agents/claude_code/skills.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use crate::adapters::agents::skill_install::{
-    install_canonical_repo_skill, prune_empty_parents, read_or_install_canonical_repo_skill,
-    remove_canonical_repo_skill, remove_managed_file, write_managed_file,
+    prune_empty_parents, remove_managed_file, write_managed_file,
 };
+use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
 
 pub const CLAUDE_CODE_SKILL_RELATIVE_PATH: &str =
     ".claude/skills/bitloops/devql-explore-first/SKILL.md";
@@ -21,16 +21,14 @@ fn legacy_repo_skill_path(repo_root: &Path) -> PathBuf {
 }
 
 pub fn install_repo_skill(repo_root: &Path) -> Result<bool> {
-    let canonical_changed = install_canonical_repo_skill(repo_root)?;
-    let skill = read_or_install_canonical_repo_skill(repo_root)?;
     let path = repo_skill_path(repo_root);
-    let changed = write_managed_file(&path, &skill)?;
+    let changed = write_managed_file(&path, DEVQL_EXPLORE_FIRST_SKILL)?;
     let legacy_path = legacy_repo_skill_path(repo_root);
     let removed_legacy = legacy_path.exists();
     remove_managed_file(&legacy_path)?;
     prune_empty_parents(&legacy_path, &repo_root.join(".claude"))?;
 
-    Ok(changed || removed_legacy || canonical_changed)
+    Ok(changed || removed_legacy)
 }
 
 pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
@@ -40,15 +38,11 @@ pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
 
     let legacy_path = legacy_repo_skill_path(repo_root);
     remove_managed_file(&legacy_path)?;
-    prune_empty_parents(&legacy_path, &repo_root.join(".claude"))?;
-
-    remove_canonical_repo_skill(repo_root)
+    prune_empty_parents(&legacy_path, &repo_root.join(".claude"))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::adapters::agents::skill_install::read_or_install_canonical_repo_skill;
-
     use super::*;
 
     #[test]
@@ -89,7 +83,7 @@ mod tests {
         assert!(!legacy_path.exists());
         assert_eq!(
             std::fs::read_to_string(skill_path).expect("read skill"),
-            read_or_install_canonical_repo_skill(dir.path()).expect("read canonical skill")
+            DEVQL_EXPLORE_FIRST_SKILL
         );
     }
 }

--- a/bitloops/src/adapters/agents/codex/skills.rs
+++ b/bitloops/src/adapters/agents/codex/skills.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use crate::adapters::agents::skill_install::{
-    install_canonical_repo_skill, prune_empty_parents, read_or_install_canonical_repo_skill,
-    remove_canonical_repo_skill, remove_managed_file, write_managed_file,
+    prune_empty_parents, remove_managed_file, write_managed_file,
 };
+use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
 
 pub const CODEX_SKILL_RELATIVE_PATH: &str = ".agents/skills/bitloops/devql-explore-first/SKILL.md";
 pub const LEGACY_CODEX_SKILL_RELATIVE_PATH: &str = ".agents/skills/bitloops/using-devql/SKILL.md";
@@ -19,16 +19,14 @@ fn legacy_repo_skill_path(repo_root: &Path) -> PathBuf {
 }
 
 pub fn install_repo_skill(repo_root: &Path) -> Result<bool> {
-    let canonical_changed = install_canonical_repo_skill(repo_root)?;
-    let skill = read_or_install_canonical_repo_skill(repo_root)?;
     let path = repo_skill_path(repo_root);
-    let changed = write_managed_file(&path, &skill)?;
+    let changed = write_managed_file(&path, DEVQL_EXPLORE_FIRST_SKILL)?;
     let legacy_path = legacy_repo_skill_path(repo_root);
     let removed_legacy = legacy_path.exists();
     remove_managed_file(&legacy_path)?;
     prune_empty_parents(&legacy_path, &repo_root.join(".agents"))?;
 
-    Ok(changed || removed_legacy || canonical_changed)
+    Ok(changed || removed_legacy)
 }
 
 pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
@@ -38,15 +36,11 @@ pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
 
     let legacy_path = legacy_repo_skill_path(repo_root);
     remove_managed_file(&legacy_path)?;
-    prune_empty_parents(&legacy_path, &repo_root.join(".agents"))?;
-
-    remove_canonical_repo_skill(repo_root)
+    prune_empty_parents(&legacy_path, &repo_root.join(".agents"))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::adapters::agents::skill_install::read_or_install_canonical_repo_skill;
-
     use super::*;
 
     #[test]
@@ -87,7 +81,7 @@ mod tests {
         assert!(!legacy_path.exists());
         assert_eq!(
             std::fs::read_to_string(skill_path).expect("read skill"),
-            read_or_install_canonical_repo_skill(dir.path()).expect("read canonical skill")
+            DEVQL_EXPLORE_FIRST_SKILL
         );
     }
 }

--- a/bitloops/src/adapters/agents/copilot/skills.rs
+++ b/bitloops/src/adapters/agents/copilot/skills.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use crate::adapters::agents::skill_install::{
-    install_canonical_repo_skill, prune_empty_parents, read_or_install_canonical_repo_skill,
-    remove_canonical_repo_skill, remove_managed_file, write_managed_file,
+    prune_empty_parents, remove_managed_file, write_managed_file,
 };
+use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
 
 pub const COPILOT_SKILL_RELATIVE_PATH: &str =
     ".github/skills/bitloops/devql-explore-first/SKILL.md";
@@ -20,16 +20,14 @@ fn legacy_repo_skill_path(repo_root: &Path) -> PathBuf {
 }
 
 pub fn install_repo_skill(repo_root: &Path) -> Result<bool> {
-    let canonical_changed = install_canonical_repo_skill(repo_root)?;
-    let skill = read_or_install_canonical_repo_skill(repo_root)?;
     let path = repo_skill_path(repo_root);
-    let changed = write_managed_file(&path, &skill)?;
+    let changed = write_managed_file(&path, DEVQL_EXPLORE_FIRST_SKILL)?;
     let legacy_path = legacy_repo_skill_path(repo_root);
     let removed_legacy = legacy_path.exists();
     remove_managed_file(&legacy_path)?;
     prune_empty_parents(&legacy_path, &repo_root.join(".github"))?;
 
-    Ok(changed || removed_legacy || canonical_changed)
+    Ok(changed || removed_legacy)
 }
 
 pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
@@ -39,15 +37,11 @@ pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
 
     let legacy_path = legacy_repo_skill_path(repo_root);
     remove_managed_file(&legacy_path)?;
-    prune_empty_parents(&legacy_path, &repo_root.join(".github"))?;
-
-    remove_canonical_repo_skill(repo_root)
+    prune_empty_parents(&legacy_path, &repo_root.join(".github"))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::adapters::agents::skill_install::read_or_install_canonical_repo_skill;
-
     use super::*;
 
     #[test]
@@ -88,7 +82,7 @@ mod tests {
         assert!(!legacy_path.exists());
         assert_eq!(
             std::fs::read_to_string(skill_path).expect("read skill"),
-            read_or_install_canonical_repo_skill(dir.path()).expect("read canonical skill")
+            DEVQL_EXPLORE_FIRST_SKILL
         );
     }
 }

--- a/bitloops/src/adapters/agents/cursor/rules.rs
+++ b/bitloops/src/adapters/agents/cursor/rules.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use crate::adapters::agents::skill_install::{
-    install_canonical_repo_skill, prune_empty_parents, read_or_install_canonical_repo_skill,
-    remove_canonical_repo_skill, remove_managed_file, strip_skill_frontmatter, write_managed_file,
+    prune_empty_parents, remove_managed_file, strip_skill_frontmatter, write_managed_file,
 };
+use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
 
 pub const CURSOR_RULE_RELATIVE_PATH: &str = ".cursor/rules/bitloops-devql-explore-first.mdc";
 pub const LEGACY_CURSOR_RULE_RELATIVE_PATH: &str = ".cursor/rules/bitloops-using-devql.mdc";
@@ -18,22 +18,20 @@ fn legacy_repo_rule_path(repo_root: &Path) -> PathBuf {
     repo_root.join(LEGACY_CURSOR_RULE_RELATIVE_PATH)
 }
 
-fn cursor_rule_content(repo_root: &Path) -> Result<String> {
-    let skill = read_or_install_canonical_repo_skill(repo_root)?;
-    let body = strip_skill_frontmatter(&skill).trim();
-    Ok(format!(
+fn cursor_rule_content() -> String {
+    let body = strip_skill_frontmatter(DEVQL_EXPLORE_FIRST_SKILL).trim();
+    format!(
         "---\n\
 description: Use DevQL before codebase exploration, symbol lookup, or any source-file reads. DevQL is the primary discovery tool — use `bitloops devql query` whenever locating symbols, files, tests, or implementations.\n\
 alwaysApply: true\n\
 ---\n\n\
 {body}\n"
-    ))
+    )
 }
 
 pub fn install_repo_rule(repo_root: &Path) -> Result<bool> {
-    let canonical_changed = install_canonical_repo_skill(repo_root)?;
     let path = repo_rule_path(repo_root);
-    let content = cursor_rule_content(repo_root)?;
+    let content = cursor_rule_content();
     let changed = write_managed_file(&path, &content)?;
 
     let legacy_path = legacy_repo_rule_path(repo_root);
@@ -41,7 +39,7 @@ pub fn install_repo_rule(repo_root: &Path) -> Result<bool> {
     remove_managed_file(&legacy_path)?;
     prune_empty_parents(&legacy_path, &repo_root.join(".cursor"))?;
 
-    Ok(changed || removed_legacy || canonical_changed)
+    Ok(changed || removed_legacy)
 }
 
 pub fn uninstall_repo_rule(repo_root: &Path) -> Result<()> {
@@ -51,9 +49,7 @@ pub fn uninstall_repo_rule(repo_root: &Path) -> Result<()> {
 
     let legacy_path = legacy_repo_rule_path(repo_root);
     remove_managed_file(&legacy_path)?;
-    prune_empty_parents(&legacy_path, &repo_root.join(".cursor"))?;
-
-    remove_canonical_repo_skill(repo_root)
+    prune_empty_parents(&legacy_path, &repo_root.join(".cursor"))
 }
 
 #[cfg(test)]
@@ -71,8 +67,7 @@ mod tests {
 
     #[test]
     fn cursor_rule_content_uses_frontmatter_and_devql_body() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let content = cursor_rule_content(dir.path()).expect("rule content");
+        let content = cursor_rule_content();
         assert!(content.starts_with("---\n"));
         assert!(content.contains("alwaysApply: true"));
         assert!(content.contains("primary discovery tool"));

--- a/bitloops/src/adapters/agents/gemini/skills.rs
+++ b/bitloops/src/adapters/agents/gemini/skills.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 use crate::adapters::agents::skill_install::{
-    install_canonical_repo_skill, prune_empty_parents, read_or_install_canonical_repo_skill,
-    remove_canonical_repo_skill, remove_managed_file, write_managed_file,
+    prune_empty_parents, remove_managed_file, write_managed_file,
 };
+use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
 
 const GEMINI_DIR_NAME: &str = ".gemini";
 const GEMINI_MD_FILE_NAME: &str = "GEMINI.md";
@@ -30,10 +30,8 @@ pub fn gemini_md_path(repo_root: &Path) -> PathBuf {
 }
 
 pub fn install_repo_skill(repo_root: &Path) -> Result<bool> {
-    let canonical_changed = install_canonical_repo_skill(repo_root)?;
-    let canonical_skill = read_or_install_canonical_repo_skill(repo_root)?;
     let skill_path = repo_skill_path(repo_root);
-    let mut changed = write_managed_file(&skill_path, &canonical_skill)?;
+    let mut changed = write_managed_file(&skill_path, DEVQL_EXPLORE_FIRST_SKILL)?;
 
     // Remove legacy skill file if present.
     let legacy_skill_path = legacy_repo_skill_path(repo_root);
@@ -80,7 +78,7 @@ pub fn install_repo_skill(repo_root: &Path) -> Result<bool> {
     changed |= write_if_changed(&gemini_md_path, &next_content)
         .with_context(|| format!("writing {}", gemini_md_path.display()))?;
 
-    Ok(changed || canonical_changed)
+    Ok(changed)
 }
 
 pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
@@ -117,7 +115,7 @@ pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
             .with_context(|| format!("writing {}", gemini_md_path.display()))?;
     }
 
-    remove_canonical_repo_skill(repo_root)
+    Ok(())
 }
 
 fn managed_block() -> String {
@@ -165,8 +163,6 @@ fn remove_managed_block(content: &str) -> String {
 mod tests {
     use tempfile::tempdir;
 
-    use crate::adapters::agents::skill_install::read_or_install_canonical_repo_skill;
-
     use super::*;
 
     #[test]
@@ -184,7 +180,7 @@ mod tests {
         let skill_path = repo_skill_path(root);
         assert_eq!(
             std::fs::read_to_string(&skill_path).expect("failed to read skill"),
-            read_or_install_canonical_repo_skill(root).expect("read canonical skill")
+            DEVQL_EXPLORE_FIRST_SKILL
         );
 
         let gemini_md =
@@ -219,8 +215,8 @@ mod tests {
         .expect("failed to seed GEMINI.md");
         std::fs::create_dir_all(repo_skill_path(root).parent().expect("skill parent"))
             .expect("failed to create skill directory");
-        let canonical_skill = read_or_install_canonical_repo_skill(root).expect("canonical skill");
-        std::fs::write(repo_skill_path(root), canonical_skill).expect("failed to seed skill");
+        std::fs::write(repo_skill_path(root), DEVQL_EXPLORE_FIRST_SKILL)
+            .expect("failed to seed skill");
 
         uninstall_repo_skill(root).expect("uninstall_repo_skill should succeed");
 
@@ -262,7 +258,7 @@ mod tests {
         assert!(skill_path.exists());
         assert_eq!(
             std::fs::read_to_string(&skill_path).expect("read skill"),
-            read_or_install_canonical_repo_skill(root).expect("read canonical skill")
+            DEVQL_EXPLORE_FIRST_SKILL
         );
 
         // GEMINI.md updated to use new import line.

--- a/bitloops/src/adapters/agents/open_code/skills.rs
+++ b/bitloops/src/adapters/agents/open_code/skills.rs
@@ -3,9 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use crate::adapters::agents::skill_install::{
-    install_canonical_repo_skill, prune_empty_parents, read_or_install_canonical_repo_skill,
-    remove_canonical_repo_skill, remove_managed_file, write_managed_file,
+    prune_empty_parents, remove_managed_file, write_managed_file,
 };
+use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
 
 pub const OPEN_CODE_SKILL_RELATIVE_PATH: &str =
     ".opencode/skills/bitloops/devql-explore-first/SKILL.md";
@@ -15,24 +15,19 @@ pub fn repo_skill_path(repo_root: &Path) -> PathBuf {
 }
 
 pub fn install_repo_skill(repo_root: &Path) -> Result<bool> {
-    let canonical_changed = install_canonical_repo_skill(repo_root)?;
-    let skill = read_or_install_canonical_repo_skill(repo_root)?;
     let path = repo_skill_path(repo_root);
-    let changed = write_managed_file(&path, &skill)?;
-    Ok(changed || canonical_changed)
+    let changed = write_managed_file(&path, DEVQL_EXPLORE_FIRST_SKILL)?;
+    Ok(changed)
 }
 
 pub fn uninstall_repo_skill(repo_root: &Path) -> Result<()> {
     let path = repo_skill_path(repo_root);
     remove_managed_file(&path)?;
-    prune_empty_parents(&path, &repo_root.join(".opencode"))?;
-    remove_canonical_repo_skill(repo_root)
+    prune_empty_parents(&path, &repo_root.join(".opencode"))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::adapters::agents::skill_install::read_or_install_canonical_repo_skill;
-
     use super::*;
 
     #[test]
@@ -54,7 +49,7 @@ mod tests {
         assert!(path.exists(), "skill file should exist after install");
         assert_eq!(
             std::fs::read_to_string(&path).expect("read skill"),
-            read_or_install_canonical_repo_skill(repo_root).expect("read canonical skill")
+            DEVQL_EXPLORE_FIRST_SKILL
         );
         assert!(
             path.to_string_lossy()

--- a/bitloops/src/adapters/agents/skill_install.rs
+++ b/bitloops/src/adapters/agents/skill_install.rs
@@ -1,16 +1,7 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
-
-use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
-
-pub const CANONICAL_DEVQL_SKILL_RELATIVE_PATH: &str =
-    ".bitloops/skills/bitloops/devql-explore-first/SKILL.md";
-
-pub fn canonical_repo_skill_path(repo_root: &Path) -> PathBuf {
-    repo_root.join(CANONICAL_DEVQL_SKILL_RELATIVE_PATH)
-}
 
 pub fn write_managed_file(path: &Path, content: &str) -> Result<bool> {
     if let Some(parent) = path.parent() {
@@ -24,25 +15,6 @@ pub fn write_managed_file(path: &Path, content: &str) -> Result<bool> {
 
     fs::write(path, content).with_context(|| format!("writing {}", path.display()))?;
     Ok(true)
-}
-
-pub fn install_canonical_repo_skill(repo_root: &Path) -> Result<bool> {
-    write_managed_file(
-        &canonical_repo_skill_path(repo_root),
-        DEVQL_EXPLORE_FIRST_SKILL,
-    )
-}
-
-pub fn read_or_install_canonical_repo_skill(repo_root: &Path) -> Result<String> {
-    install_canonical_repo_skill(repo_root)?;
-    let path = canonical_repo_skill_path(repo_root);
-    fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))
-}
-
-pub fn remove_canonical_repo_skill(repo_root: &Path) -> Result<()> {
-    let path = canonical_repo_skill_path(repo_root);
-    remove_managed_file(&path)?;
-    prune_empty_parents(&path, &repo_root.join(".bitloops"))
 }
 
 pub fn strip_skill_frontmatter(skill: &str) -> &str {
@@ -85,6 +57,8 @@ pub fn prune_empty_parents(path: &Path, stop_at: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
+    use crate::host::hooks::augmentation::skill_content::DEVQL_EXPLORE_FIRST_SKILL;
+
     #[test]
     fn write_managed_file_is_idempotent() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -95,45 +69,6 @@ mod tests {
         assert!(write_managed_file(&path, "hello").expect("initial write"));
         assert!(!write_managed_file(&path, "hello").expect("idempotent write"));
         assert_eq!(fs::read_to_string(&path).expect("read"), "hello");
-    }
-
-    #[test]
-    fn canonical_repo_skill_path_uses_repo_root() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        assert_eq!(
-            canonical_repo_skill_path(dir.path()),
-            dir.path().join(CANONICAL_DEVQL_SKILL_RELATIVE_PATH)
-        );
-    }
-
-    #[test]
-    fn canonical_repo_skill_is_written_and_rewritten_from_builtin_content() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        assert!(install_canonical_repo_skill(dir.path()).expect("initial install"));
-
-        let path = canonical_repo_skill_path(dir.path());
-        assert_eq!(
-            fs::read_to_string(&path).expect("read canonical skill"),
-            DEVQL_EXPLORE_FIRST_SKILL
-        );
-
-        fs::write(&path, "mutated").expect("mutate canonical skill");
-        assert!(install_canonical_repo_skill(dir.path()).expect("rewrite canonical skill"));
-        assert_eq!(
-            fs::read_to_string(&path).expect("read rewritten canonical skill"),
-            DEVQL_EXPLORE_FIRST_SKILL
-        );
-    }
-
-    #[test]
-    fn remove_canonical_repo_skill_prunes_managed_subtree_but_keeps_bitloops_root() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        install_canonical_repo_skill(dir.path()).expect("install canonical skill");
-        remove_canonical_repo_skill(dir.path()).expect("remove canonical skill");
-
-        assert!(!canonical_repo_skill_path(dir.path()).exists());
-        assert!(dir.path().join(".bitloops").exists());
-        assert!(!dir.path().join(".bitloops/skills").exists());
     }
 
     #[test]

--- a/bitloops/src/cli/init/repo_excludes.rs
+++ b/bitloops/src/cli/init/repo_excludes.rs
@@ -142,8 +142,7 @@ fn managed_repo_skill_agents() -> [&'static str; 5] {
 }
 
 fn repo_managed_skill_paths(project_root: &Path, selected_agents: &[&str]) -> Vec<PathBuf> {
-    let mut paths =
-        vec![crate::adapters::agents::skill_install::canonical_repo_skill_path(project_root)];
+    let mut paths = Vec::new();
 
     for agent in selected_agents {
         let path = match *agent {

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -1369,7 +1369,6 @@ fn run_init_creates_project_local_policy_and_installs_selected_agents() {
         let exclude = std::fs::read_to_string(repo.path().join(".git/info/exclude"))
             .expect("read git exclude");
         assert!(exclude.contains(".bitloops.local.toml"));
-        assert!(exclude.contains(".bitloops/skills/bitloops/devql-explore-first/SKILL.md"));
         assert!(exclude.contains(".claude/skills/bitloops/devql-explore-first/SKILL.md"));
         assert!(!exclude.contains("config.local.json"));
         assert!(!exclude.contains(".bitloops/config.local.json"));
@@ -2072,7 +2071,6 @@ fn run_init_with_codex_agent_writes_project_local_codex_config_and_hooks() {
                 );
                 let exclude = std::fs::read_to_string(repo.path().join(".git/info/exclude"))
                     .expect("read git exclude");
-                assert!(exclude.contains(".bitloops/skills/bitloops/devql-explore-first/SKILL.md"));
                 assert!(exclude.contains(".agents/skills/bitloops/devql-explore-first/SKILL.md"));
                 assert!(!repo.path().join(".claude/settings.json").exists());
             });
@@ -2130,7 +2128,6 @@ fn run_init_with_gemini_agent_installs_repo_skill_and_root_import() {
             );
             let exclude = std::fs::read_to_string(repo.path().join(".git/info/exclude"))
                 .expect("read exclude");
-            assert!(exclude.contains(".bitloops/skills/bitloops/devql-explore-first/SKILL.md"));
             assert!(exclude.contains(".gemini/skills/bitloops/devql-explore-first/SKILL.md"));
         });
     });
@@ -2183,7 +2180,6 @@ fn run_init_with_copilot_agent_installs_hooks_and_repo_skill() {
         );
         let exclude =
             std::fs::read_to_string(repo.path().join(".git/info/exclude")).expect("read exclude");
-        assert!(exclude.contains(".bitloops/skills/bitloops/devql-explore-first/SKILL.md"));
         assert!(exclude.contains(".github/skills/bitloops/devql-explore-first/SKILL.md"));
     });
 }
@@ -2235,7 +2231,6 @@ fn run_init_with_opencode_agent_installs_plugin_and_repo_skill() {
         );
         let exclude =
             std::fs::read_to_string(repo.path().join(".git/info/exclude")).expect("read exclude");
-        assert!(exclude.contains(".bitloops/skills/bitloops/devql-explore-first/SKILL.md"));
         assert!(exclude.contains(".opencode/skills/bitloops/devql-explore-first/SKILL.md"));
     });
 }

--- a/bitloops/src/cli/uninstall/tests.rs
+++ b/bitloops/src/cli/uninstall/tests.rs
@@ -17,7 +17,6 @@ use super::{
 use crate::adapters::agents::claude_code::git_hooks;
 use crate::adapters::agents::codex::hooks as codex_hooks;
 use crate::adapters::agents::codex::skills::CODEX_SKILL_RELATIVE_PATH;
-use crate::adapters::agents::skill_install::CANONICAL_DEVQL_SKILL_RELATIVE_PATH;
 use crate::cli::embeddings::{
     managed_embeddings_binary_dir, managed_embeddings_binary_path, managed_embeddings_metadata_path,
 };
@@ -479,9 +478,7 @@ fn uninstall_agent_hooks_keeps_repo_policy_files_and_policy_exclude_entries() {
             let exclude_path = repo.path().join(".git/info/exclude");
             fs::write(
                 &exclude_path,
-                format!(
-                    "coverage/\n{REPO_POLICY_LOCAL_FILE_NAME}\n{CODEX_SKILL_RELATIVE_PATH}\n{CANONICAL_DEVQL_SKILL_RELATIVE_PATH}\n"
-                ),
+                format!("coverage/\n{REPO_POLICY_LOCAL_FILE_NAME}\n{CODEX_SKILL_RELATIVE_PATH}\n"),
             )
             .unwrap();
 
@@ -508,7 +505,6 @@ fn uninstall_agent_hooks_keeps_repo_policy_files_and_policy_exclude_entries() {
             assert!(exclude.contains("coverage/"));
             assert!(exclude.contains(REPO_POLICY_LOCAL_FILE_NAME));
             assert!(!exclude.contains(CODEX_SKILL_RELATIVE_PATH));
-            assert!(!exclude.contains(CANONICAL_DEVQL_SKILL_RELATIVE_PATH));
         },
     );
 }
@@ -549,9 +545,7 @@ fn uninstall_repo_config_removes_repo_policy_files_and_policy_exclude_entries_on
             let exclude_path = repo.path().join(".git/info/exclude");
             fs::write(
                 &exclude_path,
-                format!(
-                    "coverage/\n{REPO_POLICY_LOCAL_FILE_NAME}\n{CODEX_SKILL_RELATIVE_PATH}\n{CANONICAL_DEVQL_SKILL_RELATIVE_PATH}\n"
-                ),
+                format!("coverage/\n{REPO_POLICY_LOCAL_FILE_NAME}\n{CODEX_SKILL_RELATIVE_PATH}\n"),
             )
             .unwrap();
 
@@ -578,7 +572,6 @@ fn uninstall_repo_config_removes_repo_policy_files_and_policy_exclude_entries_on
             assert!(exclude.contains("coverage/"));
             assert!(!exclude.contains(REPO_POLICY_LOCAL_FILE_NAME));
             assert!(exclude.contains(CODEX_SKILL_RELATIVE_PATH));
-            assert!(exclude.contains(CANONICAL_DEVQL_SKILL_RELATIVE_PATH));
         },
     );
 }
@@ -894,9 +887,7 @@ fn full_uninstall_removes_supported_temp_artefacts() {
             let exclude_path = repo.path().join(".git/info/exclude");
             fs::write(
                 &exclude_path,
-                format!(
-                    "coverage/\n{REPO_POLICY_LOCAL_FILE_NAME}\n{CODEX_SKILL_RELATIVE_PATH}\n{CANONICAL_DEVQL_SKILL_RELATIVE_PATH}\n"
-                ),
+                format!("coverage/\n{REPO_POLICY_LOCAL_FILE_NAME}\n{CODEX_SKILL_RELATIVE_PATH}\n"),
             )
             .unwrap();
             git_hooks::install_git_hooks(repo.path(), false).unwrap();
@@ -949,7 +940,6 @@ fn full_uninstall_removes_supported_temp_artefacts() {
             assert!(exclude.contains("coverage/"));
             assert!(!exclude.contains(REPO_POLICY_LOCAL_FILE_NAME));
             assert!(!exclude.contains(CODEX_SKILL_RELATIVE_PATH));
-            assert!(!exclude.contains(CANONICAL_DEVQL_SKILL_RELATIVE_PATH));
         },
     );
 }


### PR DESCRIPTION
## Summary
- Removed the shared canonical DevQL skill copy under .bitloops/skills.
- Updated agent installers to write embedded DevQL guidance directly to native agent surfaces.
- Simplified init/uninstall exclude handling now that the canonical path is no longer managed.
- Updated tests and changelog for the new behavior.


## Validation

- [X] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

