### PR TITLE
Opencode fixes and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Existing repo-local OpenCode plugins could silently stop dashboard capture after model-metadata updates**: the generated `.opencode/plugins/bitloops.ts` plugin now keeps rich OpenCode transcript metadata such as nested `model.id`, `model.modelID`, and provider ids in the exported transcript while emitting only the single canonical `model` field on lifecycle hook payloads. This prevents Bitloops from rejecting OpenCode hook payloads with duplicate-model parse errors, restores live session and turn capture for fresh OpenCode runs, and ensures newly generated plugins come out with the corrected payload shape after rebuild/regeneration.
+
 ## [0.0.22] - 2026-05-09
 
 ### Changed

--- a/bitloops/src/adapters/agents/open_code/hooks.rs
+++ b/bitloops/src/adapters/agents/open_code/hooks.rs
@@ -210,6 +210,37 @@ enabled = true
     }
 
     #[test]
+    fn render_plugin_template_limits_hook_payloads_to_single_model_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");
+
+        assert!(
+            rendered.contains("function hookModelPayload"),
+            "plugin should derive a hook-safe model payload from the richer model metadata"
+        );
+        assert!(
+            rendered.contains("return modelMetadata.model ? { model: modelMetadata.model } : {}"),
+            "hook-safe model payload should only emit a single canonical model field"
+        );
+        assert!(
+            rendered.contains("...hookModelPayload(session)"),
+            "session-start hooks should use the hook-safe model payload"
+        );
+        assert!(
+            rendered.contains("...hookModelPayload(msg, currentSessionInfo)"),
+            "turn-start hooks should use the hook-safe model payload"
+        );
+        assert!(
+            rendered.contains("...hookModelPayload(latestSessionModelMetadata(sessionID))"),
+            "turn-end and compaction hooks should use the hook-safe model payload"
+        );
+        assert!(
+            rendered.contains("...hookModelPayload(modelMetadata)"),
+            "session-end hooks should use the hook-safe model payload"
+        );
+    }
+
+    #[test]
     fn render_plugin_template_runs_hooks_from_repo_directory() {
         let dir = tempfile::tempdir().expect("tempdir");
         let rendered = render_plugin_template(dir.path(), false).expect("render should succeed");

--- a/bitloops/src/adapters/agents/open_code/plugin.rs
+++ b/bitloops/src/adapters/agents/open_code/plugin.rs
@@ -172,6 +172,11 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
     return extractModelMetadata(messages[0], currentSessionInfo)
   }
 
+  function hookModelPayload(...sources: any[]): Record<string, string> {
+    const modelMetadata = extractModelMetadata(...sources)
+    return modelMetadata.model ? { model: modelMetadata.model } : {}
+  }
+
   /** Format a message object from its accumulated parts. */
   function formatMessageFromStore(msg: any) {
     const parts = partStore.get(msg.id) ?? []
@@ -315,7 +320,7 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
           await callHook("session-start", {
             session_id: session.id,
             transcript_path: `${transcriptDir}/${session.id}.jsonl`,
-            ...extractModelMetadata(session),
+            ...hookModelPayload(session),
           })
           break
         }
@@ -354,7 +359,7 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
                 session_id: sessionID,
                 transcript_path: `${transcriptDir}/${sessionID}.jsonl`,
                 prompt: part.text ?? "",
-                ...extractModelMetadata(msg, currentSessionInfo),
+                ...hookModelPayload(msg, currentSessionInfo),
               })
             }
           }
@@ -371,7 +376,7 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
           callHookSync("turn-end", {
             session_id: sessionID,
             transcript_path: transcriptPath,
-            ...latestSessionModelMetadata(sessionID),
+            ...hookModelPayload(latestSessionModelMetadata(sessionID)),
           })
           break
         }
@@ -382,7 +387,7 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
           await callHook("compaction", {
             session_id: sessionID,
             transcript_path: `${transcriptDir}/${sessionID}.jsonl`,
-            ...latestSessionModelMetadata(sessionID),
+            ...hookModelPayload(latestSessionModelMetadata(sessionID)),
           })
           break
         }
@@ -404,7 +409,7 @@ export const BitloopsPlugin: Plugin = async ({ client, directory, $ }) => {
           callHookSync("session-end", {
             session_id: session.id,
             transcript_path: `${transcriptDir}/${session.id}.jsonl`,
-            ...modelMetadata,
+            ...hookModelPayload(modelMetadata),
           })
           break
         }


### PR DESCRIPTION
## Summary

Existing repo-local OpenCode plugins could silently stop dashboard capture after model-metadata updates**: the generated `.opencode/plugins/bitloops.ts` plugin now keeps rich OpenCode transcript metadata such as nested `model.id`, `model.modelID`, and provider ids in the exported transcript while emitting only the single canonical `model` field on lifecycle hook payloads. This prevents Bitloops from rejecting OpenCode hook payloads with duplicate-model parse errors, restores live session and turn capture for fresh OpenCode runs, and ensures newly generated plugins come out with the corrected payload shape after rebuild/regeneration.

## Validation

- [ ] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

