### PR TITLE
Fix log level filtering and improve test clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Daemon log level filtering now applies before tail limits**: `bitloops daemon logs --level ...` now returns the last matching log lines instead of filtering only the already-tailed mixed log window, so recent INFO noise no longer hides older WARN or ERROR entries.
+
 ## [0.0.24] - 2026-05-12
 
 ### Fixed

--- a/bitloops/src/cli/daemon.rs
+++ b/bitloops/src/cli/daemon.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::fs::File;
 use std::future::Future;
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write};
@@ -349,11 +350,9 @@ where
 
     ensure_log_file_exists(&log_path)?;
     let tail_lines = args.tail.unwrap_or(DEFAULT_LOG_TAIL_LINES);
-    write_filtered_log_lines(
-        out,
-        read_tail_lines(log_path.clone(), tail_lines).await?,
-        &args.levels,
-    )?;
+    let initial_lines =
+        read_log_view_lines(log_path.clone(), tail_lines, args.levels.clone()).await?;
+    write_filtered_log_lines(out, initial_lines, &args.levels)?;
     out.flush().context("flushing daemon log output")?;
     if args.follow {
         follow_log_file_until_shutdown(&log_path, out, shutdown, poll_interval, args.levels)
@@ -515,6 +514,20 @@ async fn read_tail_lines(path: std::path::PathBuf, lines: usize) -> Result<Vec<S
         .context("joining daemon log tail task")?
 }
 
+async fn read_log_view_lines(
+    path: std::path::PathBuf,
+    lines: usize,
+    levels: Vec<DaemonLogLevel>,
+) -> Result<Vec<String>> {
+    if levels.is_empty() {
+        return read_tail_lines(path, lines).await;
+    }
+
+    task::spawn_blocking(move || tail_log_file_after_filter(&path, lines, &levels))
+        .await
+        .context("joining filtered daemon log tail task")?
+}
+
 fn write_filtered_log_lines(
     out: &mut dyn Write,
     lines: Vec<String>,
@@ -575,6 +588,37 @@ fn tail_log_file(path: &Path, lines: usize) -> Result<Vec<String>> {
         .with_context(|| format!("decoding daemon log {}", path.display()))?;
 
     Ok(content.lines().map(str::to_owned).collect())
+}
+
+fn tail_log_file_after_filter(
+    path: &Path,
+    lines: usize,
+    levels: &[DaemonLogLevel],
+) -> Result<Vec<String>> {
+    if lines == 0 {
+        return Ok(Vec::new());
+    }
+
+    let file =
+        File::open(path).with_context(|| format!("opening daemon log {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut tail = VecDeque::with_capacity(lines);
+
+    for line in reader.lines() {
+        let line = line.with_context(|| format!("reading daemon log {}", path.display()))?;
+        if should_emit_log_line(&line, levels) {
+            push_tail_line(&mut tail, line, lines);
+        }
+    }
+
+    Ok(tail.into_iter().collect())
+}
+
+fn push_tail_line(tail: &mut VecDeque<String>, line: String, lines: usize) {
+    if tail.len() == lines {
+        tail.pop_front();
+    }
+    tail.push_back(line);
 }
 
 fn find_tail_start_offset(file: &mut File, lines: usize, path: &Path) -> Result<u64> {

--- a/bitloops/src/cli/daemon.rs
+++ b/bitloops/src/cli/daemon.rs
@@ -352,7 +352,7 @@ where
     let tail_lines = args.tail.unwrap_or(DEFAULT_LOG_TAIL_LINES);
     let initial_lines =
         read_log_view_lines(log_path.clone(), tail_lines, args.levels.clone()).await?;
-    write_filtered_log_lines(out, initial_lines, &args.levels)?;
+    write_log_lines(out, initial_lines)?;
     out.flush().context("flushing daemon log output")?;
     if args.follow {
         follow_log_file_until_shutdown(&log_path, out, shutdown, poll_interval, args.levels)
@@ -528,16 +528,8 @@ async fn read_log_view_lines(
         .context("joining filtered daemon log tail task")?
 }
 
-fn write_filtered_log_lines(
-    out: &mut dyn Write,
-    lines: Vec<String>,
-    levels: &[DaemonLogLevel],
-) -> Result<()> {
+fn write_log_lines(out: &mut dyn Write, lines: Vec<String>) -> Result<()> {
     for line in lines {
-        if !should_emit_log_line(&line, levels) {
-            continue;
-        }
-
         writeln!(out, "{line}").context("writing daemon log output")?;
     }
     Ok(())
@@ -602,7 +594,7 @@ fn tail_log_file_after_filter(
     let file =
         File::open(path).with_context(|| format!("opening daemon log {}", path.display()))?;
     let reader = BufReader::new(file);
-    let mut tail = VecDeque::with_capacity(lines);
+    let mut tail = VecDeque::new();
 
     for line in reader.lines() {
         let line = line.with_context(|| format!("reading daemon log {}", path.display()))?;

--- a/bitloops/src/cli/daemon/tests.rs
+++ b/bitloops/src/cli/daemon/tests.rs
@@ -1103,7 +1103,7 @@ fn run_logs_honours_explicit_line_count() {
 }
 
 #[test]
-fn run_logs_filters_tail_output_by_exact_levels() {
+fn run_logs_returns_last_matching_lines_for_selected_levels() {
     let (_log_dir, log_path) = temp_log_path();
     write_log_lines(
         &log_path,
@@ -1132,7 +1132,39 @@ fn run_logs_filters_tail_output_by_exact_levels() {
 
     assert_eq!(
         String::from_utf8(out).expect("utf8 output"),
-        "{\"line\":4,\"level\":\"WARNING\",\"message\":\"tail-warning\"}\n{\"line\":5,\"level\":\"ERROR\",\"message\":\"tail-error\"}\n"
+        "{\"line\":1,\"level\":\"ERROR\",\"message\":\"before-tail\"}\n{\"line\":4,\"level\":\"WARNING\",\"message\":\"tail-warning\"}\n{\"line\":5,\"level\":\"ERROR\",\"message\":\"tail-error\"}\n"
+    );
+}
+
+#[test]
+fn run_logs_filters_by_level_before_applying_tail_limit() {
+    let (_log_dir, log_path) = temp_log_path();
+    let mut lines = vec![
+        "{\"line\":1,\"level\":\"WARN\",\"message\":\"hidden-by-info\"}".to_string(),
+        "{\"line\":2,\"level\":\"ERROR\",\"message\":\"also-hidden-by-info\"}".to_string(),
+    ];
+    lines.extend((3..=20).map(|line| {
+        format!("{{\"line\":{line},\"level\":\"INFO\",\"message\":\"noisy-info-{line}\"}}")
+    }));
+    write_log_lines(&log_path, &lines);
+    let mut out = Vec::new();
+
+    test_runtime()
+        .block_on(run_logs_with_io_at_path(
+            DaemonLogsArgs {
+                tail: Some(2),
+                levels: vec![DaemonLogLevel::Warn, DaemonLogLevel::Error],
+                follow: false,
+                path: false,
+            },
+            &mut out,
+            log_path,
+        ))
+        .expect("run filtered daemon logs");
+
+    assert_eq!(
+        String::from_utf8(out).expect("utf8 output"),
+        "{\"line\":1,\"level\":\"WARN\",\"message\":\"hidden-by-info\"}\n{\"line\":2,\"level\":\"ERROR\",\"message\":\"also-hidden-by-info\"}\n"
     );
 }
 


### PR DESCRIPTION
## Summary

- Fix `bitloops daemon logs --level ...` so level filtering happens before tail limiting.
- Preserve existing unfiltered tail behavior and existing follow-mode filtering for appended lines.
- Add focused regression coverage for noisy INFO logs hiding older WARN/ERROR entries, plus updated expectations for repeated level filters.
- Add an Unreleased changelog entry for the CLI behavior fix.

## Jira

- [CLI-1834](https://bitloops.atlassian.net/browse/CLI-1834)

## Validation

- [x] `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features -p bitloops run_logs` passed: 9/9.
- [x] `cargo fmt --manifest-path bitloops/Cargo.toml --check` passed.
- [x] `git diff --check` passed.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.


[CLI-1834]: https://bitloops.atlassian.net/browse/CLI-1834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ