### PR TITLE
Upgrade duckdb to 1.10502.0 and remove the stale local libduckdb-sys patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -945,10 +945,11 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1096,6 +1097,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1429,12 +1452,13 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10501.0"
+version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
+checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
  "arrow",
  "cast",
+ "comfy-table",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
@@ -2568,7 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10501.0"
+version = "1.10502.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
 dependencies = [
  "cc",
  "flate2",
@@ -2615,6 +2641,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3232,7 +3264,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3822,6 +3854,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3829,7 +3874,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4402,7 +4447,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4412,7 +4457,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5783,7 +5828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
 ]
 exclude = ["third_party/fastembed"]
 resolver = "2"
-
-[patch.crates-io]
-libduckdb-sys = { path = "third_party/libduckdb-sys" }

--- a/bitloops/Cargo.toml
+++ b/bitloops/Cargo.toml
@@ -189,7 +189,7 @@ tar = "0.4"
 xz2 = "0.1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 zstd = "0.13"
-duckdb = { version = "1", default-features = false }
+duckdb = { version = "=1.10502.0", default-features = false }
 object_store = { version = "0.13.2", features = ["aws", "gcp"] }
 walkdir = "2.5"
 chrono = { version = "0.4", default-features = true, features = ["clock"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -122,8 +122,8 @@ fn run_dev_install() -> Result<(), String> {
 
     run_command(
         &workspace_root,
-        "cargo install --path bitloops --force",
-        &["install", "--path", "bitloops", "--force"],
+        "cargo install --path bitloops --force --locked",
+        &["install", "--path", "bitloops", "--force", "--locked"],
     )?;
 
     let binary_path = installed_binary_path("bitloops")?;


### PR DESCRIPTION
## Summary

Update the DuckDB dependency path to use the matching crates.io package pair and make local dev installs deterministic.

## Changes

- Upgrade `duckdb` to `=1.10502.0`.
- Update `Cargo.lock` to resolve `duckdb v1.10502.0` with `libduckdb-sys v1.10502.0`.
- Remove the stale root `[patch.crates-io]` override for `third_party/libduckdb-sys`.
- Add `--locked` to `cargo dev-install` so installs use the committed lockfile dependency graph.

## Why

`cargo dev-install` could resolve a newer `duckdb` package while the workspace still patched `libduckdb-sys` to the older local `1.10501.0` copy. Cargo warned because that patched package did not match the selected dependency graph and was therefore unused.

Using the matching crates.io `duckdb` / `libduckdb-sys` versions removes the warning and avoids carrying a stale local patch.

## Validation

- `cargo tree --manifest-path bitloops/Cargo.toml -i libduckdb-sys --no-default-features --offline`
- `cargo test --package xtask --offline`
- `cargo check --manifest-path bitloops/Cargo.toml --no-default-features --offline`


## Validation

- [ ] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

