### PR TITLE
[codex] Fix runtime snapshot polling stalling sync

### DIFF
--- a/bitloops/src/api/runtime_schema/roots.rs
+++ b/bitloops/src/api/runtime_schema/roots.rs
@@ -58,12 +58,12 @@ impl RuntimeQueryRoot {
             .await
             .map_err(map_runtime_api_error)?;
         crate::daemon::shared_init_runtime_coordinator()
-            .snapshot_for_repo(&cfg)
-            .map(Into::into)
+            .overview_snapshot_for_repo(&cfg)
+            .map(|snapshot| RuntimeSnapshotObject::from_overview(cfg, snapshot))
             .map_err(|err| {
                 graphql_error(
                     "internal",
-                    format!("failed to load runtime snapshot: {err:#}"),
+                    format!("failed to load runtime snapshot overview: {err:#}"),
                 )
             })
     }

--- a/bitloops/src/api/runtime_schema/snapshot.rs
+++ b/bitloops/src/api/runtime_schema/snapshot.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use async_graphql::{ID, Object, Result, SimpleObject};
 
 use super::init_session::RuntimeInitSessionObject;
@@ -11,10 +13,11 @@ use crate::daemon::{
 use crate::graphql::{TaskQueueStatusObject, graphql_error};
 use crate::host::devql::DevqlConfig;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct RuntimeSnapshotObject {
-    cfg: DevqlConfig,
     repo_id: String,
+    daemon_config_root: PathBuf,
+    repo_root: PathBuf,
     task_queue: TaskQueueStatusObject,
     current_state_consumer: RuntimeCurrentStateConsumerObject,
     workplane: RuntimeWorkplaneObject,
@@ -26,7 +29,8 @@ pub(crate) struct RuntimeSnapshotObject {
 impl RuntimeSnapshotObject {
     pub(crate) fn from_overview(cfg: DevqlConfig, value: InitRuntimeOverviewSnapshot) -> Self {
         Self {
-            cfg,
+            daemon_config_root: cfg.daemon_config_root,
+            repo_root: cfg.repo_root,
             repo_id: value.repo_id,
             task_queue: value.task_queue.into(),
             current_state_consumer: value.current_state_consumer.into(),
@@ -81,7 +85,11 @@ impl RuntimeSnapshotObject {
     #[graphql(name = "currentInitSession")]
     async fn current_init_session(&self) -> Result<Option<RuntimeInitSessionObject>> {
         crate::daemon::shared_init_runtime_coordinator()
-            .current_session_for_repo(&self.cfg)
+            .current_session_for_repo_roots(
+                &self.daemon_config_root,
+                &self.repo_root,
+                &self.repo_id,
+            )
             .map(|session| session.map(Into::into))
             .map_err(|err| {
                 graphql_error(

--- a/bitloops/src/api/runtime_schema/snapshot.rs
+++ b/bitloops/src/api/runtime_schema/snapshot.rs
@@ -1,31 +1,95 @@
-use async_graphql::{ID, SimpleObject};
+use async_graphql::{ID, Object, Result, SimpleObject};
 
 use super::init_session::RuntimeInitSessionObject;
 use super::util::{summary_bootstrap_action_name, to_graphql_i32, to_graphql_i64};
 use crate::daemon::{
     CapabilityEventQueueStatus, CapabilityEventRunRecord, EmbeddingsBootstrapGateStatus,
-    InitRuntimeSnapshot, InitRuntimeWorkplaneMailboxSnapshot, InitRuntimeWorkplanePoolSnapshot,
-    InitRuntimeWorkplaneSnapshot, SummaryBootstrapResultRecord, SummaryBootstrapRunRecord,
+    InitRuntimeOverviewSnapshot, InitRuntimeWorkplaneMailboxSnapshot,
+    InitRuntimeWorkplanePoolSnapshot, InitRuntimeWorkplaneSnapshot, SummaryBootstrapResultRecord,
+    SummaryBootstrapRunRecord,
 };
-use crate::graphql::TaskQueueStatusObject;
+use crate::graphql::{TaskQueueStatusObject, graphql_error};
+use crate::host::devql::DevqlConfig;
 
-#[derive(Debug, Clone, SimpleObject)]
+#[derive(Debug, Clone)]
 pub(crate) struct RuntimeSnapshotObject {
+    cfg: DevqlConfig,
+    repo_id: String,
+    task_queue: TaskQueueStatusObject,
+    current_state_consumer: RuntimeCurrentStateConsumerObject,
+    workplane: RuntimeWorkplaneObject,
+    blocked_mailboxes: Vec<RuntimeBlockedMailboxObject>,
+    embeddings_readiness_gate: Option<RuntimeEmbeddingsReadinessGateObject>,
+    summaries_bootstrap: Option<RuntimeSummaryBootstrapRunObject>,
+}
+
+impl RuntimeSnapshotObject {
+    pub(crate) fn from_overview(cfg: DevqlConfig, value: InitRuntimeOverviewSnapshot) -> Self {
+        Self {
+            cfg,
+            repo_id: value.repo_id,
+            task_queue: value.task_queue.into(),
+            current_state_consumer: value.current_state_consumer.into(),
+            workplane: value.workplane.into(),
+            blocked_mailboxes: value
+                .blocked_mailboxes
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            embeddings_readiness_gate: value.embeddings_readiness_gate.map(Into::into),
+            summaries_bootstrap: value.summaries_bootstrap.map(Into::into),
+        }
+    }
+}
+
+#[Object]
+impl RuntimeSnapshotObject {
     #[graphql(name = "repoId")]
-    pub repo_id: String,
+    async fn repo_id(&self) -> String {
+        self.repo_id.clone()
+    }
+
     #[graphql(name = "taskQueue")]
-    pub task_queue: TaskQueueStatusObject,
+    async fn task_queue(&self) -> TaskQueueStatusObject {
+        self.task_queue.clone()
+    }
+
     #[graphql(name = "currentStateConsumer")]
-    pub current_state_consumer: RuntimeCurrentStateConsumerObject,
-    pub workplane: RuntimeWorkplaneObject,
+    async fn current_state_consumer(&self) -> RuntimeCurrentStateConsumerObject {
+        self.current_state_consumer.clone()
+    }
+
+    async fn workplane(&self) -> RuntimeWorkplaneObject {
+        self.workplane.clone()
+    }
+
     #[graphql(name = "blockedMailboxes")]
-    pub blocked_mailboxes: Vec<RuntimeBlockedMailboxObject>,
+    async fn blocked_mailboxes(&self) -> Vec<RuntimeBlockedMailboxObject> {
+        self.blocked_mailboxes.clone()
+    }
+
     #[graphql(name = "embeddingsReadinessGate")]
-    pub embeddings_readiness_gate: Option<RuntimeEmbeddingsReadinessGateObject>,
+    async fn embeddings_readiness_gate(&self) -> Option<RuntimeEmbeddingsReadinessGateObject> {
+        self.embeddings_readiness_gate.clone()
+    }
+
     #[graphql(name = "summariesBootstrap")]
-    pub summaries_bootstrap: Option<RuntimeSummaryBootstrapRunObject>,
+    async fn summaries_bootstrap(&self) -> Option<RuntimeSummaryBootstrapRunObject> {
+        self.summaries_bootstrap.clone()
+    }
+
     #[graphql(name = "currentInitSession")]
-    pub current_init_session: Option<RuntimeInitSessionObject>,
+    async fn current_init_session(&self) -> Result<Option<RuntimeInitSessionObject>> {
+        crate::daemon::shared_init_runtime_coordinator()
+            .current_session_for_repo(&self.cfg)
+            .map(|session| session.map(Into::into))
+            .map_err(|err| {
+                graphql_error(
+                    "internal",
+                    format!("failed to load current init session: {err:#}"),
+                )
+            })
+    }
 }
 
 #[derive(Debug, Clone, SimpleObject)]
@@ -221,25 +285,6 @@ pub(crate) struct RuntimeSummaryBootstrapResultObject {
     #[graphql(name = "modelName")]
     pub model_name: Option<String>,
     pub message: String,
-}
-
-impl From<InitRuntimeSnapshot> for RuntimeSnapshotObject {
-    fn from(value: InitRuntimeSnapshot) -> Self {
-        Self {
-            repo_id: value.repo_id,
-            task_queue: value.task_queue.into(),
-            current_state_consumer: value.current_state_consumer.into(),
-            workplane: value.workplane.into(),
-            blocked_mailboxes: value
-                .blocked_mailboxes
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-            embeddings_readiness_gate: value.embeddings_readiness_gate.map(Into::into),
-            summaries_bootstrap: value.summaries_bootstrap.map(Into::into),
-            current_init_session: value.current_init_session.map(Into::into),
-        }
-    }
 }
 
 impl From<CapabilityEventQueueStatus> for RuntimeCurrentStateConsumerObject {

--- a/bitloops/src/api/tests/devql_routes_subscriptions.rs
+++ b/bitloops/src/api/tests/devql_routes_subscriptions.rs
@@ -1,5 +1,39 @@
 use super::*;
 
+const DASHBOARD_RUNTIME_OVERVIEW_QUERY: &str = r#"
+    query RuntimeOverview($repoId: String!) {
+      runtimeSnapshot(repoId: $repoId) {
+        repoId
+        taskQueue {
+          queuedTasks
+          runningTasks
+          failedTasks
+          completedRecentTasks
+        }
+        currentStateConsumer {
+          pendingRuns
+          runningRuns
+          failedRuns
+          completedRecentRuns
+        }
+        workplane {
+          pendingJobs
+          runningJobs
+          failedJobs
+          completedRecentJobs
+        }
+        blockedMailboxes {
+          mailboxName
+          reason
+        }
+        embeddingsReadinessGate {
+          blocked
+          readiness
+        }
+      }
+    }
+"#;
+
 #[allow(dead_code)]
 fn write_current_repo_runtime_state(repo_root: &Path) {
     let runtime_path = crate::daemon::repo_local_runtime_state_path_for_tests(repo_root)
@@ -1011,6 +1045,107 @@ fn devql_runtime_route_accepts_the_runtime_snapshot_query_used_by_init() {
                     payload.get("errors")
                 );
                 assert_eq!(payload["data"]["runtimeSnapshot"]["repoId"], repo_id);
+            });
+        },
+    );
+}
+
+#[test]
+fn devql_runtime_route_dashboard_overview_query_skips_current_init_session_progress() {
+    let repo = seed_dashboard_repo();
+    let repo_id = crate::host::devql::resolve_repo_identity(repo.path())
+        .expect("resolve repo identity")
+        .repo_id;
+    let config_path = repo
+        .path()
+        .join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH);
+    let config_path_string = config_path.to_string_lossy().to_string();
+
+    crate::test_support::process_state::with_env_var(
+        crate::config::ENV_DAEMON_CONFIG_PATH_OVERRIDE,
+        Some(config_path_string.as_str()),
+        || {
+            let runtime = tokio::runtime::Runtime::new().expect("create runtime");
+            runtime.block_on(async {
+                let app = build_dashboard_router(test_state(
+                    repo.path().to_path_buf(),
+                    ServeMode::HelloWorld,
+                    repo.path().to_path_buf(),
+                ));
+                let headers = runtime_binding_headers(repo.path());
+                let headers_ref = headers
+                    .iter()
+                    .map(|(name, value)| (name.as_str(), value.as_str()))
+                    .collect::<Vec<_>>();
+
+                let (start_status, start_payload) =
+                    request_json_with_method_content_type_and_headers(
+                        app.clone(),
+                        Method::POST,
+                        "/devql/runtime",
+                        "application/json",
+                        &headers_ref,
+                        Body::from(
+                            json!({
+                                "query": "mutation StartInit($repoId: String!, $input: StartInitInput!) { startInit(repoId: $repoId, input: $input) { initSessionId } }",
+                                "variables": {
+                                    "repoId": repo_id,
+                                    "input": {
+                                        "runSync": false,
+                                        "runIngest": false,
+                                        "runCodeEmbeddings": false,
+                                        "runSummaries": false,
+                                        "runSummaryEmbeddings": false,
+                                        "ingestBackfill": serde_json::Value::Null,
+                                        "embeddingsBootstrap": serde_json::Value::Null,
+                                        "summariesBootstrap": serde_json::Value::Null,
+                                    }
+                                }
+                            })
+                            .to_string(),
+                        ),
+                    )
+                    .await;
+
+                assert_eq!(start_status, StatusCode::OK);
+                assert!(
+                    start_payload.get("errors").is_none(),
+                    "startInit graphql errors: {:?}",
+                    start_payload.get("errors")
+                );
+
+                crate::daemon::reset_runtime_lane_progress_load_count();
+
+                let (status, payload) = request_json_with_method_content_type_and_headers(
+                    app,
+                    Method::POST,
+                    "/devql/runtime",
+                    "application/json",
+                    &headers_ref,
+                    Body::from(
+                        json!({
+                            "query": DASHBOARD_RUNTIME_OVERVIEW_QUERY,
+                            "variables": {
+                                "repoId": repo_id,
+                            }
+                        })
+                        .to_string(),
+                    ),
+                )
+                .await;
+
+                assert_eq!(status, StatusCode::OK);
+                assert!(
+                    payload.get("errors").is_none(),
+                    "runtime graphql errors: {:?}",
+                    payload.get("errors")
+                );
+                assert_eq!(payload["data"]["runtimeSnapshot"]["repoId"], repo_id);
+                assert_eq!(
+                    crate::daemon::runtime_lane_progress_load_count(),
+                    0,
+                    "dashboard overview runtimeSnapshot must not load init lane progress"
+                );
             });
         },
     );

--- a/bitloops/src/daemon.rs
+++ b/bitloops/src/daemon.rs
@@ -93,9 +93,13 @@ pub use self::enrichment::EnrichmentJobTarget;
 pub use self::init_runtime::{InitRuntimeCoordinator, InitSessionHandle, RuntimeEventRecord};
 pub(crate) use self::init_runtime::{
     InitRuntimeLaneProgressView, InitRuntimeLaneQueueView, InitRuntimeLaneView,
-    InitRuntimeLaneWarningView, InitRuntimeSessionView, InitRuntimeSnapshot,
-    InitRuntimeWorkplaneMailboxSnapshot, InitRuntimeWorkplanePoolSnapshot,
+    InitRuntimeLaneWarningView, InitRuntimeOverviewSnapshot, InitRuntimeSessionView,
+    InitRuntimeSnapshot, InitRuntimeWorkplaneMailboxSnapshot, InitRuntimeWorkplanePoolSnapshot,
     InitRuntimeWorkplaneSnapshot, PersistedInitSessionState, PersistedSummaryBootstrapState,
+};
+#[cfg(test)]
+pub(crate) use self::init_runtime::{
+    reset_runtime_lane_progress_load_count, runtime_lane_progress_load_count,
 };
 pub use self::logger::{ProcessLogContext, daemon_log_file_path, init_process_logger};
 // Staged for the runtime schema watcher mutation added in CLI-1832 Task 2.

--- a/bitloops/src/daemon/init_runtime.rs
+++ b/bitloops/src/daemon/init_runtime.rs
@@ -39,10 +39,14 @@ mod workplane;
 mod tests;
 
 pub use self::coordinator::InitRuntimeCoordinator;
+#[cfg(test)]
+pub(crate) use self::progress::{
+    reset_runtime_lane_progress_load_count, runtime_lane_progress_load_count,
+};
 pub(crate) use self::types::{
     InitRuntimeLaneProgressView, InitRuntimeLaneQueueView, InitRuntimeLaneView,
-    InitRuntimeLaneWarningView, InitRuntimeSessionView, InitRuntimeSnapshot,
-    InitRuntimeWorkplaneMailboxSnapshot, InitRuntimeWorkplanePoolSnapshot,
+    InitRuntimeLaneWarningView, InitRuntimeOverviewSnapshot, InitRuntimeSessionView,
+    InitRuntimeSnapshot, InitRuntimeWorkplaneMailboxSnapshot, InitRuntimeWorkplanePoolSnapshot,
     InitRuntimeWorkplaneSnapshot, PersistedInitSessionState, PersistedSummaryBootstrapState,
 };
 pub use self::types::{InitSessionHandle, RuntimeEventRecord};

--- a/bitloops/src/daemon/init_runtime/coordinator.rs
+++ b/bitloops/src/daemon/init_runtime/coordinator.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{Context, Result};
@@ -309,9 +309,21 @@ impl InitRuntimeCoordinator {
         &self,
         cfg: &DevqlConfig,
     ) -> Result<Option<InitRuntimeSessionView>> {
-        let repo_store =
-            RepoSqliteRuntimeStore::open_for_roots(&cfg.daemon_config_root, &cfg.repo_root)?;
-        self.current_session_view(cfg, &repo_store)
+        self.current_session_for_repo_roots(
+            &cfg.daemon_config_root,
+            &cfg.repo_root,
+            &cfg.repo.repo_id,
+        )
+    }
+
+    pub(crate) fn current_session_for_repo_roots(
+        &self,
+        daemon_config_root: &Path,
+        repo_root: &Path,
+        repo_id: &str,
+    ) -> Result<Option<InitRuntimeSessionView>> {
+        let repo_store = RepoSqliteRuntimeStore::open_for_roots(daemon_config_root, repo_root)?;
+        self.current_session_view(repo_root, repo_id, &repo_store)
     }
 
     pub(crate) fn snapshot_for_repo(&self, cfg: &DevqlConfig) -> Result<InitRuntimeSnapshot> {
@@ -347,7 +359,8 @@ impl InitRuntimeCoordinator {
 
     fn current_session_view(
         &self,
-        cfg: &DevqlConfig,
+        repo_root: &Path,
+        repo_id: &str,
         repo_store: &RepoSqliteRuntimeStore,
     ) -> Result<Option<InitRuntimeSessionView>> {
         let state = self
@@ -357,18 +370,14 @@ impl InitRuntimeCoordinator {
         let Some(session) = state
             .sessions
             .into_iter()
-            .filter(|session| session.repo_id == cfg.repo.repo_id)
+            .filter(|session| session.repo_id == repo_id)
             .max_by_key(|session| (session.updated_at_unix, session.submitted_at_unix))
         else {
             return Ok(None);
         };
 
-        let stats = load_session_workplane_stats(
-            &cfg.repo_root,
-            repo_store,
-            &cfg.repo.repo_id,
-            &session.init_session_id,
-        )?;
+        let stats =
+            load_session_workplane_stats(repo_root, repo_store, repo_id, &session.init_session_id)?;
         let summary_task = load_summary_task_by_id(session.summary_bootstrap_task_id.as_deref())?;
         let summary_run = summary_task.as_ref().and_then(summary_run_from_task_ref);
         let initial_sync = load_task_by_id(session.initial_sync_task_id.as_deref())?;
@@ -376,10 +385,10 @@ impl InitRuntimeCoordinator {
         let follow_up_sync = load_task_by_id(session.follow_up_sync_task_id.as_deref())?;
         let embeddings_task = load_task_by_id(session.embeddings_bootstrap_task_id.as_deref())?;
         let summary_in_memory_completed =
-            self.summary_in_memory_completed(&cfg.repo.repo_id, &session.init_session_id);
+            self.summary_in_memory_completed(repo_id, &session.init_session_id);
         let lane_progress = match load_runtime_lane_progress(
-            &cfg.repo_root,
-            &cfg.repo.repo_id,
+            repo_root,
+            repo_id,
             &session,
             &stats,
             summary_in_memory_completed,
@@ -388,7 +397,7 @@ impl InitRuntimeCoordinator {
             Err(err) => {
                 log::debug!(
                     "failed to load runtime lane progress for repo `{}`: {err:#}",
-                    cfg.repo.repo_id
+                    repo_id
                 );
                 RuntimeLaneProgressState::default()
             }

--- a/bitloops/src/daemon/init_runtime/coordinator.rs
+++ b/bitloops/src/daemon/init_runtime/coordinator.rs
@@ -42,8 +42,8 @@ use super::tasks::{
     summary_run_from_task_ref, summary_status_is_failed, task_status_is_failed,
 };
 use super::types::{
-    InitRuntimeLaneView, InitRuntimeSessionView, InitRuntimeSnapshot, InitSessionHandle,
-    RuntimeEventRecord,
+    InitRuntimeLaneView, InitRuntimeOverviewSnapshot, InitRuntimeSessionView, InitRuntimeSnapshot,
+    InitSessionHandle, RuntimeEventRecord,
 };
 use super::workplane::{repo_blocked_mailboxes, workplane_snapshot_from_mailboxes};
 
@@ -261,7 +261,10 @@ impl InitRuntimeCoordinator {
         Ok(())
     }
 
-    pub(crate) fn snapshot_for_repo(&self, cfg: &DevqlConfig) -> Result<InitRuntimeSnapshot> {
+    pub(crate) fn overview_snapshot_for_repo(
+        &self,
+        cfg: &DevqlConfig,
+    ) -> Result<InitRuntimeOverviewSnapshot> {
         let repo_store =
             RepoSqliteRuntimeStore::open_for_roots(&cfg.daemon_config_root, &cfg.repo_root)?;
         let repo_id = cfg.repo.repo_id.clone();
@@ -290,9 +293,8 @@ impl InitRuntimeCoordinator {
                 vec![cfg.daemon_config_root.clone()],
             )?;
         let summaries_bootstrap = self.current_summary_bootstrap_run(&repo_id)?;
-        let current_session = self.current_session_view(cfg, &repo_store)?;
 
-        Ok(InitRuntimeSnapshot {
+        Ok(InitRuntimeOverviewSnapshot {
             repo_id,
             task_queue,
             current_state_consumer,
@@ -300,6 +302,30 @@ impl InitRuntimeCoordinator {
             blocked_mailboxes,
             embeddings_readiness_gate,
             summaries_bootstrap,
+        })
+    }
+
+    pub(crate) fn current_session_for_repo(
+        &self,
+        cfg: &DevqlConfig,
+    ) -> Result<Option<InitRuntimeSessionView>> {
+        let repo_store =
+            RepoSqliteRuntimeStore::open_for_roots(&cfg.daemon_config_root, &cfg.repo_root)?;
+        self.current_session_view(cfg, &repo_store)
+    }
+
+    pub(crate) fn snapshot_for_repo(&self, cfg: &DevqlConfig) -> Result<InitRuntimeSnapshot> {
+        let overview = self.overview_snapshot_for_repo(cfg)?;
+        let current_session = self.current_session_for_repo(cfg)?;
+
+        Ok(InitRuntimeSnapshot {
+            repo_id: overview.repo_id,
+            task_queue: overview.task_queue,
+            current_state_consumer: overview.current_state_consumer,
+            workplane: overview.workplane,
+            blocked_mailboxes: overview.blocked_mailboxes,
+            embeddings_readiness_gate: overview.embeddings_readiness_gate,
+            summaries_bootstrap: overview.summaries_bootstrap,
             current_init_session: current_session,
         })
     }

--- a/bitloops/src/daemon/init_runtime/embedding_freshness.rs
+++ b/bitloops/src/daemon/init_runtime/embedding_freshness.rs
@@ -13,13 +13,23 @@ pub(crate) struct EmbeddingFreshnessState {
     pub(crate) fresh_summary_artefact_ids: BTreeSet<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct EmbeddingFreshnessCountSelection {
+    pub(crate) code_lane: bool,
+    pub(crate) summary_embeddings: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct EmbeddingFreshnessCounts {
+    pub(crate) eligible: u64,
+    pub(crate) code_lane_completed: u64,
+    pub(crate) fresh_summary: u64,
+}
+
 impl EmbeddingFreshnessState {
+    #[cfg(test)]
     pub(crate) fn code_lane_completed_count(&self) -> u64 {
         self.code_lane_ready_artefact_ids().len() as u64
-    }
-
-    pub(crate) fn summary_embeddings_completed_count(&self) -> u64 {
-        self.fresh_summary_artefact_ids.len() as u64
     }
 
     pub(crate) fn outstanding_work_item_count(
@@ -58,6 +68,7 @@ impl EmbeddingFreshnessState {
                 .contains(artefact_id)
     }
 
+    #[cfg(test)]
     fn code_lane_ready_artefact_ids(&self) -> BTreeSet<String> {
         // The init code lane is only complete once both code and identity views are current.
         self.eligible_artefact_ids
@@ -100,6 +111,41 @@ pub(crate) fn load_embedding_freshness_state(
             relational,
             &fresh_embedding_artefacts_sql(repo_id, EmbeddingRepresentationKind::Summary),
         )?,
+    })
+}
+
+pub(crate) fn load_embedding_freshness_counts(
+    relational: &DefaultRelationalStore,
+    repo_id: &str,
+    selection: EmbeddingFreshnessCountSelection,
+) -> Result<EmbeddingFreshnessCounts> {
+    let eligible_sql = eligible_current_artefacts_sql(repo_id);
+    let fresh_code_sql = selection
+        .code_lane
+        .then(|| fresh_embedding_artefacts_sql(repo_id, EmbeddingRepresentationKind::Code));
+    let fresh_identity_sql = selection
+        .code_lane
+        .then(|| fresh_embedding_artefacts_sql(repo_id, EmbeddingRepresentationKind::Identity));
+    let fresh_summary_sql = selection
+        .summary_embeddings
+        .then(|| fresh_embedding_artefacts_sql(repo_id, EmbeddingRepresentationKind::Summary));
+
+    let code_lane_completed = match (fresh_code_sql.as_deref(), fresh_identity_sql.as_deref()) {
+        (Some(code_sql), Some(identity_sql)) => query_progress_count(
+            relational,
+            &fresh_code_and_identity_count_sql(code_sql, identity_sql),
+        )?,
+        _ => 0,
+    };
+    let fresh_summary = match fresh_summary_sql.as_deref() {
+        Some(sql) => query_progress_count(relational, &count_sql(sql))?,
+        None => 0,
+    };
+
+    Ok(EmbeddingFreshnessCounts {
+        eligible: query_progress_count(relational, &count_sql(&eligible_sql))?,
+        code_lane_completed,
+        fresh_summary,
     })
 }
 
@@ -205,6 +251,30 @@ fn query_progress_ids(relational: &DefaultRelationalStore, sql: &str) -> Result<
     }
 }
 
+pub(crate) fn query_progress_count(relational: &DefaultRelationalStore, sql: &str) -> Result<u64> {
+    let sqlite = relational.local_sqlite_pool()?;
+    let count =
+        sqlite.with_connection(|conn| Ok(conn.query_row(sql, [], |row| row.get::<_, i64>(0))?));
+    match count {
+        Ok(value) => Ok(u64::try_from(value).unwrap_or_default()),
+        Err(err) if missing_progress_table(&err) => Ok(0),
+        Err(err) => Err(err),
+    }
+}
+
+fn count_sql(inner: &str) -> String {
+    format!("SELECT COUNT(*) AS total FROM ({inner}) progress_rows")
+}
+
+fn fresh_code_and_identity_count_sql(fresh_code_sql: &str, fresh_identity_sql: &str) -> String {
+    format!(
+        "SELECT COUNT(*) AS total \
+         FROM ({fresh_code_sql}) code_rows \
+         JOIN ({fresh_identity_sql}) identity_rows \
+           ON identity_rows.artefact_id = code_rows.artefact_id"
+    )
+}
+
 fn missing_progress_table(err: &anyhow::Error) -> bool {
     let message = err.to_string();
     message.contains("no such table:") || message.contains("does not exist")
@@ -212,4 +282,28 @@ fn missing_progress_table(err: &anyhow::Error) -> bool {
 
 fn escape_sql_string(value: &str) -> String {
     value.replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_sql_wraps_distinct_progress_query() {
+        assert_eq!(
+            count_sql("SELECT DISTINCT artefact_id FROM artefacts_current"),
+            "SELECT COUNT(*) AS total FROM (SELECT DISTINCT artefact_id FROM artefacts_current) progress_rows"
+        );
+    }
+
+    #[test]
+    fn fresh_code_and_identity_count_sql_intersects_by_artefact_id() {
+        let sql = fresh_code_and_identity_count_sql(
+            "SELECT DISTINCT artefact_id FROM code_rows",
+            "SELECT DISTINCT artefact_id FROM identity_rows",
+        );
+
+        assert!(sql.contains("identity_rows.artefact_id = code_rows.artefact_id"));
+        assert!(sql.contains("SELECT COUNT(*) AS total"));
+    }
 }

--- a/bitloops/src/daemon/init_runtime/progress.rs
+++ b/bitloops/src/daemon/init_runtime/progress.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 use std::path::Path;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
 
@@ -9,11 +11,26 @@ use crate::config::resolve_semantic_clones_config_for_repo;
 use crate::daemon::types::InitSessionRecord;
 use crate::host::relational_store::{DefaultRelationalStore, RelationalStore};
 
-use super::embedding_freshness::load_embedding_freshness_state;
+use super::embedding_freshness::{
+    EmbeddingFreshnessCountSelection, load_embedding_freshness_counts, query_progress_count,
+};
 use super::stats::{RuntimeLaneProgressState, SessionWorkplaneStats, SummaryFreshnessState};
 use super::types::InitRuntimeLaneProgressView;
 
 const CURRENT_SUMMARY_SEMANTICS_TABLE: &str = "symbol_semantics_current";
+
+#[cfg(test)]
+static RUNTIME_LANE_PROGRESS_LOADS: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn reset_runtime_lane_progress_load_count() {
+    RUNTIME_LANE_PROGRESS_LOADS.store(0, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn runtime_lane_progress_load_count() -> usize {
+    RUNTIME_LANE_PROGRESS_LOADS.load(Ordering::SeqCst)
+}
 
 pub(crate) fn load_runtime_lane_progress(
     repo_root: &Path,
@@ -22,27 +39,41 @@ pub(crate) fn load_runtime_lane_progress(
     _stats: &SessionWorkplaneStats,
     summary_in_memory_completed: u64,
 ) -> Result<RuntimeLaneProgressState> {
-    let relational =
-        DefaultRelationalStore::open_local_for_repo_root_preferring_bound_config(repo_root)?;
-    let embedding_freshness = load_embedding_freshness_state(&relational, repo_id)?;
-    let total_eligible = embedding_freshness.eligible_artefact_ids.len() as u64;
-    let summaries_completed = count_current_model_backed_summary_artefacts(&relational, repo_id)?;
-    let semantic_clones = resolve_semantic_clones_config_for_repo(repo_root);
+    #[cfg(test)]
+    RUNTIME_LANE_PROGRESS_LOADS.fetch_add(1, Ordering::SeqCst);
 
+    let semantic_clones = resolve_semantic_clones_config_for_repo(repo_root);
     let code_embeddings_enabled =
         embedding_slot_for_representation(&semantic_clones, EmbeddingRepresentationKind::Code)
             .is_some();
     let summary_embeddings_enabled =
         embedding_slot_for_representation(&semantic_clones, EmbeddingRepresentationKind::Summary)
             .is_some();
-    let code_embeddings_total =
-        u64::from(session.selections.run_code_embeddings && code_embeddings_enabled)
-            * total_eligible;
-    let summary_embeddings_total =
-        u64::from(session.selections.run_summary_embeddings && summary_embeddings_enabled)
-            * total_eligible;
+    let needs_code_embeddings = session.selections.run_code_embeddings && code_embeddings_enabled;
+    let needs_summaries = session.selections.run_summaries;
+    let needs_summary_embeddings =
+        session.selections.run_summary_embeddings && summary_embeddings_enabled;
+
+    if !needs_code_embeddings && !needs_summaries && !needs_summary_embeddings {
+        return Ok(RuntimeLaneProgressState::default());
+    }
+
+    let relational =
+        DefaultRelationalStore::open_local_for_repo_root_preferring_bound_config(repo_root)?;
+    let embedding_freshness = load_embedding_freshness_counts(
+        &relational,
+        repo_id,
+        EmbeddingFreshnessCountSelection {
+            code_lane: needs_code_embeddings,
+            summary_embeddings: needs_summary_embeddings,
+        },
+    )?;
+    let total_eligible = embedding_freshness.eligible;
+    let summaries_completed = count_current_model_backed_summary_artefacts(&relational, repo_id)?;
+    let code_embeddings_total = u64::from(needs_code_embeddings) * total_eligible;
+    let summary_embeddings_total = u64::from(needs_summary_embeddings) * total_eligible;
     let code_embeddings_completed = embedding_freshness
-        .code_lane_completed_count()
+        .code_lane_completed
         .min(code_embeddings_total);
     let summaries_total = if session.selections.run_summaries {
         total_eligible
@@ -51,35 +82,34 @@ pub(crate) fn load_runtime_lane_progress(
     };
     let summaries_completed = summaries_completed.min(summaries_total);
     let summary_embeddings_completed = embedding_freshness
-        .summary_embeddings_completed_count()
+        .fresh_summary
         .min(summary_embeddings_total);
     let summary_in_memory_completed =
         summary_in_memory_completed.min(summaries_total.saturating_sub(summaries_completed));
 
     Ok(RuntimeLaneProgressState {
-        code_embeddings: (session.selections.run_code_embeddings && code_embeddings_total > 0)
-            .then(|| InitRuntimeLaneProgressView {
+        code_embeddings: (needs_code_embeddings && code_embeddings_total > 0).then(|| {
+            InitRuntimeLaneProgressView {
                 completed: code_embeddings_completed,
                 in_memory_completed: 0,
                 total: code_embeddings_total,
                 remaining: code_embeddings_total.saturating_sub(code_embeddings_completed),
-            }),
-        summaries: (session.selections.run_summaries && summaries_total > 0).then(|| {
-            InitRuntimeLaneProgressView {
-                completed: summaries_completed,
-                in_memory_completed: summary_in_memory_completed,
-                total: summaries_total,
-                remaining: summaries_total.saturating_sub(summaries_completed),
             }
         }),
-        summary_embeddings: (session.selections.run_summary_embeddings
-            && summary_embeddings_total > 0)
-            .then(|| InitRuntimeLaneProgressView {
+        summaries: (needs_summaries && summaries_total > 0).then(|| InitRuntimeLaneProgressView {
+            completed: summaries_completed,
+            in_memory_completed: summary_in_memory_completed,
+            total: summaries_total,
+            remaining: summaries_total.saturating_sub(summaries_completed),
+        }),
+        summary_embeddings: (needs_summary_embeddings && summary_embeddings_total > 0).then(|| {
+            InitRuntimeLaneProgressView {
                 completed: summary_embeddings_completed,
                 in_memory_completed: 0,
                 total: summary_embeddings_total,
                 remaining: summary_embeddings_total.saturating_sub(summary_embeddings_completed),
-            }),
+            }
+        }),
     })
 }
 
@@ -169,17 +199,6 @@ fn fresh_model_backed_summary_artefacts_sql(repo_id: &str) -> String {
                 ) \
            )",
     )
-}
-
-fn query_progress_count(relational: &DefaultRelationalStore, sql: &str) -> Result<u64> {
-    let sqlite = relational.local_sqlite_pool()?;
-    let count =
-        sqlite.with_connection(|conn| Ok(conn.query_row(sql, [], |row| row.get::<_, i64>(0))?));
-    match count {
-        Ok(value) => Ok(u64::try_from(value).unwrap_or_default()),
-        Err(err) if missing_progress_table(&err) => Ok(0),
-        Err(err) => Err(err),
-    }
 }
 
 fn query_progress_ids(relational: &DefaultRelationalStore, sql: &str) -> Result<BTreeSet<String>> {

--- a/bitloops/src/daemon/init_runtime/progress.rs
+++ b/bitloops/src/daemon/init_runtime/progress.rs
@@ -69,7 +69,11 @@ pub(crate) fn load_runtime_lane_progress(
         },
     )?;
     let total_eligible = embedding_freshness.eligible;
-    let summaries_completed = count_current_model_backed_summary_artefacts(&relational, repo_id)?;
+    let summaries_completed = if needs_summaries {
+        count_current_model_backed_summary_artefacts(&relational, repo_id)?
+    } else {
+        0
+    };
     let code_embeddings_total = u64::from(needs_code_embeddings) * total_eligible;
     let summary_embeddings_total = u64::from(needs_summary_embeddings) * total_eligible;
     let code_embeddings_completed = embedding_freshness
@@ -226,4 +230,162 @@ fn missing_progress_table(err: &anyhow::Error) -> bool {
 
 fn escape_sql_string(value: &str) -> String {
     value.replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+    use std::path::Path;
+
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::resolve_store_backend_config_for_repo;
+    use crate::daemon::{InitSessionRecord, StartInitSessionSelections};
+
+    #[test]
+    fn code_embeddings_only_progress_does_not_query_summary_counts() {
+        let repo = tempdir().expect("temp repo");
+        let config_path = crate::test_support::git_fixtures::write_test_daemon_config(repo.path());
+        let mut config = fs::OpenOptions::new()
+            .append(true)
+            .open(&config_path)
+            .expect("open daemon config");
+        writeln!(
+            config,
+            r#"
+[semantic_clones]
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+code_embeddings = "local_code"
+"#
+        )
+        .expect("append semantic clones config");
+
+        initialise_progress_tables(repo.path());
+
+        let session = InitSessionRecord {
+            init_session_id: "init-session-1".to_string(),
+            repo_id: "repo-1".to_string(),
+            repo_root: repo.path().to_path_buf(),
+            daemon_config_root: repo.path().to_path_buf(),
+            selections: StartInitSessionSelections {
+                run_sync: true,
+                run_ingest: true,
+                run_code_embeddings: true,
+                run_summaries: false,
+                run_summary_embeddings: false,
+                ingest_backfill: None,
+                embeddings_bootstrap: None,
+                summaries_bootstrap: None,
+            },
+            initial_sync_task_id: None,
+            initial_sync_terminal: None,
+            ingest_task_id: None,
+            ingest_terminal: None,
+            embeddings_bootstrap_task_id: None,
+            embeddings_bootstrap_terminal: None,
+            summary_bootstrap_task_id: None,
+            summary_bootstrap_terminal: None,
+            follow_up_sync_required: false,
+            follow_up_sync_task_id: None,
+            follow_up_sync_terminal: None,
+            next_completion_seq: 0,
+            initial_sync_completion_seq: None,
+            embeddings_bootstrap_completion_seq: None,
+            summary_bootstrap_completion_seq: None,
+            follow_up_sync_completion_seq: None,
+            submitted_at_unix: 1,
+            updated_at_unix: 1,
+            terminal_status: None,
+            terminal_error: None,
+        };
+
+        let progress = load_runtime_lane_progress(
+            repo.path(),
+            "repo-1",
+            &session,
+            &SessionWorkplaneStats::default(),
+            0,
+        )
+        .expect("load code embeddings progress without touching summary count tables");
+
+        assert!(progress.summaries.is_none());
+    }
+
+    fn initialise_progress_tables(repo_root: &Path) {
+        let backend =
+            resolve_store_backend_config_for_repo(repo_root).expect("resolve store backend");
+        let sqlite_path = backend
+            .relational
+            .resolve_sqlite_db_path_for_repo(repo_root)
+            .expect("resolve sqlite path");
+        fs::create_dir_all(sqlite_path.parent().expect("sqlite parent"))
+            .expect("create sqlite dir");
+        let conn = Connection::open(sqlite_path).expect("open sqlite");
+        conn.execute_batch(
+            "
+            CREATE TABLE artefacts_current (
+                repo_id TEXT,
+                path TEXT,
+                artefact_id TEXT,
+                content_id TEXT,
+                canonical_kind TEXT,
+                language_kind TEXT
+            );
+            CREATE TABLE current_file_state (
+                repo_id TEXT,
+                path TEXT,
+                analysis_mode TEXT
+            );
+            CREATE TABLE semantic_clone_embedding_setup_state (
+                repo_id TEXT,
+                representation_kind TEXT,
+                setup_fingerprint TEXT,
+                provider TEXT,
+                model TEXT,
+                dimension INTEGER
+            );
+            CREATE TABLE symbol_embeddings_current (
+                repo_id TEXT,
+                artefact_id TEXT,
+                content_id TEXT,
+                setup_fingerprint TEXT,
+                provider TEXT,
+                model TEXT,
+                dimension INTEGER,
+                representation_kind TEXT
+            );
+            CREATE TABLE symbol_features_current (
+                repo_id TEXT,
+                artefact_id TEXT,
+                content_id TEXT,
+                semantic_features_input_hash TEXT
+            );
+            CREATE TABLE symbol_semantics_current (
+                repo_id TEXT,
+                artefact_id TEXT,
+                content_id TEXT
+            );
+            CREATE TABLE symbol_features (
+                repo_id TEXT,
+                artefact_id TEXT,
+                blob_sha TEXT,
+                semantic_features_input_hash TEXT
+            );
+            CREATE TABLE symbol_semantics (
+                repo_id TEXT,
+                artefact_id TEXT,
+                blob_sha TEXT,
+                semantic_features_input_hash TEXT,
+                llm_summary TEXT,
+                source_model TEXT
+            );
+            ",
+        )
+        .expect("initialise progress tables");
+    }
 }

--- a/bitloops/src/daemon/init_runtime/types.rs
+++ b/bitloops/src/daemon/init_runtime/types.rs
@@ -128,6 +128,17 @@ pub struct InitRuntimeSessionView {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct InitRuntimeOverviewSnapshot {
+    pub repo_id: String,
+    pub task_queue: DevqlTaskQueueStatus,
+    pub current_state_consumer: CapabilityEventQueueStatus,
+    pub workplane: InitRuntimeWorkplaneSnapshot,
+    pub blocked_mailboxes: Vec<BlockedMailboxStatus>,
+    pub embeddings_readiness_gate: Option<EmbeddingsBootstrapGateStatus>,
+    pub summaries_bootstrap: Option<SummaryBootstrapRunRecord>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct InitRuntimeSnapshot {
     pub repo_id: String,
     pub task_queue: DevqlTaskQueueStatus,


### PR DESCRIPTION
## Summary
- Split runtime snapshots into a cheap overview and lazy `currentInitSession` resolution so dashboard polling only computes selected GraphQL fields.
- Skip semantic lane progress before opening the relational store for sync-only init sessions.
- Replace runtime embedding progress set materialization with selected count queries and add regression coverage.

## Root cause
`runtimeSnapshot` eagerly built the full `InitRuntimeSnapshot` before GraphQL field selection was applied. Dashboard debug queries did not request `currentInitSession`, but the backend still computed init lane progress and embedding freshness, causing expensive SQLite reads during active sync.

## Validation
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features --lib devql_runtime_route_dashboard_overview_query_skips_current_init_session_progress`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features --lib devql_runtime_route_accepts_the_runtime_snapshot_query_used_by_init`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features --lib runtime_snapshot_query_deserializes_current_init_session_lane_state`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features --lib init_runtime`
- `cargo dev-check`
- `pnpm test src/features/debug/api.test.ts` in `/Users/markos/code/bitloops/local-dashboard`
- `git diff --check`
