### PR TITLE
fixed issue with progress bar

### DIFF
--- a/bitloops/src/daemon/init_runtime/coordinator.rs
+++ b/bitloops/src/daemon/init_runtime/coordinator.rs
@@ -462,7 +462,7 @@ impl InitRuntimeCoordinator {
             &selected_workplane,
         );
         let warning_failures = selected_workplane.warning_failed_jobs_total;
-        let selected_lane_warning = selected_lanes_have_warning_status(&[
+        let selected_lanes = [
             (
                 session.selections.run_code_embeddings,
                 &code_embeddings_lane,
@@ -472,7 +472,9 @@ impl InitRuntimeCoordinator {
                 session.selections.run_summary_embeddings,
                 &summary_embeddings_lane,
             ),
-        ]);
+        ];
+        let selected_lane_warning = selected_lanes_have_warning_status(&selected_lanes);
+        let selected_lane_blocking_reason = selected_lane_waiting_reason(&selected_lanes);
         let has_warnings = warning_failures > 0 || selected_lane_warning;
         let semantic_bootstraps_terminal =
             semantic_bootstraps_terminal(&session, embeddings_task.as_ref(), summary_run.as_ref());
@@ -521,7 +523,7 @@ impl InitRuntimeCoordinator {
         } else if !semantic_bootstraps_terminal {
             Some("waiting_for_bootstrap".to_string())
         } else {
-            None
+            selected_lane_blocking_reason.clone()
         };
 
         let completed = !has_fatal_failure
@@ -535,7 +537,8 @@ impl InitRuntimeCoordinator {
             && selected_workplane.summary_jobs.pending == 0
             && selected_workplane.summary_jobs.running == 0
             && blocked_embedding.is_none()
-            && blocked_summary.is_none();
+            && blocked_summary.is_none()
+            && selected_lane_blocking_reason.is_none();
         let terminal_failed = has_fatal_failure && !has_remaining_work;
         let status = derive_session_status(
             has_fatal_failure,
@@ -838,6 +841,30 @@ pub(super) fn selected_lanes_have_warning_status(
     selected_lanes
         .iter()
         .any(|(selected, lane)| *selected && lane.status.eq_ignore_ascii_case("warning"))
+}
+
+pub(super) fn selected_lane_waiting_reason(
+    selected_lanes: &[(bool, &InitRuntimeLaneView)],
+) -> Option<String> {
+    selected_lanes.iter().find_map(|(selected, lane)| {
+        if !*selected {
+            return None;
+        }
+        if lane.status.eq_ignore_ascii_case("waiting") {
+            return Some(
+                lane.waiting_reason
+                    .as_deref()
+                    .filter(|reason| reason.starts_with("waiting"))
+                    .unwrap_or("waiting_for_workplane")
+                    .to_string(),
+            );
+        }
+        if lane.status.eq_ignore_ascii_case("queued") || lane.status.eq_ignore_ascii_case("running")
+        {
+            return Some("waiting_for_workplane".to_string());
+        }
+        None
+    })
 }
 
 fn task_terminal_snapshot(task: &DevqlTaskRecord) -> Option<InitSessionTaskTerminalSnapshot> {

--- a/bitloops/src/daemon/init_runtime/tests.rs
+++ b/bitloops/src/daemon/init_runtime/tests.rs
@@ -25,7 +25,7 @@ use crate::host::relational_store::DefaultRelationalStore;
 use crate::host::runtime_store::DaemonSqliteRuntimeStore;
 
 use super::coordinator::InitRuntimeCoordinator;
-use super::coordinator::selected_lanes_have_warning_status;
+use super::coordinator::{selected_lane_waiting_reason, selected_lanes_have_warning_status};
 use super::embedding_freshness::EmbeddingFreshnessState;
 use super::lanes::{
     derive_code_embeddings_lane, derive_ingest_lane, derive_session_status, derive_summaries_lane,
@@ -44,7 +44,7 @@ use super::stats::{
     SessionMailboxStats, SessionWorkplaneStats, StatusCounts, SummaryFreshnessState,
     is_summary_mailbox,
 };
-use super::types::InitRuntimeLaneProgressView;
+use super::types::{InitRuntimeLaneProgressView, InitRuntimeLaneQueueView, InitRuntimeLaneView};
 use tempfile::tempdir;
 
 fn completed_sync_task(task_id: &str, completed_at_unix: u64) -> DevqlTaskRecord {
@@ -390,6 +390,32 @@ fn test_init_runtime_coordinator() -> InitRuntimeCoordinator {
             .expect("opening test init runtime store"),
         subscription_hub: Mutex::new(None),
         summary_in_memory_batches: Mutex::new(BTreeMap::new()),
+    }
+}
+
+fn test_runtime_lane(
+    status: &str,
+    waiting_reason: Option<&str>,
+    progress: Option<InitRuntimeLaneProgressView>,
+) -> InitRuntimeLaneView {
+    InitRuntimeLaneView {
+        status: status.to_string(),
+        waiting_reason: waiting_reason.map(str::to_string),
+        detail: None,
+        activity_label: None,
+        task_id: None,
+        run_id: None,
+        progress,
+        queue: InitRuntimeLaneQueueView {
+            queued: 0,
+            running: 0,
+            failed: 0,
+        },
+        warnings: Vec::new(),
+        pending_count: 0,
+        running_count: 0,
+        failed_count: 0,
+        completed_count: 0,
     }
 }
 
@@ -2364,4 +2390,50 @@ fn session_status_only_becomes_failed_after_claimed_work_drains() {
         derive_session_status(false, false, true, None, true),
         "completed_with_warnings"
     );
+}
+
+#[test]
+fn selected_lane_waiting_reason_keeps_session_waiting_until_summary_embeddings_catch_up() {
+    let completed_lane = test_runtime_lane("completed", None, None);
+    let waiting_lane = test_runtime_lane(
+        "waiting",
+        Some("waiting_for_workplane"),
+        Some(InitRuntimeLaneProgressView {
+            completed: 24,
+            in_memory_completed: 0,
+            total: 40,
+            remaining: 16,
+        }),
+    );
+
+    let waiting_reason =
+        selected_lane_waiting_reason(&[(true, &completed_lane), (true, &waiting_lane)]);
+
+    assert_eq!(waiting_reason.as_deref(), Some("waiting_for_workplane"));
+    assert_eq!(
+        derive_session_status(
+            false,
+            false,
+            waiting_reason.is_none(),
+            waiting_reason.as_deref(),
+            false,
+        ),
+        "waiting"
+    );
+}
+
+#[test]
+fn selected_lane_waiting_reason_ignores_warning_lanes() {
+    let warning_lane = test_runtime_lane(
+        "warning",
+        None,
+        Some(InitRuntimeLaneProgressView {
+            completed: 38,
+            in_memory_completed: 0,
+            total: 40,
+            remaining: 2,
+        }),
+    );
+
+    assert_eq!(selected_lane_waiting_reason(&[(true, &warning_lane)]), None);
 }


### PR DESCRIPTION
## Summary

**Batch cleanup bug** (affected the actual counted progress)
In summary-embedding batches, the stale-row cleanup built its keep-set from only the artefacts in the current batch. For large files split across multiple batches, later same-file artefacts were missing from that keep-set, so their valid rows in symbol_embeddings_current got deleted temporarily. Since progress counts read from symbol_embeddings_current, the percentage could drop or stall.

**Early-completion bug** (affected the displayed final bar)
The init session was marked completed when task/workplane queues were empty, but it did not also require the selected lane state to be terminal. So we could end up with session.status = completed while summary_embeddings_lane still had remaining > 0 / status = waiting. The CLI then stopped on that stale snapshot before rendering the final 100%.

## Validation

- [x] I ran the relevant tests locally.
- [x] Linked Jira issue(s) are updated with implementation notes and test results.
- [x] Final status transitions match the task definition of done.

