### PR TITLE
[codex] Release v0.0.28: fix init daemon recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,8 @@ Do not use git worktrees when there is no need to parallelise, or not specifical
 Prefer cargo nextest-backed repo aliases over cargo test; use cargo test only for documented exceptions.
 For daemon, supervisor, background worker, server/API, and other long-lived backend flows, use the shared main logger and follow documentation/contributors/guides/daemon-service-logging.md. Do not introduce silent terminal failures.
 If you run any qat tests, prefer to run them with --parallel flag
+
+After a task/feature is done, you should validate with:
+
+- cargo dev-loop
+- cargo qat-develop-gate --parallel 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Local embeddings setup now honors repo-bound daemon configs**: local managed embeddings bootstrap now writes the `local_code` runtime profile into the daemon config bound by the repo's `.bitloops.local.toml`, matching the platform embeddings path and avoiding accidental writes to an unrelated default daemon config.
 - **Plain init no longer disables embeddings implicitly**: running `bitloops init` without an embeddings flag now keeps the repo's semantic embeddings policy unchanged instead of writing `embedding_mode = "off"` into `.bitloops.local.toml`.
+- **Default-daemon init now recovers when a service exists without a live daemon runtime**: `bitloops init --install-default-daemon` now detects existing always-on service metadata and restarts through the service path instead of attempting a detached daemon start, avoiding the contradictory second-repo flow where init reported both an already-running service and a missing daemon.
 - **Repo semantic profile bindings inherit daemon mode when mode is omitted**: repo-local `code_embeddings` or `summary_embeddings` bindings now keep the daemon's active semantic embedding mode unless the repo policy explicitly overrides it.
 
 ## [0.0.27] - 2026-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.0.28] - 2026-05-18
+
 ### Changed
 
 - **Semantic embeddings are now opt-in per repo policy instead of daemon-global intent**: repo policy files (`.bitloops.toml` / `.bitloops.local.toml`) now own `semantic_clones` embedding mode and profile bindings, while the daemon `config.toml` owns the available inference runtimes and profiles. `bitloops init`, `--no-embeddings`, and local/platform embeddings setup now persist the selected repo's intent without silently enabling embeddings for every repo that shares the same daemon.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitloops"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/bitloops/Cargo.toml
+++ b/bitloops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitloops"
-version = "0.0.27"
+version = "0.0.28"
 edition = "2024"
 autotests = false
 

--- a/bitloops/src/cli/init/daemon_bootstrap.rs
+++ b/bitloops/src/cli/init/daemon_bootstrap.rs
@@ -32,20 +32,44 @@ fn default_daemon_server_config() -> crate::api::DashboardServerConfig {
     }
 }
 
-#[cfg(not(test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DefaultDaemonBootstrapMode {
+    AlreadyRunning,
+    ServiceManaged,
+    Detached,
+}
+
+fn choose_default_daemon_bootstrap_mode(
+    runtime: Option<&crate::daemon::DaemonRuntimeState>,
+    service: Option<&crate::daemon::DaemonServiceMetadata>,
+) -> DefaultDaemonBootstrapMode {
+    if runtime.is_some() {
+        DefaultDaemonBootstrapMode::AlreadyRunning
+    } else if service.is_some() {
+        DefaultDaemonBootstrapMode::ServiceManaged
+    } else {
+        DefaultDaemonBootstrapMode::Detached
+    }
+}
+
 fn daemon_server_config_from_status(
     runtime: Option<&crate::daemon::DaemonRuntimeState>,
+    service: Option<&crate::daemon::DaemonServiceMetadata>,
 ) -> crate::api::DashboardServerConfig {
-    runtime.map_or_else(default_daemon_server_config, |runtime| {
-        crate::api::DashboardServerConfig {
+    if let Some(runtime) = runtime {
+        return crate::api::DashboardServerConfig {
             host: Some(runtime.host.clone()),
             port: runtime.port,
             no_open: true,
             force_http: runtime.url.starts_with("http://"),
             recheck_local_dashboard_net: false,
             bundle_dir: Some(runtime.bundle_dir.clone()),
-        }
-    })
+        };
+    }
+
+    service
+        .map(|metadata| metadata.config.clone())
+        .unwrap_or_else(default_daemon_server_config)
 }
 
 pub(crate) async fn maybe_install_default_daemon(
@@ -62,16 +86,29 @@ pub(crate) async fn maybe_install_default_daemon(
     }
 
     let _guard = DefaultDaemonBootstrapLock::acquire()?;
-    if crate::daemon::runtime_state()?.is_some() {
-        return Ok(());
-    }
+    let runtime = crate::daemon::runtime_state()?;
+    let service = crate::daemon::service_metadata()?;
+    let bootstrap_mode = choose_default_daemon_bootstrap_mode(runtime.as_ref(), service.as_ref());
 
-    let config_path = bootstrap_default_daemon_environment()?;
-    let daemon_config = crate::daemon::resolve_daemon_config(Some(config_path.as_path()))?;
-    let _ =
-        crate::daemon::start_detached(&daemon_config, default_daemon_server_config(), telemetry)
-            .await?;
-    Ok(())
+    match bootstrap_mode {
+        DefaultDaemonBootstrapMode::AlreadyRunning => Ok(()),
+        DefaultDaemonBootstrapMode::ServiceManaged | DefaultDaemonBootstrapMode::Detached => {
+            let config_path = bootstrap_default_daemon_environment()?;
+            let daemon_config = crate::daemon::resolve_daemon_config(Some(config_path.as_path()))?;
+            let config = daemon_server_config_from_status(runtime.as_ref(), service.as_ref());
+            match bootstrap_mode {
+                DefaultDaemonBootstrapMode::ServiceManaged => {
+                    let _ = crate::daemon::start_service(&daemon_config, config, telemetry).await?;
+                }
+                DefaultDaemonBootstrapMode::Detached => {
+                    let _ =
+                        crate::daemon::start_detached(&daemon_config, config, telemetry).await?;
+                }
+                DefaultDaemonBootstrapMode::AlreadyRunning => {}
+            }
+            Ok(())
+        }
+    }
 }
 
 struct DefaultDaemonBootstrapLock {
@@ -155,7 +192,7 @@ pub(crate) async fn maybe_enable_default_daemon_service(
             return Ok(());
         }
 
-        let config = daemon_server_config_from_status(runtime.as_ref());
+        let config = daemon_server_config_from_status(runtime.as_ref(), service.as_ref());
         if runtime.is_some() {
             crate::daemon::stop().await?;
         }
@@ -228,4 +265,109 @@ pub(crate) fn with_enable_default_daemon_service_hook<T>(
         },
     );
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    fn dashboard_config(port: u16, force_http: bool) -> crate::api::DashboardServerConfig {
+        crate::api::DashboardServerConfig {
+            host: Some("127.0.0.1".to_string()),
+            port,
+            no_open: true,
+            force_http,
+            recheck_local_dashboard_net: false,
+            bundle_dir: Some(PathBuf::from("/tmp/bitloops-dashboard-service")),
+        }
+    }
+
+    fn daemon_runtime_state() -> crate::daemon::DaemonRuntimeState {
+        crate::daemon::DaemonRuntimeState {
+            version: 1,
+            config_path: PathBuf::from("/tmp/bitloops/config.toml"),
+            config_root: PathBuf::from("/tmp/bitloops"),
+            pid: 12345,
+            mode: crate::daemon::DaemonMode::Service,
+            service_name: Some("com.bitloops.daemon".to_string()),
+            url: "http://127.0.0.1:5667".to_string(),
+            host: "127.0.0.1".to_string(),
+            port: 5667,
+            bundle_dir: PathBuf::from("/tmp/bitloops-dashboard-runtime"),
+            relational_db_path: PathBuf::from("/tmp/bitloops/relational.db"),
+            events_db_path: PathBuf::from("/tmp/bitloops/events.db"),
+            blob_store_path: PathBuf::from("/tmp/bitloops/blob-store"),
+            repo_registry_path: PathBuf::from("/tmp/bitloops/repos.json"),
+            binary_fingerprint: "test-fingerprint".to_string(),
+            updated_at_unix: 1,
+        }
+    }
+
+    fn daemon_service_metadata() -> crate::daemon::DaemonServiceMetadata {
+        crate::daemon::DaemonServiceMetadata {
+            version: 1,
+            config_path: PathBuf::from("/tmp/bitloops/config.toml"),
+            config_root: PathBuf::from("/tmp/bitloops"),
+            manager: crate::daemon::ServiceManagerKind::Launchd,
+            service_name: "com.bitloops.daemon".to_string(),
+            service_file: Some(PathBuf::from("/tmp/com.bitloops.daemon.plist")),
+            config: dashboard_config(5777, false),
+            last_url: Some("http://127.0.0.1:5777".to_string()),
+            last_pid: None,
+        }
+    }
+
+    #[test]
+    fn default_daemon_bootstrap_mode_uses_service_when_metadata_exists_without_runtime() {
+        assert_eq!(
+            super::choose_default_daemon_bootstrap_mode(None, None),
+            super::DefaultDaemonBootstrapMode::Detached
+        );
+
+        let service = daemon_service_metadata();
+        assert_eq!(
+            super::choose_default_daemon_bootstrap_mode(None, Some(&service)),
+            super::DefaultDaemonBootstrapMode::ServiceManaged
+        );
+
+        let runtime = daemon_runtime_state();
+        assert_eq!(
+            super::choose_default_daemon_bootstrap_mode(Some(&runtime), Some(&service)),
+            super::DefaultDaemonBootstrapMode::AlreadyRunning
+        );
+    }
+
+    #[test]
+    fn daemon_server_config_prefers_runtime_then_service_then_defaults() {
+        let runtime = daemon_runtime_state();
+        let service = daemon_service_metadata();
+
+        let from_runtime = super::daemon_server_config_from_status(Some(&runtime), Some(&service));
+        assert_eq!(from_runtime.port, 5667);
+        assert_eq!(from_runtime.bundle_dir, Some(runtime.bundle_dir.clone()));
+        assert!(from_runtime.force_http);
+
+        let from_service = super::daemon_server_config_from_status(None, Some(&service));
+        assert_eq!(from_service.port, 5777);
+        assert_eq!(from_service.bundle_dir, service.config.bundle_dir.clone());
+        assert!(!from_service.force_http);
+
+        let defaulted = super::daemon_server_config_from_status(None, None);
+        assert_eq!(defaulted.port, crate::api::DEFAULT_DASHBOARD_PORT);
+        assert!(defaulted.bundle_dir.is_none());
+    }
+
+    #[test]
+    fn default_daemon_bootstrap_mode_matches_second_repo_stale_service_state() {
+        let service = daemon_service_metadata();
+
+        let runtime_absent = None;
+        let service_present = Some(&service);
+
+        assert_eq!(
+            super::choose_default_daemon_bootstrap_mode(runtime_absent, service_present),
+            super::DefaultDaemonBootstrapMode::ServiceManaged,
+            "when the supervisor service is installed but no daemon runtime is attached, init bootstrap must use the service path rather than detached start"
+        );
+    }
 }

--- a/bitloops/src/daemon/server_runtime.rs
+++ b/bitloops/src/daemon/server_runtime.rs
@@ -314,7 +314,7 @@ pub(super) fn ensure_can_start(repo_root: &Path, allow_stopped_service: bool) ->
         && supervisor_running
     {
         bail!(
-            "Bitloops daemon is already running as an always-on service ({}) for this repository.",
+            "Bitloops daemon is managed by the always-on service ({}), but no daemon runtime is currently attached. Start it with `bitloops start` or stop/uninstall the service before starting a detached daemon.",
             metadata.service_name
         );
     }

--- a/bitloops/src/daemon/tests.rs
+++ b/bitloops/src/daemon/tests.rs
@@ -554,6 +554,67 @@ fn read_runtime_state_drops_stale_file() {
 }
 
 #[test]
+fn ensure_can_start_reports_global_service_without_claiming_repo_runtime() {
+    let repo_root = TempDir::new().expect("repo root");
+    let state_root = TempDir::new().expect("state root");
+    let state_root_str = state_root.path().to_string_lossy().to_string();
+    let _guard = enter_process_state(
+        Some(repo_root.path()),
+        &[(
+            "BITLOOPS_TEST_STATE_DIR_OVERRIDE",
+            Some(state_root_str.as_str()),
+        )],
+    );
+
+    write_service_metadata(
+        &service_metadata_path(Path::new(".")),
+        &DaemonServiceMetadata {
+            version: 1,
+            config_path: repo_root.path().join(BITLOOPS_CONFIG_RELATIVE_PATH),
+            config_root: repo_root.path().to_path_buf(),
+            manager: ServiceManagerKind::Launchd,
+            service_name: GLOBAL_SUPERVISOR_SERVICE_NAME.to_string(),
+            service_file: None,
+            config: DashboardServerConfig {
+                host: None,
+                port: crate::api::DEFAULT_DASHBOARD_PORT,
+                no_open: true,
+                force_http: false,
+                recheck_local_dashboard_net: false,
+                bundle_dir: None,
+            },
+            last_url: None,
+            last_pid: None,
+        },
+    )
+    .expect("write service metadata");
+
+    write_supervisor_runtime_state(&SupervisorRuntimeState {
+        version: 1,
+        pid: std::process::id(),
+        control_url: "http://127.0.0.1:1".to_string(),
+        binary_fingerprint: "test-fingerprint".to_string(),
+        updated_at_unix: 0,
+    })
+    .expect("write supervisor runtime state");
+
+    let err =
+        ensure_can_start(repo_root.path(), false).expect_err("detached start should be blocked");
+    let message = err.to_string();
+    assert!(
+        message.contains("always-on service"),
+        "error should mention service management: {message}"
+    );
+    assert!(
+        !message.contains("for this repository"),
+        "global service guard must not claim a repo runtime is already running: {message}"
+    );
+
+    ensure_can_start(repo_root.path(), true)
+        .expect("service-managed start path should be allowed to reuse stopped service metadata");
+}
+
+#[test]
 fn resolve_daemon_config_uses_explicit_config_path_independent_of_cwd() {
     let config_root = TempDir::new().expect("temp dir");
     let other_cwd = TempDir::new().expect("temp dir");


### PR DESCRIPTION
Fix for https://bitloops.atlassian.net/browse/CLI-1863

## Release Context

This PR prepares the Bitloops CLI `v0.0.28` release on `develop`.

Release metadata included here:

- Bump `bitloops` from `0.0.27` to `0.0.28`.
- Update `Cargo.lock` with the matching `bitloops` package version.
- Promote the changelog notes into `## [0.0.28] - 2026-05-18`.

## Summary

- Make `bitloops init --install-default-daemon` reuse the existing always-on daemon service when service metadata exists but no daemon runtime is attached.
- Keep first-run detached daemon startup behavior unchanged when no service metadata exists.
- Update the direct detached-start guard message so it no longer says a daemon is already running "for this repository" when only the global service manager is present.
- Add focused regression tests for the bootstrap decision, config precedence, and service guard wording.

## Context for Beginners

Bitloops has two related daemon pieces:

1. The **always-on service / supervisor**: a background service managed by the OS, like `com.bitloops.daemon` on macOS.
2. The **daemon runtime**: the actual Bitloops daemon process that serves requests on `127.0.0.1`.

The bug happened when the supervisor service existed and was running, but the actual daemon runtime was not currently attached. In that state:

- `bitloops init --install-default-daemon` tried to start a detached daemon.
- Detached startup is intentionally blocked when the always-on service owns daemon lifecycle.
- The user saw an "already running as an always-on service" error.
- Then plain `bitloops init` checked for a live daemon runtime, found none, and said the daemon was not running.
- `bitloops start` recovered because it already knew how to start through the service-managed path.

So the CLI looked contradictory: one command said the daemon was already running, while the next said it was not running.

## Root Cause

`maybe_install_default_daemon` only checked `runtime_state()` before choosing how to start the daemon. If no runtime existed, it always called `start_detached(...)`.

That missed the important middle state:

```text
service metadata exists + supervisor exists/runs + daemon runtime absent
```

In that state, init should use the service-managed startup path, just like `bitloops start` already does.

## What Changed

The init bootstrap path now chooses among three modes:

- **AlreadyRunning**: runtime exists, so init does nothing.
- **ServiceManaged**: service metadata exists but no runtime is attached, so init calls `daemon::start_service(...)`.
- **Detached**: no runtime and no service metadata, so init keeps the existing detached startup behavior.

The server config helper now also uses this precedence:

1. live runtime config,
2. service metadata config,
3. default daemon config.

The detached-start guard still blocks direct detached startup when the service owns lifecycle, but the message now explains that no daemon runtime is attached and tells the user to run `bitloops start` or stop/uninstall the service.

## Validation

Automated checks:

- `cargo fmt --check -- bitloops/src/cli/init/daemon_bootstrap.rs bitloops/src/daemon/server_runtime.rs bitloops/src/daemon/tests.rs`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features -- cli::init::daemon_bootstrap::tests::default_daemon_bootstrap_mode_uses_service_when_metadata_exists_without_runtime --exact`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features -- cli::init::daemon_bootstrap::tests::default_daemon_bootstrap_mode_matches_second_repo_stale_service_state --exact`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features -- cli::init::daemon_bootstrap::tests::daemon_server_config_prefers_runtime_then_service_then_defaults --exact`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --lib --no-default-features -- daemon::tests::ensure_can_start_reports_global_service_without_claiming_repo_runtime --exact`
- `cargo dev-test-lib` (`4019 passed, 21 skipped`)
- `cargo metadata --locked --format-version 1 --no-deps`

Manual QA:

- Installed the PR build locally.
- Initialized repo 1 with `bitloops init --install-default-daemon`.
- Killed only the daemon runtime PID while leaving the always-on service/supervisor present.
- Confirmed status showed service metadata/supervisor still present and no live runtime.
- Initialized repo 2 with `bitloops init --install-default-daemon` and confirmed it recovered through the service path instead of failing with contradictory daemon lifecycle messages.

## Jira

- CLI-1863