### PR TITLE
Fix init optional setup prompt parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Interactive init now uses the same optional setup prompt path with or without the default daemon** (`CLI-1872`): `bitloops init` now offers embeddings, semantic summaries, and context guidance setup when those features are unconfigured, matching `bitloops init --install-default-daemon`; the daemon flag now only adds default-daemon bootstrap behavior.
 - **DevQL sync now handles Vite's package fixtures and duplicate test names** (`CLI-1858`, `CLI-1859`, `CLI-1866`): project-aware classification now accepts `package.json` files with a leading UTF-8 BOM and reports the package path on parse failures. Test-harness materialization now keeps semantic `symbol_id`s independent of source line spans, collapses repeated source suite containers into one logical suite, then applies duplicate-aware tokens when repeated case or doctest identities collide. Current-state sync reuses prior duplicate tokens by source order so legal repeated Vitest `it` names, Gitea tests, NestJS specs, and Rust doctests no longer collapse to the same test artefact ID when line numbers shift.
 
 ## [0.0.28] - 2026-05-18

--- a/bitloops/src/cli/init.rs
+++ b/bitloops/src/cli/init.rs
@@ -34,12 +34,10 @@ pub(super) use daemon_bootstrap::{
 pub(super) use daemon_bootstrap::{
     with_enable_default_daemon_service_hook, with_install_default_daemon_hook,
 };
+#[cfg(test)]
+pub(super) use embeddings_setup::prompt_install_embeddings_setup_selection;
 pub(super) use embeddings_setup::{
     InitEmbeddingsSetupSelection, should_install_embeddings_during_init,
-};
-#[cfg(test)]
-pub(super) use embeddings_setup::{
-    NON_INTERACTIVE_INIT_EMBEDDINGS_SELECTION_ERROR, prompt_install_embeddings_setup_selection,
 };
 #[cfg(test)]
 pub(super) use final_setup::InitFinalSetupSelection;

--- a/bitloops/src/cli/init.rs
+++ b/bitloops/src/cli/init.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 mod agent_hooks;
 mod agent_selection;
 mod args;
+mod cloud_login_status;
 mod context_guidance_setup;
 mod daemon_bootstrap;
 mod embeddings_setup;
@@ -26,6 +27,8 @@ pub use args::{InitArgs, InitCommand, InitStatusArgs};
 pub(super) use args::{
     DEFAULT_INIT_INGEST_BACKFILL, normalize_cli_exclusions, normalize_exclude_from_paths,
 };
+#[cfg(test)]
+pub(super) use cloud_login_status::with_cloud_login_status_hook;
 pub(super) use context_guidance_setup::choose_context_guidance_setup_during_init;
 pub(super) use daemon_bootstrap::{
     maybe_enable_default_daemon_service, maybe_install_default_daemon,

--- a/bitloops/src/cli/init/cloud_login_status.rs
+++ b/bitloops/src/cli/init/cloud_login_status.rs
@@ -1,0 +1,41 @@
+use anyhow::Result;
+
+#[cfg(test)]
+type CloudLoginStatusHook = dyn Fn() -> Result<bool>;
+#[cfg(test)]
+type CloudLoginStatusHookCell = std::cell::RefCell<Option<std::rc::Rc<CloudLoginStatusHook>>>;
+
+#[cfg(test)]
+thread_local! {
+    static CLOUD_LOGIN_STATUS_HOOK: CloudLoginStatusHookCell = std::cell::RefCell::new(None);
+}
+
+pub(super) async fn resolve_cloud_logged_in_for_optional_setup() -> Result<bool> {
+    #[cfg(test)]
+    if let Some(hook) = CLOUD_LOGIN_STATUS_HOOK.with(|cell| cell.borrow().clone()) {
+        return hook();
+    }
+
+    Ok(crate::daemon::resolve_workos_session_status()
+        .await?
+        .is_some())
+}
+
+#[cfg(test)]
+pub(crate) fn with_cloud_login_status_hook<T>(
+    hook: impl Fn() -> Result<bool> + 'static,
+    f: impl FnOnce() -> T,
+) -> T {
+    CLOUD_LOGIN_STATUS_HOOK.with(|cell| {
+        assert!(
+            cell.borrow().is_none(),
+            "cloud login status hook already installed"
+        );
+        *cell.borrow_mut() = Some(std::rc::Rc::new(hook));
+    });
+    let result = f();
+    CLOUD_LOGIN_STATUS_HOOK.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+    result
+}

--- a/bitloops/src/cli/init/context_guidance_setup.rs
+++ b/bitloops/src/cli/init/context_guidance_setup.rs
@@ -39,15 +39,5 @@ pub(crate) async fn choose_context_guidance_setup_during_init(
         return Ok(ContextGuidanceSetupSelection::Skip);
     }
 
-    let cloud_logged_in = crate::daemon::resolve_workos_session_status()
-        .await?
-        .is_some();
-
-    prompt_context_guidance_setup_selection(
-        out,
-        input,
-        true,
-        args.install_default_daemon,
-        cloud_logged_in,
-    )
+    prompt_context_guidance_setup_selection(out, input, true, args.install_default_daemon, false)
 }

--- a/bitloops/src/cli/init/context_guidance_setup.rs
+++ b/bitloops/src/cli/init/context_guidance_setup.rs
@@ -25,10 +25,6 @@ pub(crate) async fn choose_context_guidance_setup_during_init(
         return Ok(ContextGuidanceSetupSelection::Skip);
     }
 
-    if !args.install_default_daemon {
-        return Ok(ContextGuidanceSetupSelection::Skip);
-    }
-
     if let Some(runtime) = args.context_guidance_runtime {
         return Ok(match runtime {
             TextGenerationRuntime::Local => ContextGuidanceSetupSelection::Local,

--- a/bitloops/src/cli/init/embeddings_setup.rs
+++ b/bitloops/src/cli/init/embeddings_setup.rs
@@ -1,7 +1,7 @@
 use std::io::{BufRead, Write};
 use std::path::Path;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 
 use crate::cli::embeddings::{
     EmbeddingsInstallState, EmbeddingsRuntime, inspect_embeddings_install_state,
@@ -12,8 +12,6 @@ use crate::cli::terminal_picker::{
 };
 
 use super::InitArgs;
-
-pub(crate) const NON_INTERACTIVE_INIT_EMBEDDINGS_SELECTION_ERROR: &str = "`bitloops init --install-default-daemon` requires an explicit embeddings choice when not running interactively. Pass `--embeddings-runtime local`, `--embeddings-runtime platform`, or `--no-embeddings`.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InitEmbeddingsSetupSelection {
@@ -41,10 +39,6 @@ pub(crate) fn should_install_embeddings_during_init(
         });
     }
 
-    if !args.install_default_daemon {
-        return Ok(InitEmbeddingsSetupSelection::Unchanged);
-    }
-
     if !matches!(
         inspect_embeddings_install_state(repo_root),
         EmbeddingsInstallState::NotConfigured
@@ -53,7 +47,7 @@ pub(crate) fn should_install_embeddings_during_init(
     }
 
     if !telemetry_consent::can_prompt_interactively() {
-        bail!(NON_INTERACTIVE_INIT_EMBEDDINGS_SELECTION_ERROR);
+        return Ok(InitEmbeddingsSetupSelection::Unchanged);
     }
 
     prompt_install_embeddings_setup_selection(out, input)

--- a/bitloops/src/cli/init/summary_setup.rs
+++ b/bitloops/src/cli/init/summary_setup.rs
@@ -9,6 +9,8 @@ use crate::cli::inference::{
 use crate::cli::telemetry_consent;
 use crate::config::{SemanticSummaryMode, resolve_semantic_clones_config_for_repo};
 
+use super::cloud_login_status::resolve_cloud_logged_in_for_optional_setup;
+
 pub(crate) async fn choose_summary_setup_during_init(
     repo_root: &Path,
     install_default_daemon: bool,
@@ -28,14 +30,19 @@ pub(crate) async fn choose_summary_setup_during_init(
         return Ok(SummarySetupSelection::Skip);
     }
 
-    let cloud_logged_in = crate::daemon::resolve_workos_session_status()
-        .await?
-        .is_some();
+    let interactive = telemetry_consent::can_prompt_interactively();
+    let cloud_logged_in = if interactive {
+        false
+    } else {
+        resolve_cloud_logged_in_for_optional_setup()
+            .await
+            .unwrap_or(false)
+    };
 
     prompt_summary_setup_selection(
         out,
         input,
-        telemetry_consent::can_prompt_interactively(),
+        interactive,
         install_default_daemon,
         cloud_logged_in,
     )

--- a/bitloops/src/cli/init/summary_setup.rs
+++ b/bitloops/src/cli/init/summary_setup.rs
@@ -28,10 +28,6 @@ pub(crate) async fn choose_summary_setup_during_init(
         return Ok(SummarySetupSelection::Skip);
     }
 
-    if !install_default_daemon {
-        return Ok(SummarySetupSelection::Skip);
-    }
-
     let cloud_logged_in = crate::daemon::resolve_workos_session_status()
         .await?
         .is_some();

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -143,7 +143,7 @@ fn with_temp_app_dirs<T>(
     assume_daemon_running: bool,
     f: impl FnOnce() -> T,
 ) -> T {
-    with_temp_app_dirs_and_summary_configured(temp, tty, assume_daemon_running, true, f)
+    with_temp_app_dirs_and_generation_configured(temp, tty, assume_daemon_running, true, true, f)
 }
 
 fn with_temp_app_dirs_and_summary_configured<T>(
@@ -153,11 +153,29 @@ fn with_temp_app_dirs_and_summary_configured<T>(
     summary_configured: bool,
     f: impl FnOnce() -> T,
 ) -> T {
+    with_temp_app_dirs_and_generation_configured(
+        temp,
+        tty,
+        assume_daemon_running,
+        summary_configured,
+        true,
+        f,
+    )
+}
+
+fn with_temp_app_dirs_and_generation_configured<T>(
+    temp: &TempDir,
+    tty: bool,
+    assume_daemon_running: bool,
+    summary_configured: bool,
+    context_guidance_configured: bool,
+    f: impl FnOnce() -> T,
+) -> T {
     with_summary_generation_configured_hook(
         move |_| summary_configured,
         || {
             with_context_guidance_generation_configured_hook(
-                |_| true,
+                move |_| context_guidance_configured,
                 || {
                     with_test_platform_dir_overrides(app_dir_overrides(temp), || {
                         with_test_tty_override(tty, || {
@@ -3421,12 +3439,12 @@ fn run_init_with_install_default_daemon_prefers_https_fallback_when_mkcert_is_av
 }
 
 #[test]
-fn run_init_without_install_default_daemon_leaves_embeddings_unconfigured() {
+fn run_init_without_install_default_daemon_prompts_for_skippable_embeddings_setup() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
 
-    with_temp_app_dirs(&app_dirs, false, true, || {
+    with_temp_app_dirs(&app_dirs, true, true, || {
         let config_path = ensure_daemon_config_exists().expect("create default daemon config");
         let (command, args) = fake_runtime_command_and_args(repo.path());
         write_runtime_only_daemon_config(&config_path, &command, &args);
@@ -3443,7 +3461,7 @@ fn run_init_without_install_default_daemon_leaves_embeddings_unconfigured() {
             },
             || {
                 let mut out = Vec::new();
-                let mut input = Cursor::new("");
+                let mut input = Cursor::new("3\n\n");
                 let runtime = test_runtime();
                 runtime
                     .block_on(run_with_io_async_for_project_root(
@@ -3452,7 +3470,7 @@ fn run_init_without_install_default_daemon_leaves_embeddings_unconfigured() {
                             install_default_daemon: false,
                             force: false,
                             disable_devql_guidance: false,
-                            agent: Vec::new(),
+                            agent: vec![DEFAULT_AGENT.to_string()],
                             telemetry: Some(false),
                             no_telemetry: false,
                             skip_baseline: false,
@@ -3484,7 +3502,8 @@ fn run_init_without_install_default_daemon_leaves_embeddings_unconfigured() {
                     "plain init should not install embeddings:\n{config}"
                 );
                 let rendered = String::from_utf8(out).expect("utf8 output");
-                assert!(!rendered.contains("Configure embeddings"));
+                assert!(rendered.contains("Configure embeddings"));
+                assert!(rendered.contains("Skip for now"));
                 assert!(!rendered.contains("Install local embeddings as well?"));
             },
         );
@@ -3492,12 +3511,12 @@ fn run_init_without_install_default_daemon_leaves_embeddings_unconfigured() {
 }
 
 #[test]
-fn run_init_interactive_without_install_default_daemon_skips_daemon_setup_prompts() {
+fn run_init_interactive_without_install_default_daemon_uses_full_setup_prompt_path() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
 
-    with_temp_app_dirs_and_summary_configured(&app_dirs, true, true, false, || {
+    with_temp_app_dirs_and_generation_configured(&app_dirs, true, true, false, false, || {
         let config_path = ensure_daemon_config_exists().expect("create default daemon config");
         write_runtime_only_daemon_config(&config_path, "bitloops-local-embeddings", &[]);
 
@@ -3516,7 +3535,7 @@ fn run_init_interactive_without_install_default_daemon_skips_daemon_setup_prompt
                     |_repo_root| panic!("plain init should not install embeddings"),
                     || {
                         let mut out = Vec::new();
-                        let mut input = Cursor::new("");
+                        let mut input = Cursor::new("3\n\n\n\n");
                         let select = |_items: &[String], enable_devql_guidance: bool| {
                             Ok(InitAgentSelection {
                                 agents: vec!["claude-code".to_string()],
@@ -3559,9 +3578,10 @@ fn run_init_interactive_without_install_default_daemon_skips_daemon_setup_prompt
                             .expect("run init");
 
                         let rendered = String::from_utf8(out).expect("utf8 output");
-                        assert!(!rendered.contains("Configure embeddings"));
+                        assert!(rendered.contains("Configure embeddings"));
                         assert!(!rendered.contains("Install local embeddings as well?"));
-                        assert!(!rendered.contains("Configure semantic summaries"));
+                        assert!(rendered.contains("Configure semantic summaries"));
+                        assert!(rendered.contains("Configure context guidance"));
 
                         let daemon_config = ensure_daemon_config_exists()
                             .expect("resolve daemon config after init");
@@ -4279,7 +4299,7 @@ fn run_init_with_install_default_daemon_auto_installs_embeddings() {
 }
 
 #[test]
-fn run_init_with_install_default_daemon_requires_explicit_embeddings_choice_when_noninteractive() {
+fn run_init_with_install_default_daemon_leaves_embeddings_unchanged_when_noninteractive() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
@@ -4308,7 +4328,7 @@ fn run_init_with_install_default_daemon_requires_explicit_embeddings_choice_when
                         let mut out = Vec::new();
                         let mut input = Cursor::new("");
                         let runtime = test_runtime();
-                        let err = runtime
+                        runtime
                             .block_on(run_with_io_async_for_project_root(
                                 InitArgs {
                                     command: None,
@@ -4340,11 +4360,15 @@ fn run_init_with_install_default_daemon_requires_explicit_embeddings_choice_when
                                 &mut input,
                                 None,
                             ))
-                            .expect_err("non-interactive init should require an embeddings choice");
+                            .expect("run non-interactive init without embeddings choice");
 
+                        let daemon_config = ensure_daemon_config_exists()
+                            .expect("resolve daemon config after init");
+                        let daemon_config =
+                            std::fs::read_to_string(daemon_config).expect("read daemon config");
                         assert!(
-                            format!("{err:#}")
-                                .contains(NON_INTERACTIVE_INIT_EMBEDDINGS_SELECTION_ERROR)
+                            !daemon_config.contains("code_embeddings = "),
+                            "non-interactive init without an explicit embeddings choice should leave embeddings unconfigured:\n{daemon_config}"
                         );
                     },
                 );

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -866,6 +866,114 @@ fn choose_summary_setup_during_init_skips_when_summary_mode_is_off() {
 }
 
 #[test]
+fn choose_summary_setup_interactive_does_not_resolve_cloud_login_status() {
+    let repo = tempfile::tempdir().expect("tempdir");
+    let mut out = Vec::new();
+    let mut input = Cursor::new("\n");
+
+    let selection = with_test_tty_override(true, || {
+        with_summary_generation_configured_hook(
+            |_| false,
+            || {
+                with_cloud_login_status_hook(
+                    || panic!("interactive summary setup should not resolve cloud login status"),
+                    || {
+                        test_runtime().block_on(choose_summary_setup_during_init(
+                            repo.path(),
+                            false,
+                            false,
+                            &mut out,
+                            &mut input,
+                        ))
+                    },
+                )
+            },
+        )
+    })
+    .expect("choose summary setup");
+
+    assert_eq!(
+        selection,
+        crate::cli::inference::SummarySetupSelection::Skip
+    );
+    let rendered = String::from_utf8(out).expect("utf8 output");
+    assert!(rendered.contains("Configure semantic summaries"));
+}
+
+#[test]
+fn choose_summary_setup_noninteractive_treats_login_error_as_not_logged_in() {
+    let repo = tempfile::tempdir().expect("tempdir");
+    let mut out = Vec::new();
+    let mut input = Cursor::new("");
+
+    let selection = with_test_tty_override(false, || {
+        with_summary_generation_configured_hook(
+            |_| false,
+            || {
+                with_cloud_login_status_hook(
+                    || Err(anyhow::anyhow!("keyring unavailable")),
+                    || {
+                        test_runtime().block_on(choose_summary_setup_during_init(
+                            repo.path(),
+                            false,
+                            false,
+                            &mut out,
+                            &mut input,
+                        ))
+                    },
+                )
+            },
+        )
+    })
+    .expect("choose summary setup");
+
+    assert_eq!(
+        selection,
+        crate::cli::inference::SummarySetupSelection::Skip
+    );
+}
+
+#[test]
+fn choose_context_guidance_setup_interactive_does_not_resolve_cloud_login_status() {
+    let repo = tempfile::tempdir().expect("tempdir");
+    let parsed = Cli::try_parse_from(["bitloops", "init"]).expect("parse init");
+    let Some(Commands::Init(args)) = parsed.command else {
+        panic!("expected init command");
+    };
+    let mut out = Vec::new();
+    let mut input = Cursor::new("\n");
+
+    let selection = with_test_tty_override(true, || {
+        with_context_guidance_generation_configured_hook(
+            |_| false,
+            || {
+                with_cloud_login_status_hook(
+                    || {
+                        panic!("interactive context guidance setup should not resolve cloud login status")
+                    },
+                    || {
+                        test_runtime().block_on(choose_context_guidance_setup_during_init(
+                            repo.path(),
+                            &args,
+                            &mut out,
+                            &mut input,
+                        ))
+                    },
+                )
+            },
+        )
+    })
+    .expect("choose context guidance setup");
+
+    assert_eq!(
+        selection,
+        crate::cli::inference::ContextGuidanceSetupSelection::Skip
+    );
+    let rendered = String::from_utf8(out).expect("utf8 output");
+    assert!(rendered.contains("Configure context guidance"));
+}
+
+#[test]
 fn init_args_reject_conflicting_no_embeddings_and_runtime_flags() {
     let err = Cli::try_parse_from([
         "bitloops",


### PR DESCRIPTION
## Summary
- Align interactive `bitloops init` optional setup prompts with `bitloops init --install-default-daemon`.
- Remove default-daemon gating from embeddings, semantic summaries, and context guidance prompt selection.
- Keep non-interactive embeddings unchanged unless an explicit embeddings choice is passed.

## Validation
- `cargo fmt --all --manifest-path bitloops/Cargo.toml`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features -p bitloops run_init_without_install_default_daemon_prompts_for_skippable_embeddings_setup run_init_interactive_without_install_default_daemon_uses_full_setup_prompt_path`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features -p bitloops cli::init::tests`
- Full `cargo dev-loop` was started, then stopped at request; local validation will cover the remaining gate.
