### PR TITLE
Add file fallback for WorkOS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **WorkOS auth token storage now falls back on headless Linux** (`CLI-1875`): when the platform secure store is unavailable, such as a Linux server without DBus Secret Service, Bitloops now persists auth tokens to a private file-backed fallback store instead of aborting sign-in.
 - **Interactive init now uses the same optional setup prompt path with or without the default daemon** (`CLI-1872`): `bitloops init` now offers embeddings, semantic summaries, and context guidance setup when those features are unconfigured, matching `bitloops init --install-default-daemon`; the daemon flag now only adds default-daemon bootstrap behavior.
 - **DevQL sync now handles Vite's package fixtures and duplicate test names** (`CLI-1858`, `CLI-1859`, `CLI-1866`): project-aware classification now accepts `package.json` files with a leading UTF-8 BOM and reports the package path on parse failures. Test-harness materialization now keeps semantic `symbol_id`s independent of source line spans, collapses repeated source suite containers into one logical suite, then applies duplicate-aware tokens when repeated case or doctest identities collide. Current-state sync reuses prior duplicate tokens by source order so legal repeated Vitest `it` names, Gitea tests, NestJS specs, and Rust doctests no longer collapse to the same test artefact ID when line numbers shift.
 

--- a/bitloops/src/daemon/auth/credentials.rs
+++ b/bitloops/src/daemon/auth/credentials.rs
@@ -107,21 +107,21 @@ impl FileCredentialStore {
             {
                 options.mode(0o600);
             }
-            let mut file = options.open(&tmp_path).with_context(|| {
-                format!("creating temporary credential file {}", tmp_path.display())
-            })?;
-            serde_json::to_writer(&mut file, record)
-                .context("serialising fallback credential payload")?;
-            file.write_all(b"\n")
-                .context("finalising fallback credential payload")?;
-            file.flush()
-                .context("flushing fallback credential payload")?;
-            file.sync_all()
-                .context("syncing fallback credential payload")?;
+            {
+                let mut file = options.open(&tmp_path).with_context(|| {
+                    format!("creating temporary credential file {}", tmp_path.display())
+                })?;
+                serde_json::to_writer(&mut file, record)
+                    .context("serialising fallback credential payload")?;
+                file.write_all(b"\n")
+                    .context("finalising fallback credential payload")?;
+                file.flush()
+                    .context("flushing fallback credential payload")?;
+                file.sync_all()
+                    .context("syncing fallback credential payload")?;
+            }
             set_file_private(&tmp_path)?;
-            fs::rename(&tmp_path, path).with_context(|| {
-                format!("installing fallback credential file {}", path.display())
-            })?;
+            replace_file_atomically(&tmp_path, path)?;
             Ok(())
         })();
 
@@ -190,6 +190,56 @@ fn credential_key_hash(key: &WorkosCredentialKey) -> String {
     hasher.update([0]);
     hasher.update(key.account.as_bytes());
     hex::encode(hasher.finalize())
+}
+
+fn replace_file_atomically(temp_path: &Path, final_path: &Path) -> Result<()> {
+    #[cfg(windows)]
+    {
+        if !final_path.exists() {
+            return fs::rename(temp_path, final_path).with_context(|| {
+                format!(
+                    "installing fallback credential file {}",
+                    final_path.display()
+                )
+            });
+        }
+
+        let counter = FALLBACK_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let backup_path =
+            final_path.with_extension(format!("json.bak.{}.{}", std::process::id(), counter));
+        fs::rename(final_path, &backup_path).with_context(|| {
+            format!(
+                "moving existing fallback credential file {} aside",
+                final_path.display()
+            )
+        })?;
+        match fs::rename(temp_path, final_path) {
+            Ok(()) => {
+                let _ = fs::remove_file(&backup_path);
+                Ok(())
+            }
+            Err(err) => {
+                let _ = fs::rename(&backup_path, final_path);
+                let _ = fs::remove_file(temp_path);
+                Err(err).with_context(|| {
+                    format!(
+                        "installing fallback credential file {}",
+                        final_path.display()
+                    )
+                })
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        fs::rename(temp_path, final_path).with_context(|| {
+            format!(
+                "installing fallback credential file {}",
+                final_path.display()
+            )
+        })
+    }
 }
 
 fn set_dir_private(path: &Path) -> Result<()> {

--- a/bitloops/src/daemon/auth/credentials.rs
+++ b/bitloops/src/daemon/auth/credentials.rs
@@ -1,18 +1,235 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 #[cfg(test)]
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 #[cfg(test)]
 use std::sync::Mutex;
 
 use super::types::{StoredWorkosTokens, WorkosCredentialKey};
 
+static FALLBACK_TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+const FILE_CREDENTIAL_STORE_VERSION: u8 = 1;
+
 pub(super) trait SecureCredentialStore: Send + Sync {
     fn load_tokens(&self, key: &WorkosCredentialKey) -> Result<Option<StoredWorkosTokens>>;
     fn save_tokens(&self, key: &WorkosCredentialKey, tokens: &StoredWorkosTokens) -> Result<()>;
     fn delete_tokens(&self, key: &WorkosCredentialKey) -> Result<()>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FileCredentialRecord {
+    version: u8,
+    service: String,
+    account: String,
+    tokens: StoredWorkosTokens,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct SecureStoreUnavailable {
+    operation: &'static str,
+    message: String,
+}
+
+impl SecureStoreUnavailable {
+    pub(super) fn new(operation: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            operation,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for SecureStoreUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.operation, self.message)
+    }
+}
+
+impl std::error::Error for SecureStoreUnavailable {}
+
+#[derive(Debug, Clone)]
+pub(super) struct FileCredentialStore {
+    dir: PathBuf,
+}
+
+impl FileCredentialStore {
+    pub(super) fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
+    fn from_default_state_dir() -> Result<Self> {
+        Ok(Self::new(
+            crate::utils::platform_dirs::bitloops_state_dir()?
+                .join("auth")
+                .join("credentials"),
+        ))
+    }
+
+    #[cfg(test)]
+    pub(super) fn credential_file_path_for_test(&self, key: &WorkosCredentialKey) -> PathBuf {
+        self.credential_file_path(key)
+    }
+
+    fn credential_file_path(&self, key: &WorkosCredentialKey) -> PathBuf {
+        self.dir.join(format!("{}.json", credential_key_hash(key)))
+    }
+
+    fn ensure_dir(&self) -> Result<()> {
+        fs::create_dir_all(&self.dir).with_context(|| {
+            format!(
+                "creating credential fallback directory {}",
+                self.dir.display()
+            )
+        })?;
+        set_dir_private(&self.dir)?;
+        Ok(())
+    }
+
+    fn write_record_atomically(&self, path: &Path, record: &FileCredentialRecord) -> Result<()> {
+        self.ensure_dir()?;
+        let counter = FALLBACK_TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = path.with_extension(format!("json.tmp.{}.{}", std::process::id(), counter));
+
+        let write_result = (|| -> Result<()> {
+            let mut options = fs::OpenOptions::new();
+            options.write(true).create(true).truncate(true);
+            #[cfg(unix)]
+            {
+                options.mode(0o600);
+            }
+            let mut file = options.open(&tmp_path).with_context(|| {
+                format!("creating temporary credential file {}", tmp_path.display())
+            })?;
+            serde_json::to_writer(&mut file, record)
+                .context("serialising fallback credential payload")?;
+            file.write_all(b"\n")
+                .context("finalising fallback credential payload")?;
+            file.flush()
+                .context("flushing fallback credential payload")?;
+            file.sync_all()
+                .context("syncing fallback credential payload")?;
+            set_file_private(&tmp_path)?;
+            fs::rename(&tmp_path, path).with_context(|| {
+                format!("installing fallback credential file {}", path.display())
+            })?;
+            Ok(())
+        })();
+
+        if write_result.is_err() {
+            let _ = fs::remove_file(&tmp_path);
+        }
+        write_result
+    }
+}
+
+impl SecureCredentialStore for FileCredentialStore {
+    fn load_tokens(&self, key: &WorkosCredentialKey) -> Result<Option<StoredWorkosTokens>> {
+        let path = self.credential_file_path(key);
+        let file = match fs::File::open(&path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("opening fallback credential file {}", path.display())
+                });
+            }
+        };
+        let record: FileCredentialRecord = serde_json::from_reader(file)
+            .with_context(|| format!("parsing fallback credential file {}", path.display()))?;
+        if record.version != FILE_CREDENTIAL_STORE_VERSION {
+            bail!(
+                "fallback credential file {} has unsupported version {}",
+                path.display(),
+                record.version
+            );
+        }
+        if record.service != key.service || record.account != key.account {
+            bail!(
+                "fallback credential file {} does not match requested credential key",
+                path.display()
+            );
+        }
+        Ok(Some(record.tokens))
+    }
+
+    fn save_tokens(&self, key: &WorkosCredentialKey, tokens: &StoredWorkosTokens) -> Result<()> {
+        let path = self.credential_file_path(key);
+        let record = FileCredentialRecord {
+            version: FILE_CREDENTIAL_STORE_VERSION,
+            service: key.service.clone(),
+            account: key.account.clone(),
+            tokens: tokens.clone(),
+        };
+        self.write_record_atomically(&path, &record)
+    }
+
+    fn delete_tokens(&self, key: &WorkosCredentialKey) -> Result<()> {
+        let path = self.credential_file_path(key);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err)
+                .with_context(|| format!("deleting fallback credential file {}", path.display())),
+        }
+    }
+}
+
+fn credential_key_hash(key: &WorkosCredentialKey) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(key.service.as_bytes());
+    hasher.update([0]);
+    hasher.update(key.account.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn set_dir_private(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("setting private permissions on {}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+fn set_file_private(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("setting private permissions on {}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+fn keyring_error(operation: &'static str, err: keyring::Error) -> anyhow::Error {
+    match err {
+        keyring::Error::PlatformFailure(_) | keyring::Error::NoStorageAccess(_) => {
+            SecureStoreUnavailable::new(operation, err.to_string()).into()
+        }
+        other => anyhow!(other).context(operation),
+    }
+}
+
+fn is_secure_store_unavailable(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.is::<SecureStoreUnavailable>())
 }
 
 pub(super) struct KeyringCredentialStore;
@@ -24,7 +241,7 @@ impl SecureCredentialStore for KeyringCredentialStore {
         let secret = match entry.get_secret() {
             Ok(secret) => secret,
             Err(keyring::Error::NoEntry) => return Ok(None),
-            Err(err) => return Err(err).context("reading secure credentials"),
+            Err(err) => return Err(keyring_error("reading secure credentials", err)),
         };
         serde_json::from_slice(&secret)
             .context("parsing secure credential payload")
@@ -38,7 +255,7 @@ impl SecureCredentialStore for KeyringCredentialStore {
             serde_json::to_vec(tokens).context("serialising secure credential payload")?;
         entry
             .set_secret(&payload)
-            .context("writing secure credentials")
+            .map_err(|err| keyring_error("writing secure credentials", err))
     }
 
     fn delete_tokens(&self, key: &WorkosCredentialKey) -> Result<()> {
@@ -46,13 +263,78 @@ impl SecureCredentialStore for KeyringCredentialStore {
             .context("opening secure credential entry")?;
         match entry.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(err) => Err(err).context("deleting secure credentials"),
+            Err(err) => Err(keyring_error("deleting secure credentials", err)),
         }
     }
 }
 
+pub(super) struct FallbackCredentialStore {
+    primary: Arc<dyn SecureCredentialStore>,
+    fallback: Arc<dyn SecureCredentialStore>,
+}
+
+impl FallbackCredentialStore {
+    pub(super) fn new(
+        primary: Arc<dyn SecureCredentialStore>,
+        fallback: Arc<dyn SecureCredentialStore>,
+    ) -> Self {
+        Self { primary, fallback }
+    }
+}
+
+impl SecureCredentialStore for FallbackCredentialStore {
+    fn load_tokens(&self, key: &WorkosCredentialKey) -> Result<Option<StoredWorkosTokens>> {
+        match self.primary.load_tokens(key) {
+            Ok(Some(tokens)) => Ok(Some(tokens)),
+            Ok(None) => self.fallback.load_tokens(key),
+            Err(err) if is_secure_store_unavailable(&err) => self.fallback.load_tokens(key),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn save_tokens(&self, key: &WorkosCredentialKey, tokens: &StoredWorkosTokens) -> Result<()> {
+        match self.primary.save_tokens(key, tokens) {
+            Ok(()) => {
+                self.fallback
+                    .delete_tokens(key)
+                    .context("clearing fallback credentials after secure credential write")?;
+                Ok(())
+            }
+            Err(err) if is_secure_store_unavailable(&err) => self
+                .fallback
+                .save_tokens(key, tokens)
+                .with_context(|| format!("falling back after secure store failure: {err:#}")),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn delete_tokens(&self, key: &WorkosCredentialKey) -> Result<()> {
+        let primary_result = self.primary.delete_tokens(key);
+        let fallback_result = self.fallback.delete_tokens(key);
+
+        if let Err(err) = primary_result
+            && !is_secure_store_unavailable(&err)
+        {
+            return Err(err);
+        }
+
+        fallback_result
+    }
+}
+
 pub(super) fn default_secure_store() -> Arc<dyn SecureCredentialStore> {
-    Arc::new(KeyringCredentialStore)
+    match FileCredentialStore::from_default_state_dir() {
+        Ok(fallback) => Arc::new(FallbackCredentialStore::new(
+            Arc::new(KeyringCredentialStore),
+            Arc::new(fallback),
+        )),
+        Err(err) => {
+            log::warn!(
+                "file credential fallback is unavailable; using platform secure store only: {err:#}"
+            );
+            Arc::new(KeyringCredentialStore)
+        }
+    }
 }
 
 pub(super) async fn load_tokens(

--- a/bitloops/src/daemon/auth/tests.rs
+++ b/bitloops/src/daemon/auth/tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use anyhow::{Result, anyhow};
 use axum::{
     Json, Router,
     extract::State,
@@ -13,7 +15,10 @@ use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use crate::test_support::process_state::enter_env_vars;
 use crate::utils::platform_dirs::{TestPlatformDirOverrides, with_test_platform_dir_overrides};
 
-use super::credentials::{MemoryCredentialStore, SecureCredentialStore};
+use super::credentials::{
+    FallbackCredentialStore, FileCredentialStore, MemoryCredentialStore, SecureCredentialStore,
+    SecureStoreUnavailable,
+};
 use super::session::{
     complete_workos_device_login_with_store, credential_key_for_client, load_workos_session_state,
     now_secs, prepare_workos_device_login_with_store_and_env, resolve_workos_auth_settings_with,
@@ -25,6 +30,9 @@ use super::types::{
     WORKOS_REFRESH_GRANT_TYPE, WORKOS_SESSION_STATE_VERSION,
 };
 use super::{WorkosDeviceLoginStart, WorkosLoginStart};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 #[derive(Clone)]
 struct AuthServerState {
@@ -76,6 +84,72 @@ fn localhost_bind_available(test_name: &str) -> bool {
     }
 }
 
+#[derive(Debug, Default)]
+struct AlwaysUnavailableStore;
+
+impl SecureCredentialStore for AlwaysUnavailableStore {
+    fn load_tokens(
+        &self,
+        _key: &super::types::WorkosCredentialKey,
+    ) -> Result<Option<StoredWorkosTokens>> {
+        Err(SecureStoreUnavailable::new(
+            "reading secure credentials",
+            "test secure store unavailable",
+        )
+        .into())
+    }
+
+    fn save_tokens(
+        &self,
+        _key: &super::types::WorkosCredentialKey,
+        _tokens: &StoredWorkosTokens,
+    ) -> Result<()> {
+        Err(SecureStoreUnavailable::new(
+            "writing secure credentials",
+            "test secure store unavailable",
+        )
+        .into())
+    }
+
+    fn delete_tokens(&self, _key: &super::types::WorkosCredentialKey) -> Result<()> {
+        Err(SecureStoreUnavailable::new(
+            "deleting secure credentials",
+            "test secure store unavailable",
+        )
+        .into())
+    }
+}
+
+#[derive(Debug, Default)]
+struct HardFailStore;
+
+impl SecureCredentialStore for HardFailStore {
+    fn load_tokens(
+        &self,
+        _key: &super::types::WorkosCredentialKey,
+    ) -> Result<Option<StoredWorkosTokens>> {
+        Err(anyhow!("hard secure store failure"))
+    }
+
+    fn save_tokens(
+        &self,
+        _key: &super::types::WorkosCredentialKey,
+        _tokens: &StoredWorkosTokens,
+    ) -> Result<()> {
+        Err(anyhow!("hard secure store failure"))
+    }
+
+    fn delete_tokens(&self, _key: &super::types::WorkosCredentialKey) -> Result<()> {
+        Err(anyhow!("hard secure store failure"))
+    }
+}
+
+fn fallback_file_store_at(root: PathBuf) -> Arc<FileCredentialStore> {
+    Arc::new(FileCredentialStore::new(
+        root.join("auth").join("credentials"),
+    ))
+}
+
 #[test]
 fn workos_auth_settings_default_to_built_in_values() {
     let _guard = enter_env_vars(&[(WORKOS_CLIENT_ID_ENV, None), (WORKOS_BASE_URL_ENV, None)]);
@@ -102,6 +176,130 @@ fn workos_auth_settings_allow_base_url_override() {
     });
     assert_eq!(settings.client_id, DEFAULT_WORKOS_CLIENT_ID);
     assert_eq!(settings.base_url, "https://workos.example.test");
+}
+
+#[test]
+fn file_credential_store_round_trips_tokens_with_safe_permissions() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let store = FileCredentialStore::new(temp.path().join("auth").join("credentials"));
+    let key = credential_key_for_client("client_file");
+    let tokens = StoredWorkosTokens {
+        access_token: "access-file".to_string(),
+        refresh_token: "refresh-file".to_string(),
+    };
+
+    store.save_tokens(&key, &tokens).expect("save file tokens");
+
+    let loaded = store
+        .load_tokens(&key)
+        .expect("load file tokens")
+        .expect("tokens should exist");
+    assert_eq!(loaded, tokens);
+
+    let path = store.credential_file_path_for_test(&key);
+    assert!(path.exists(), "fallback credential file should exist");
+
+    #[cfg(unix)]
+    {
+        let dir_mode = std::fs::metadata(path.parent().expect("credential dir"))
+            .expect("credential dir metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        let file_mode = std::fs::metadata(&path)
+            .expect("credential file metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o700);
+        assert_eq!(file_mode, 0o600);
+    }
+}
+
+#[test]
+fn fallback_credential_store_saves_to_file_when_secure_store_unavailable() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let fallback = fallback_file_store_at(temp.path().to_path_buf());
+    let store = FallbackCredentialStore::new(Arc::new(AlwaysUnavailableStore), fallback.clone());
+    let key = credential_key_for_client("client_fallback_save");
+    let tokens = StoredWorkosTokens {
+        access_token: "access-fallback".to_string(),
+        refresh_token: "refresh-fallback".to_string(),
+    };
+
+    store.save_tokens(&key, &tokens).expect("save via fallback");
+
+    assert_eq!(
+        fallback
+            .load_tokens(&key)
+            .expect("load fallback tokens")
+            .expect("fallback tokens should exist"),
+        tokens
+    );
+}
+
+#[test]
+fn fallback_credential_store_loads_file_tokens_when_secure_store_unavailable() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let fallback = fallback_file_store_at(temp.path().to_path_buf());
+    let store = FallbackCredentialStore::new(Arc::new(AlwaysUnavailableStore), fallback.clone());
+    let key = credential_key_for_client("client_fallback_load");
+    let tokens = StoredWorkosTokens {
+        access_token: "access-load".to_string(),
+        refresh_token: "refresh-load".to_string(),
+    };
+    fallback
+        .save_tokens(&key, &tokens)
+        .expect("seed fallback tokens");
+
+    let loaded = store
+        .load_tokens(&key)
+        .expect("load via composite")
+        .expect("tokens should load from fallback");
+
+    assert_eq!(loaded, tokens);
+}
+
+#[test]
+fn fallback_credential_store_deletes_file_tokens_when_secure_store_unavailable() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let fallback = fallback_file_store_at(temp.path().to_path_buf());
+    let store = FallbackCredentialStore::new(Arc::new(AlwaysUnavailableStore), fallback.clone());
+    let key = credential_key_for_client("client_fallback_delete");
+    let tokens = StoredWorkosTokens {
+        access_token: "access-delete".to_string(),
+        refresh_token: "refresh-delete".to_string(),
+    };
+    fallback
+        .save_tokens(&key, &tokens)
+        .expect("seed fallback tokens");
+
+    store.delete_tokens(&key).expect("delete via composite");
+
+    assert!(
+        fallback
+            .load_tokens(&key)
+            .expect("load fallback tokens")
+            .is_none()
+    );
+}
+
+#[test]
+fn fallback_credential_store_does_not_swallow_hard_secure_store_errors() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let fallback = fallback_file_store_at(temp.path().to_path_buf());
+    let store = FallbackCredentialStore::new(Arc::new(HardFailStore), fallback);
+    let key = credential_key_for_client("client_hard_fail");
+    let tokens = StoredWorkosTokens {
+        access_token: "access-hard".to_string(),
+        refresh_token: "refresh-hard".to_string(),
+    };
+
+    let err = store
+        .save_tokens(&key, &tokens)
+        .expect_err("hard primary failures should not fall back");
+
+    assert!(format!("{err:#}").contains("hard secure store failure"));
 }
 
 #[test]
@@ -154,6 +352,64 @@ fn workos_device_login_persists_session_to_runtime_store() {
                 .expect("load tokens")
                 .expect("tokens should exist");
             assert!(tokens.access_token.starts_with("ey"));
+
+            runtime.block_on(server.shutdown());
+        },
+    );
+}
+
+#[test]
+fn workos_device_login_falls_back_to_file_tokens_when_secure_store_unavailable() {
+    if !localhost_bind_available(
+        "workos_device_login_falls_back_to_file_tokens_when_secure_store_unavailable",
+    ) {
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("temp dir");
+    let fallback = fallback_file_store_at(temp.path().join("state").join("bitloops"));
+    let store = Arc::new(FallbackCredentialStore::new(
+        Arc::new(AlwaysUnavailableStore),
+        fallback.clone(),
+    ));
+
+    with_test_platform_dir_overrides(
+        TestPlatformDirOverrides {
+            config_root: Some(temp.path().join("config")),
+            data_root: Some(temp.path().join("data")),
+            cache_root: Some(temp.path().join("cache")),
+            state_root: Some(temp.path().join("state")),
+        },
+        || {
+            let runtime = tokio::runtime::Runtime::new().expect("create tokio runtime");
+            let server = runtime.block_on(start_test_auth_server());
+            let base_url = server.base_url.clone();
+            let start = WorkosDeviceLoginStart {
+                verification_url: format!("{base_url}/verify"),
+                verification_url_complete: Some(format!("{base_url}/verify?code=TEST-CODE")),
+                user_code: "TEST-CODE".to_string(),
+                expires_in_secs: 30,
+                poll_interval_secs: 0,
+                client_id: "client_fallback_login".to_string(),
+                base_url: base_url.clone(),
+                device_code: "device_123".to_string(),
+            };
+
+            let session = runtime
+                .block_on(complete_workos_device_login_with_store(
+                    &start,
+                    store.clone(),
+                ))
+                .expect("complete login with file fallback");
+
+            assert_eq!(session.user_email.as_deref(), Some("cli@example.com"));
+            assert!(load_workos_session_state().expect("load state").is_some());
+            assert!(
+                store
+                    .load_tokens(&credential_key_for_client("client_fallback_login"))
+                    .expect("load tokens")
+                    .is_some()
+            );
 
             runtime.block_on(server.shutdown());
         },


### PR DESCRIPTION
## Summary
- Add a file-backed fallback credential store for WorkOS tokens when the platform secure store is unavailable.
- Preserve hard failures from the secure store, while falling back only for unavailable/no-storage platform errors.
- Add focused tests for file permissions, fallback save/load/delete, hard-error behavior, and the WorkOS device-login persistence path.

## Root Cause
Headless Linux environments without a DBus Secret Service can make the keyring backend fail with a platform storage error. The CLI previously surfaced that error directly while writing secure credentials, aborting auth.

## Validation
- cargo fmt --all --manifest-path bitloops/Cargo.toml
- git diff --check
- focused auth nextest selection: passed
- cargo clippy --manifest-path bitloops/Cargo.toml --all-targets --no-default-features -- -D warnings
- cargo dev-loop
- cargo qat-develop-gate --parallel 5: left for follow-up per discussion after local/devcontainer target contamination made the first attempt invalid
