### PR TITLE
Fix role adjudication blocked jobs and fixes for context guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unconfigured architecture role adjudication no longer blocks enrichment work**: current-state role classification now skips queuing role-adjudication jobs when the `role_adjudication` structured-generation slot is not configured, maintenance marks already-queued unconfigured adjudication jobs as completed, and summary-refresh job claiming can page past blocked generic inference work to continue claimable context-guidance jobs.
+- **Context guidance distillation now keeps more useful evidence and reports dropped facts**: history guidance inputs include tool results, file paths, write/edit/bash evidence, and prioritized high-value transcript/tool evidence. Distillation now infers targets for multi-file facts, filters targetless or low-value guidance with validation/quality diagnostics, and stores richer tool excerpts as guidance sources.
+- **Repeated semantic follow-up syncs no longer leave init lanes blocked**: follow-up sync completion sequencing now advances for later follow-up sync tasks while remaining idempotent for already-recorded completions.
+
 ## [0.0.29] - 2026-05-19
 
 ### Added

--- a/bitloops/src/api/tests/support_graphql_knowledge.rs
+++ b/bitloops/src/api/tests/support_graphql_knowledge.rs
@@ -592,10 +592,13 @@ pub(super) fn seed_graphql_context_guidance_data(repo_root: &Path) {
         transcript_fragment: Some("Rejected std::any::type_name parsing.".to_string()),
         files_modified: vec!["src/target.ts".to_string()],
         tool_events: vec![GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
             tool_kind: Some("shell".to_string()),
             input_summary: Some("cargo nextest run --lib context_guidance".to_string()),
             output_summary: Some("nextest passed".to_string()),
             command: Some("cargo nextest run --lib context_guidance".to_string()),
+            file_path: None,
+            evidence_text: None,
         }],
     };
     let output = GuidanceDistillationOutput {

--- a/bitloops/src/capability_packs/architecture_graph/current_state/tests.rs
+++ b/bitloops/src/capability_packs/architecture_graph/current_state/tests.rs
@@ -165,6 +165,39 @@ impl crate::host::capability_host::gateways::CapabilityWorkplaneGateway
     }
 }
 
+struct ConfiguredRoleAdjudicationInferenceGateway;
+
+impl crate::host::inference::InferenceGateway for ConfiguredRoleAdjudicationInferenceGateway {
+    fn embeddings(
+        &self,
+        slot_name: &str,
+    ) -> anyhow::Result<std::sync::Arc<dyn crate::host::inference::EmbeddingService>> {
+        anyhow::bail!("embedding inference is not available for slot `{slot_name}`")
+    }
+
+    fn text_generation(
+        &self,
+        slot_name: &str,
+    ) -> anyhow::Result<std::sync::Arc<dyn crate::host::inference::TextGenerationService>> {
+        anyhow::bail!("text-generation inference is not available for slot `{slot_name}`")
+    }
+
+    fn structured_generation(
+        &self,
+        slot_name: &str,
+    ) -> anyhow::Result<std::sync::Arc<dyn crate::host::inference::StructuredGenerationService>>
+    {
+        anyhow::bail!(
+            "structured-generation inference should not execute in current-state tests for slot `{slot_name}`"
+        )
+    }
+
+    fn has_slot(&self, slot_name: &str) -> bool {
+        slot_name
+            == crate::capability_packs::architecture_graph::types::ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT
+    }
+}
+
 struct ArchitectureConsumerTestContext {
     _temp: tempfile::TempDir,
     sqlite_path: std::path::PathBuf,
@@ -177,6 +210,14 @@ async fn architecture_consumer_test_context(
     repo_id: &str,
 ) -> anyhow::Result<ArchitectureConsumerTestContext> {
     architecture_consumer_test_context_with_config(repo_id, json!({})).await
+}
+
+async fn architecture_consumer_test_context_with_role_adjudication_slot(
+    repo_id: &str,
+) -> anyhow::Result<ArchitectureConsumerTestContext> {
+    let mut test = architecture_consumer_test_context(repo_id).await?;
+    test.context.inference = std::sync::Arc::new(ConfiguredRoleAdjudicationInferenceGateway);
+    Ok(test)
 }
 
 async fn architecture_consumer_test_context_with_config(
@@ -707,10 +748,76 @@ async fn current_state_reconcile_skips_architecture_embedding_jobs_without_embed
 }
 
 #[tokio::test]
+async fn current_state_reconcile_skips_role_adjudication_when_slot_unconfigured()
+-> anyhow::Result<()> {
+    let repo_id = "repo-role-adjudication-unconfigured";
+    let test = architecture_consumer_test_context(repo_id).await?;
+    insert_current_file(&test.sqlite_path, repo_id, "src/api.rs", "rust")?;
+    upsert_test_role(test.storage.as_ref(), repo_id, "role-api-low-review", "api").await?;
+    upsert_path_suffix_rule(
+        test.storage.as_ref(),
+        repo_id,
+        "role-api-low-review",
+        "rule-api-low-review",
+        "api.rs",
+        0.6,
+    )
+    .await?;
+
+    let request = CurrentStateConsumerRequest {
+        run_id: Some("run".to_string()),
+        repo_id: repo_id.to_string(),
+        repo_root: test._temp.path().to_path_buf(),
+        active_branch: Some("main".to_string()),
+        head_commit_sha: Some("abc123".to_string()),
+        from_generation_seq_exclusive: 0,
+        to_generation_seq_inclusive: 41,
+        reconcile_mode: crate::host::capability_host::ReconcileMode::MergedDelta,
+        file_upserts: Vec::new(),
+        file_removals: Vec::new(),
+        affected_paths: vec!["src/api.rs".to_string()],
+        artefact_upserts: Vec::new(),
+        artefact_removals: Vec::new(),
+    };
+
+    let result = ArchitectureGraphRoleCurrentStateConsumer
+        .reconcile(&request, &test.context)
+        .await?;
+
+    assert!(
+        test.workplane.jobs().is_empty(),
+        "unconfigured role_adjudication must not enqueue workplane jobs"
+    );
+    let metrics = result.metrics.as_ref().expect("metrics should be present");
+    assert_eq!(
+        metrics
+            .get("role_adjudication_selected")
+            .and_then(serde_json::Value::as_u64),
+        Some(1)
+    );
+    assert_eq!(
+        metrics
+            .get("role_adjudication_enqueued")
+            .and_then(serde_json::Value::as_u64),
+        Some(0)
+    );
+    assert_eq!(
+        metrics
+            .get("role_adjudication_skipped_unconfigured")
+            .and_then(serde_json::Value::as_u64),
+        Some(1)
+    );
+    assert!(result.warnings.iter().any(|warning| {
+        warning.contains("role_adjudication") && warning.contains("not configured")
+    }));
+    Ok(())
+}
+
+#[tokio::test]
 async fn current_state_reconcile_enqueues_low_confidence_role_adjudication_job()
 -> anyhow::Result<()> {
     let repo_id = "repo-low-confidence-current-state";
-    let test = architecture_consumer_test_context(repo_id).await?;
+    let test = architecture_consumer_test_context_with_role_adjudication_slot(repo_id).await?;
     insert_current_file(&test.sqlite_path, repo_id, "src/api.rs", "rust")?;
     upsert_test_role(test.storage.as_ref(), repo_id, "role-api-low-review", "api").await?;
     upsert_path_suffix_rule(
@@ -847,7 +954,7 @@ async fn graph_snapshot_reconcile_does_not_enqueue_role_adjudication_jobs() -> a
 #[tokio::test]
 async fn current_state_reconcile_enqueues_conflict_role_adjudication_job() -> anyhow::Result<()> {
     let repo_id = "repo-conflict-current-state";
-    let test = architecture_consumer_test_context(repo_id).await?;
+    let test = architecture_consumer_test_context_with_role_adjudication_slot(repo_id).await?;
     insert_current_file(&test.sqlite_path, repo_id, "src/api.rs", "rust")?;
     upsert_test_role(test.storage.as_ref(), repo_id, "role-api-conflict", "api").await?;
     upsert_test_role(
@@ -931,7 +1038,7 @@ async fn current_state_reconcile_enqueues_conflict_role_adjudication_job() -> an
 async fn current_state_reconcile_enqueues_high_impact_role_adjudication_job() -> anyhow::Result<()>
 {
     let repo_id = "repo-high-impact-current-state";
-    let test = architecture_consumer_test_context(repo_id).await?;
+    let test = architecture_consumer_test_context_with_role_adjudication_slot(repo_id).await?;
     insert_current_file(&test.sqlite_path, repo_id, "src/main.rs", "rust")?;
 
     let request = CurrentStateConsumerRequest {
@@ -978,7 +1085,7 @@ async fn current_state_reconcile_enqueues_high_impact_role_adjudication_job() ->
 async fn current_state_reconcile_warns_when_role_adjudication_enqueue_fails() -> anyhow::Result<()>
 {
     let repo_id = "repo-role-enqueue-failure";
-    let test = architecture_consumer_test_context(repo_id).await?;
+    let test = architecture_consumer_test_context_with_role_adjudication_slot(repo_id).await?;
     insert_current_file(&test.sqlite_path, repo_id, "src/api.rs", "rust")?;
     upsert_test_role(
         test.storage.as_ref(),

--- a/bitloops/src/capability_packs/architecture_graph/roles/current_state_consumer.rs
+++ b/bitloops/src/capability_packs/architecture_graph/roles/current_state_consumer.rs
@@ -241,8 +241,9 @@ fn role_current_state_metrics(
         "role_adjudication_deduped": adjudication_metrics.deduped,
     });
     if role_adjudication_skipped_unconfigured > 0 {
-        metrics["role_adjudication_skipped_unconfigured"] =
-            serde_json::Value::Number(role_adjudication_skipped_unconfigured.into());
+        metrics["role_adjudication_skipped_unconfigured"] = serde_json::Value::Number(
+            serde_json::Number::from(role_adjudication_skipped_unconfigured as u64),
+        );
     }
     if architecture_embedding_enqueue_failed {
         metrics["architecture_embedding_enqueue_failed"] = serde_json::Value::Bool(true);

--- a/bitloops/src/capability_packs/architecture_graph/roles/current_state_consumer.rs
+++ b/bitloops/src/capability_packs/architecture_graph/roles/current_state_consumer.rs
@@ -7,7 +7,8 @@ use crate::capability_packs::architecture_graph::roles::{
     RoleAdjudicationEnqueueMetrics, default_queue_store, enqueue_adjudication_requests,
 };
 use crate::capability_packs::architecture_graph::types::{
-    ARCHITECTURE_GRAPH_CAPABILITY_ID, ARCHITECTURE_GRAPH_ROLE_CURRENT_STATE_CONSUMER_ID,
+    ARCHITECTURE_GRAPH_CAPABILITY_ID, ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT,
+    ARCHITECTURE_GRAPH_ROLE_CURRENT_STATE_CONSUMER_ID,
 };
 use crate::capability_packs::semantic_clones::{
     runtime_config::resolve_semantic_clones_config,
@@ -91,23 +92,41 @@ impl CurrentStateConsumer for ArchitectureGraphRoleCurrentStateConsumer {
                     ArchitectureEmbeddingEnqueueMetrics::default()
                 }
             };
+            let role_adjudication_configured = context
+                .inference
+                .has_slot(ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT);
             let mut role_adjudication_enqueue_failed = false;
-            let adjudication_metrics = match enqueue_adjudication_requests(
-                &outcome.adjudication_requests,
-                context.workplane.as_ref(),
-                default_queue_store().as_ref(),
-            ) {
-                Ok(metrics) => metrics,
-                Err(err) => {
-                    warnings.push(format!(
-                        "Architecture role adjudication enqueue failed: {err:#}"
-                    ));
-                    role_adjudication_enqueue_failed = true;
-                    RoleAdjudicationEnqueueMetrics {
-                        selected: adjudication_request_count,
-                        enqueued: 0,
-                        deduped: 0,
+            let mut role_adjudication_skipped_unconfigured = 0usize;
+            let adjudication_metrics = if role_adjudication_configured {
+                match enqueue_adjudication_requests(
+                    &outcome.adjudication_requests,
+                    context.workplane.as_ref(),
+                    default_queue_store().as_ref(),
+                ) {
+                    Ok(metrics) => metrics,
+                    Err(err) => {
+                        warnings.push(format!(
+                            "Architecture role adjudication enqueue failed: {err:#}"
+                        ));
+                        role_adjudication_enqueue_failed = true;
+                        RoleAdjudicationEnqueueMetrics {
+                            selected: adjudication_request_count,
+                            enqueued: 0,
+                            deduped: 0,
+                        }
                     }
+                }
+            } else {
+                role_adjudication_skipped_unconfigured = adjudication_request_count;
+                if adjudication_request_count > 0 {
+                    warnings.push(format!(
+                        "Architecture role adjudication skipped because inference slot `{ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT}` is not configured"
+                    ));
+                }
+                RoleAdjudicationEnqueueMetrics {
+                    selected: adjudication_request_count,
+                    enqueued: 0,
+                    deduped: 0,
                 }
             };
 
@@ -118,6 +137,7 @@ impl CurrentStateConsumer for ArchitectureGraphRoleCurrentStateConsumer {
                     role_metrics,
                     &adjudication_metrics,
                     role_adjudication_enqueue_failed,
+                    role_adjudication_skipped_unconfigured,
                     &architecture_embedding_metrics,
                     architecture_embedding_enqueue_failed,
                 )),
@@ -207,6 +227,7 @@ fn role_current_state_metrics(
     role_metrics: serde_json::Value,
     adjudication_metrics: &RoleAdjudicationEnqueueMetrics,
     role_adjudication_enqueue_failed: bool,
+    role_adjudication_skipped_unconfigured: usize,
     architecture_embedding_metrics: &ArchitectureEmbeddingEnqueueMetrics,
     architecture_embedding_enqueue_failed: bool,
 ) -> serde_json::Value {
@@ -219,6 +240,10 @@ fn role_current_state_metrics(
         "role_adjudication_enqueued": adjudication_metrics.enqueued,
         "role_adjudication_deduped": adjudication_metrics.deduped,
     });
+    if role_adjudication_skipped_unconfigured > 0 {
+        metrics["role_adjudication_skipped_unconfigured"] =
+            serde_json::Value::Number(role_adjudication_skipped_unconfigured.into());
+    }
     if architecture_embedding_enqueue_failed {
         metrics["architecture_embedding_enqueue_failed"] = serde_json::Value::Bool(true);
     }

--- a/bitloops/src/capability_packs/context_guidance/distillation.rs
+++ b/bitloops/src/capability_packs/context_guidance/distillation.rs
@@ -8,7 +8,9 @@ use super::evidence::{
     GuidanceEvidenceInput, GuidanceEvidenceSource, GuidanceEvidenceToolEvent, evidence_input_body,
     evidence_input_title, evidence_target_symbols, knowledge_source_label,
 };
-use super::types::{GuidanceDistillationOutput, trim_guidance_distillation_output};
+use super::types::{
+    GuidanceDistillationOutput, GuidanceFactCategory, trim_guidance_distillation_output,
+};
 
 pub struct GuidanceDistillationInput {
     pub checkpoint_id: Option<String>,
@@ -23,11 +25,51 @@ pub struct GuidanceDistillationInput {
     pub tool_events: Vec<GuidanceToolEvidence>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GuidanceToolEvidence {
+    pub event_type: Option<String>,
     pub tool_kind: Option<String>,
     pub input_summary: Option<String>,
     pub output_summary: Option<String>,
     pub command: Option<String>,
+    pub file_path: Option<String>,
+    pub evidence_text: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DistilledGuidance {
+    pub output: GuidanceDistillationOutput,
+    pub report: GuidanceDistillationReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GuidanceDistillationReport {
+    pub raw_response_chars: usize,
+    pub raw_fact_count: usize,
+    pub validation_input_fact_count: usize,
+    pub validation_kept_fact_count: usize,
+    pub validation_discards: Vec<GuidanceValidationDiscard>,
+    pub quality_input_fact_count: usize,
+    pub quality_kept_fact_count: usize,
+    pub quality_discards: Vec<GuidanceQualityDiscardSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuidanceValidationDiscard {
+    pub kind: String,
+    pub reason: GuidanceValidationDiscardReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuidanceValidationDiscardReason {
+    MissingTargetWithoutDefault,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuidanceQualityDiscardSummary {
+    pub kind: String,
+    pub category: GuidanceFactCategory,
+    pub reason: String,
 }
 
 pub struct KnowledgeGuidanceDistillationInput {
@@ -62,6 +104,9 @@ The guidanceFacts field must be a flat array of fact objects.
 Do not nest facts under category keys such as decision, verification, or doNotRepeat.
 Do not return summary.context or guidanceFacts.decision objects.
 Only emit guidance that will help a future coding session. Preserve durable decisions, constraints, risks, reusable patterns, and specific verification requirements. If no durable guidance is supported by evidence, return "guidanceFacts": [].
+Durable decisions in summary.decisions must also be emitted as guidanceFacts with category DECISION or CONSTRAINT.
+Every guidanceFact must include appliesTo.paths or appliesTo.symbols; targetless facts are discarded.
+For multi-file refactors, target the production files that own the decision. Use tests as evidence unless the guidance is specifically about test contracts.
 Do not emit status updates, completed-work summaries, code-size metrics, line-count reductions, generic "tests passed" facts, generic "ensure quality" advice, or "the agent edited this file" context.
 VERIFICATION facts must name a reusable command/check and explain why a future session should run it.
 CONTEXT facts must describe a durable codebase boundary, invariant, dependency, or ownership fact."#;
@@ -90,50 +135,14 @@ pub fn build_guidance_distillation_prompt(input: &GuidanceDistillationInput) -> 
         }
     };
     let files_modified = bounded_files_modified(&evidence.target_paths);
-    let tool_events = evidence
-        .tool_events
-        .iter()
-        .take(MAX_TOOL_EVENTS)
-        .map(|event| {
-            format!(
-                "- kind: {}\n  command: {}\n  input: {}\n  output: {}",
-                bounded_text(
-                    event.tool_kind.as_deref().unwrap_or(""),
-                    MAX_TOOL_COMMAND_CHARS
-                ),
-                bounded_text(
-                    event.command.as_deref().unwrap_or(""),
-                    MAX_TOOL_COMMAND_CHARS
-                ),
-                bounded_text(
-                    event.input_summary.as_deref().unwrap_or(""),
-                    MAX_TOOL_INPUT_CHARS
-                ),
-                bounded_text(
-                    event.output_summary.as_deref().unwrap_or(""),
-                    MAX_TOOL_OUTPUT_CHARS
-                )
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let omitted_tool_events = evidence.tool_events.len().saturating_sub(MAX_TOOL_EVENTS);
-    let tool_events = if omitted_tool_events == 0 {
-        tool_events
-    } else if tool_events.is_empty() {
-        format!("- omitted_tool_events: {omitted_tool_events}")
-    } else {
-        format!("{tool_events}\n- omitted_tool_events: {omitted_tool_events}")
-    };
+    let tool_events = render_high_value_tool_events(&evidence.tool_events);
     let title = evidence_input_title(&evidence);
     let body = evidence_input_body(&evidence);
     let explicit_symbols = bounded_files_modified(evidence_target_symbols(&evidence));
     let knowledge_label = knowledge_source_label(&evidence).unwrap_or_default();
     let prompt = bounded_text(evidence.prompt.as_deref().unwrap_or(""), MAX_PROMPT_CHARS);
-    let transcript = bounded_text(
-        evidence.transcript_fragment.as_deref().unwrap_or(""),
-        MAX_TRANSCRIPT_CHARS,
-    );
+    let transcript =
+        bounded_history_transcript(evidence.transcript_fragment.as_deref().unwrap_or(""));
     let transcript = if body.is_empty() {
         transcript
     } else if transcript.is_empty() {
@@ -151,6 +160,8 @@ pub fn build_guidance_distillation_prompt(input: &GuidanceDistillationInput) -> 
         "{schema}\n\
 Emit guidance only when supported by supplied evidence from the prompt, transcript, modified paths, or tool events. \
 Prefer decisions, constraints, risks, rejected approaches, and do-not-repeat lessons. \
+When the user selected implementation decisions, emit those decisions as guidanceFacts and cite the decision evidence. \
+For Write/Edit evidence, prefer facts about the durable design decision over facts that merely say a file changed. \
 Use concise evidenceExcerpt text copied or tightly paraphrased from the history. \
 Use appliesTo.paths only from modified or explicitly referenced paths. \
 Use appliesTo.symbols only when symbols are explicitly named. \
@@ -263,6 +274,8 @@ fn history_evidence_input(input: &GuidanceDistillationInput) -> GuidanceEvidence
                 input_summary: event.input_summary.clone(),
                 output_summary: event.output_summary.clone(),
                 command: event.command.clone(),
+                file_path: event.file_path.clone(),
+                evidence_text: event.evidence_text.clone(),
             })
             .collect(),
     }
@@ -288,6 +301,158 @@ fn knowledge_evidence_input(input: &KnowledgeGuidanceDistillationInput) -> Guida
         target_symbols: input.target_symbols.clone(),
         tool_events: Vec::new(),
     }
+}
+
+fn render_high_value_tool_events(events: &[GuidanceEvidenceToolEvent]) -> String {
+    let mut indexed = events.iter().enumerate().collect::<Vec<_>>();
+    indexed.sort_by(|(left_index, left), (right_index, right)| {
+        tool_event_score(right)
+            .cmp(&tool_event_score(left))
+            .then_with(|| left_index.cmp(right_index))
+    });
+
+    let selected = indexed
+        .into_iter()
+        .take(MAX_TOOL_EVENTS)
+        .map(|(_, event)| render_tool_event(event))
+        .collect::<Vec<_>>();
+    let omitted_tool_events = events.len().saturating_sub(selected.len());
+
+    match (selected.is_empty(), omitted_tool_events) {
+        (true, 0) => String::new(),
+        (true, omitted) => format!("- omitted_tool_events: {omitted}"),
+        (false, 0) => format!("high_value_tool_events:\n{}", selected.join("\n")),
+        (false, omitted) => format!(
+            "high_value_tool_events:\n{}\n- omitted_tool_events: {omitted}",
+            selected.join("\n")
+        ),
+    }
+}
+
+fn bounded_history_transcript(value: &str) -> String {
+    let bounded = bounded_text(value, MAX_TRANSCRIPT_CHARS);
+    let high_value_lines = high_value_transcript_lines(value);
+    let missing_high_value_lines = high_value_lines
+        .into_iter()
+        .filter(|line| !bounded.contains(line))
+        .collect::<Vec<_>>();
+    if missing_high_value_lines.is_empty() {
+        return bounded;
+    }
+    let high_value_block = missing_high_value_lines.join("\n");
+    if bounded.is_empty() {
+        return bounded_text(high_value_block.as_str(), MAX_TRANSCRIPT_CHARS);
+    }
+    bounded_text(
+        format!("high_value_transcript_lines:\n{high_value_block}\n\n{bounded}").as_str(),
+        MAX_TRANSCRIPT_CHARS,
+    )
+}
+
+fn high_value_transcript_lines(value: &str) -> Vec<String> {
+    value
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            let text = line.to_ascii_lowercase();
+            contains_any(
+                text.as_str(),
+                &[
+                    "decisions locked",
+                    "questions have been answered",
+                    "user chose",
+                    "decision:",
+                ],
+            )
+        })
+        .take(12)
+        .map(str::to_string)
+        .collect()
+}
+
+fn render_tool_event(event: &GuidanceEvidenceToolEvent) -> String {
+    format!(
+        "- kind: {}\n  command: {}\n  input: {}\n  output: {}\n  file: {}\n  evidence: {}",
+        bounded_text(
+            event.tool_kind.as_deref().unwrap_or(""),
+            MAX_TOOL_COMMAND_CHARS
+        ),
+        bounded_text(
+            event.command.as_deref().unwrap_or(""),
+            MAX_TOOL_COMMAND_CHARS
+        ),
+        bounded_text(
+            event.input_summary.as_deref().unwrap_or(""),
+            MAX_TOOL_INPUT_CHARS
+        ),
+        bounded_text(
+            event.output_summary.as_deref().unwrap_or(""),
+            MAX_TOOL_OUTPUT_CHARS
+        ),
+        bounded_text(
+            event.file_path.as_deref().unwrap_or(""),
+            MAX_FILE_PATH_CHARS
+        ),
+        bounded_text(
+            event.evidence_text.as_deref().unwrap_or(""),
+            MAX_TOOL_OUTPUT_CHARS
+        ),
+    )
+}
+
+fn tool_event_score(event: &GuidanceEvidenceToolEvent) -> i32 {
+    let text = format!(
+        "{}\n{}\n{}\n{}\n{}",
+        event.tool_kind.as_deref().unwrap_or(""),
+        event.command.as_deref().unwrap_or(""),
+        event.input_summary.as_deref().unwrap_or(""),
+        event.output_summary.as_deref().unwrap_or(""),
+        event.evidence_text.as_deref().unwrap_or("")
+    )
+    .to_ascii_lowercase();
+
+    let mut score = 0;
+    if contains_any(
+        text.as_str(),
+        &[
+            "askuserquestion",
+            "questions have been answered",
+            "decisions locked",
+        ],
+    ) {
+        score += 100;
+    }
+    if contains_any(
+        text.as_str(),
+        &["write", "edit", "multiedit", "structuredpatch", "content:"],
+    ) {
+        score += 80;
+    }
+    if contains_any(
+        text.as_str(),
+        &[
+            "error[e",
+            "failed",
+            "doesn't implement",
+            "cannot be formatted",
+        ],
+    ) {
+        score += 70;
+    }
+    if contains_any(
+        text.as_str(),
+        &["cargo ", "nextest", "test result", "passed"],
+    ) {
+        score += 60;
+    }
+    if contains_any(text.as_str(), &["src/", "tests/"]) {
+        score += 20;
+    }
+    score
+}
+
+fn contains_any(value: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| value.contains(needle))
 }
 
 fn bounded_files_modified(paths: &[String]) -> String {
@@ -337,26 +502,30 @@ pub fn parse_guidance_distillation_output_for_input(
     raw: &str,
     input: &GuidanceDistillationInput,
 ) -> Result<GuidanceDistillationOutput> {
-    let default_path = input
+    Ok(parse_guidance_distillation_output_for_input_with_report(raw, input)?.output)
+}
+
+pub fn parse_guidance_distillation_output_for_input_with_report(
+    raw: &str,
+    input: &GuidanceDistillationInput,
+) -> Result<DistilledGuidance> {
+    let candidate_paths = candidate_paths_for_input(input);
+    parse_guidance_distillation_output_with_default_targets_and_report(
+        raw,
+        &candidate_paths,
+        &[],
+        false,
+    )
+}
+
+fn candidate_paths_for_input(input: &GuidanceDistillationInput) -> Vec<String> {
+    input
         .files_modified
         .iter()
         .map(|path| path.trim())
         .filter(|path| !path.is_empty())
-        .collect::<Vec<_>>();
-    let default_path = if default_path.len() == 1 {
-        Some(default_path[0])
-    } else {
-        None
-    };
-    match default_path {
-        Some(default_path) => parse_guidance_distillation_output_with_default_targets(
-            raw,
-            &[default_path.to_string()],
-            &[],
-            false,
-        ),
-        None => parse_guidance_distillation_output_with_default_targets(raw, &[], &[], false),
-    }
+        .map(str::to_string)
+        .collect()
 }
 
 fn parse_guidance_distillation_output_with_default_targets(
@@ -365,6 +534,23 @@ fn parse_guidance_distillation_output_with_default_targets(
     default_symbols: &[String],
     constrain_to_defaults: bool,
 ) -> Result<GuidanceDistillationOutput> {
+    Ok(
+        parse_guidance_distillation_output_with_default_targets_and_report(
+            raw,
+            default_paths,
+            default_symbols,
+            constrain_to_defaults,
+        )?
+        .output,
+    )
+}
+
+fn parse_guidance_distillation_output_with_default_targets_and_report(
+    raw: &str,
+    default_paths: &[String],
+    default_symbols: &[String],
+    constrain_to_defaults: bool,
+) -> Result<DistilledGuidance> {
     let payload = extract_json_object_from_text(raw)
         .ok_or_else(|| anyhow!("guidance distillation output did not contain a JSON object"))?;
     let parsed = match serde_json::from_str::<GuidanceDistillationOutput>(&payload) {
@@ -375,13 +561,40 @@ fn parse_guidance_distillation_output_with_default_targets(
             )
         })?,
     };
-    let validated = validate_guidance_distillation_output(
+    let raw_fact_count = parsed.guidance_facts.len();
+    let validation_input_fact_count = raw_fact_count;
+    let (validated, validation_discards) = validate_guidance_distillation_output_with_report(
         trim_guidance_distillation_output(parsed),
         default_paths,
         default_symbols,
         constrain_to_defaults,
     )?;
-    Ok(super::quality::filter_value_guidance_output(validated))
+    let validation_kept_fact_count = validated.guidance_facts.len();
+    let (filtered, quality_report) =
+        super::quality::filter_value_guidance_output_with_report(validated);
+    let quality_discards = quality_report
+        .discarded
+        .into_iter()
+        .map(|discard| GuidanceQualityDiscardSummary {
+            kind: discard.kind,
+            category: discard.category,
+            reason: format!("{:?}", discard.reason),
+        })
+        .collect();
+
+    Ok(DistilledGuidance {
+        output: filtered,
+        report: GuidanceDistillationReport {
+            raw_response_chars: raw.chars().count(),
+            raw_fact_count,
+            validation_input_fact_count,
+            validation_kept_fact_count,
+            validation_discards,
+            quality_input_fact_count: quality_report.input_fact_count,
+            quality_kept_fact_count: quality_report.kept_fact_count,
+            quality_discards,
+        },
+    })
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -619,13 +832,14 @@ fn summary_subject(file: Option<String>, function: Option<String>) -> Option<Str
     }
 }
 
-fn validate_guidance_distillation_output(
+fn validate_guidance_distillation_output_with_report(
     mut output: GuidanceDistillationOutput,
     default_paths: &[String],
     default_symbols: &[String],
     constrain_to_defaults: bool,
-) -> Result<GuidanceDistillationOutput> {
+) -> Result<(GuidanceDistillationOutput, Vec<GuidanceValidationDiscard>)> {
     let mut accepted_facts = Vec::new();
+    let mut discards = Vec::new();
     let default_path_set = default_paths
         .iter()
         .map(String::as_str)
@@ -645,13 +859,24 @@ fn validate_guidance_distillation_output(
             bail!("guidance distillation fact evidenceExcerpt must be non-empty");
         }
         if fact.applies_to.paths.is_empty() && fact.applies_to.symbols.is_empty() {
-            if default_paths.is_empty() && default_symbols.is_empty() {
-                continue;
-            } else {
+            let inferred_paths = infer_paths_from_fact_text(&fact, default_paths);
+            if inferred_paths.is_empty() && default_paths.len() == 1 && default_symbols.is_empty() {
                 fact.applies_to.paths.extend(default_paths.iter().cloned());
+            } else if inferred_paths.is_empty()
+                && default_symbols.len() == 1
+                && default_paths.is_empty()
+            {
                 fact.applies_to
                     .symbols
                     .extend(default_symbols.iter().cloned());
+            } else if inferred_paths.is_empty() {
+                discards.push(GuidanceValidationDiscard {
+                    kind: fact.kind,
+                    reason: GuidanceValidationDiscardReason::MissingTargetWithoutDefault,
+                });
+                continue;
+            } else {
+                fact.applies_to.paths = inferred_paths;
             }
         } else if constrain_to_defaults {
             fact.applies_to
@@ -670,7 +895,23 @@ fn validate_guidance_distillation_output(
         accepted_facts.push(fact);
     }
     output.guidance_facts = accepted_facts;
-    Ok(output)
+    Ok((output, discards))
+}
+
+fn infer_paths_from_fact_text(
+    fact: &super::types::GuidanceFactDraft,
+    candidate_paths: &[String],
+) -> Vec<String> {
+    let text = format!(
+        "{}\n{}",
+        fact.guidance.as_str(),
+        fact.evidence_excerpt.as_str()
+    );
+    candidate_paths
+        .iter()
+        .filter(|path| text.contains(path.as_str()))
+        .cloned()
+        .collect()
 }
 
 fn extract_json_object_from_text(content: &str) -> Option<String> {
@@ -696,6 +937,13 @@ impl GuidanceDistiller {
     }
 
     pub fn distill(&self, input: &GuidanceDistillationInput) -> Result<GuidanceDistillationOutput> {
+        Ok(self.distill_with_report(input)?.output)
+    }
+
+    pub fn distill_with_report(
+        &self,
+        input: &GuidanceDistillationInput,
+    ) -> Result<DistilledGuidance> {
         let raw = self
             .service
             .complete(
@@ -703,7 +951,7 @@ impl GuidanceDistiller {
                 &build_guidance_distillation_prompt(input),
             )
             .context("guidance distillation text generation failed")?;
-        parse_guidance_distillation_output_for_input(&raw, input)
+        parse_guidance_distillation_output_for_input_with_report(&raw, input)
             .context("guidance distillation model output was invalid")
     }
 

--- a/bitloops/src/capability_packs/context_guidance/distillation_tests.rs
+++ b/bitloops/src/capability_packs/context_guidance/distillation_tests.rs
@@ -6,6 +6,7 @@ use super::{
     GuidanceDistillationInput, GuidanceDistiller, GuidanceToolEvidence,
     build_guidance_distillation_prompt, parse_guidance_distillation_output,
     parse_guidance_distillation_output_for_input,
+    parse_guidance_distillation_output_for_input_with_report,
 };
 use crate::capability_packs::context_guidance::types::{
     GuidanceFactCategory, GuidanceFactConfidence,
@@ -49,10 +50,13 @@ fn input_with_one_modified_file() -> GuidanceDistillationInput {
         transcript_fragment: Some("Replaced fragile keyword-name parsing.".to_string()),
         files_modified: vec!["axum-macros/src/attr_parsing.rs".to_string()],
         tool_events: vec![GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
             tool_kind: Some("shell".to_string()),
             input_summary: Some("cargo nextest run --lib artefact_selection".to_string()),
             output_summary: Some("passed".to_string()),
             command: Some("cargo nextest run --lib artefact_selection".to_string()),
+            file_path: None,
+            evidence_text: None,
         }],
     }
 }
@@ -348,6 +352,7 @@ fn parse_guidance_distillation_output_drops_low_value_facts() -> Result<()> {
   },
   "confidence": "HIGH"
 }
+
   ]
 }"#;
 
@@ -366,6 +371,119 @@ fn parse_guidance_distillation_output_drops_low_value_facts() -> Result<()> {
 }
 
 #[test]
+fn parse_guidance_distillation_output_for_input_reports_target_and_quality_drops() -> Result<()> {
+    let mut input = input_with_one_modified_file();
+    input.files_modified = vec![
+        "src/api/response.rs".to_string(),
+        "src/api/users_handler.rs".to_string(),
+    ];
+
+    let raw = r#"{
+      "summary": {
+        "intent": "Refactor API responses.",
+        "outcome": "Introduced typed response values.",
+        "decisions": ["Use HttpResponse instead of raw strings."],
+        "rejectedApproaches": [],
+        "patterns": [],
+        "verification": ["4 tests passed."],
+        "openItems": []
+      },
+      "guidanceFacts": [
+        {
+          "category": "DECISION",
+          "kind": "typed_response_without_target",
+          "guidance": "Keep API handlers returning typed response values instead of raw strings.",
+          "evidenceExcerpt": "User chose HttpResponse and no Display compatibility shim.",
+          "appliesTo": { "paths": [], "symbols": [] },
+          "confidence": "HIGH"
+        },
+        {
+          "category": "VERIFICATION",
+          "kind": "generic_tests_passed",
+          "guidance": "The tests passed after the refactor completed.",
+          "evidenceExcerpt": "4 tests passed after the work completed.",
+          "appliesTo": { "paths": ["tests/api_contract_test.rs"], "symbols": [] },
+          "confidence": "MEDIUM"
+        },
+        {
+          "category": "DECISION",
+          "kind": "typed_response_targeted",
+          "guidance": "Keep API handlers returning HttpResponse so status and body remain explicit.",
+          "evidenceExcerpt": "The implementation introduced src/api/response.rs and updated handlers to return HttpResponse.",
+          "appliesTo": { "paths": ["src/api/response.rs"], "symbols": [] },
+          "confidence": "HIGH"
+        }
+      ]
+    }"#;
+
+    let distilled = parse_guidance_distillation_output_for_input_with_report(raw, &input)?;
+
+    assert_eq!(distilled.report.raw_fact_count, 3);
+    assert_eq!(distilled.report.validation_input_fact_count, 3);
+    assert_eq!(distilled.report.validation_kept_fact_count, 2);
+    assert_eq!(distilled.report.quality_input_fact_count, 2);
+    assert_eq!(distilled.report.quality_kept_fact_count, 1);
+    assert_eq!(distilled.output.guidance_facts.len(), 1);
+    assert_eq!(
+        distilled.output.guidance_facts[0].kind,
+        "typed_response_targeted"
+    );
+    assert_eq!(
+        distilled.report.validation_discards[0].kind,
+        "typed_response_without_target"
+    );
+    assert_eq!(
+        distilled.report.quality_discards[0].kind,
+        "generic_tests_passed"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn parse_guidance_distillation_output_infers_targets_from_fact_text_for_multifile_turn()
+-> Result<()> {
+    let mut input = input_with_one_modified_file();
+    input.files_modified = vec![
+        "src/api/response.rs".to_string(),
+        "src/api/users_handler.rs".to_string(),
+        "tests/api_contract_test.rs".to_string(),
+    ];
+
+    let raw = r#"{
+      "summary": {
+        "intent": "Refactor API responses.",
+        "outcome": "Introduced typed response values.",
+        "decisions": ["Use HttpResponse instead of raw strings."],
+        "rejectedApproaches": [],
+        "patterns": [],
+        "verification": [],
+        "openItems": []
+      },
+      "guidanceFacts": [
+        {
+          "category": "DECISION",
+          "kind": "typed_http_response",
+          "guidance": "Keep API handlers returning HttpResponse so status and body stay explicit in src/api/response.rs.",
+          "evidenceExcerpt": "The implementation introduced src/api/response.rs and updated handlers to return HttpResponse.",
+          "appliesTo": { "paths": [], "symbols": [] },
+          "confidence": "HIGH"
+        }
+      ]
+    }"#;
+
+    let parsed = parse_guidance_distillation_output_for_input(raw, &input)?;
+
+    assert_eq!(parsed.guidance_facts.len(), 1);
+    assert_eq!(
+        parsed.guidance_facts[0].applies_to.paths,
+        vec!["src/api/response.rs"]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn build_guidance_distillation_prompt_bounds_large_history_input() {
     let mut input = input_with_one_modified_file();
     input.prompt = Some("large prompt ".repeat(1_000));
@@ -375,10 +493,13 @@ fn build_guidance_distillation_prompt_bounds_large_history_input() {
         .collect();
     input.tool_events = (0..20)
         .map(|index| GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
             tool_kind: Some("shell".to_string()),
             input_summary: Some(format!("input {index} {}", "x".repeat(5_000))),
             output_summary: Some(format!("output {index} {}", "y".repeat(5_000))),
             command: Some(format!("cargo check {index} {}", "z".repeat(5_000))),
+            file_path: None,
+            evidence_text: None,
         })
         .collect();
 
@@ -389,6 +510,114 @@ fn build_guidance_distillation_prompt_bounds_large_history_input() {
     assert!(prompt.contains("omitted_tool_events: 14"));
     assert!(prompt.contains("omitted_paths: 30"));
     assert!(prompt.contains("src/generated/path_0.rs"));
+}
+
+#[test]
+fn build_guidance_distillation_prompt_prioritizes_write_edit_and_test_evidence() {
+    let mut input = input_with_one_modified_file();
+    input.prompt = Some("Do it".to_string());
+    input.files_modified = vec![
+        "src/api/response.rs".to_string(),
+        "src/api/routes.rs".to_string(),
+        "src/api/users_handler.rs".to_string(),
+        "tests/api_contract_test.rs".to_string(),
+    ];
+    input.transcript_fragment = Some(format!(
+        "{}\nDecisions locked in: use HttpResponse, no Display shim, typed routes.\n{}",
+        "exploration noise ".repeat(1_000),
+        "more noise ".repeat(1_000)
+    ));
+    input.tool_events = vec![
+        GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
+            tool_kind: Some("Read".to_string()),
+            input_summary: Some("src/unrelated_0.rs".to_string()),
+            output_summary: None,
+            command: None,
+            file_path: Some("src/unrelated_0.rs".to_string()),
+            evidence_text: None,
+        },
+        GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
+            tool_kind: Some("Read".to_string()),
+            input_summary: Some("src/unrelated_1.rs".to_string()),
+            output_summary: None,
+            command: None,
+            file_path: Some("src/unrelated_1.rs".to_string()),
+            evidence_text: None,
+        },
+        GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
+            tool_kind: Some("Read".to_string()),
+            input_summary: Some("src/unrelated_2.rs".to_string()),
+            output_summary: None,
+            command: None,
+            file_path: Some("src/unrelated_2.rs".to_string()),
+            evidence_text: None,
+        },
+        GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
+            tool_kind: Some("Write".to_string()),
+            input_summary: Some("src/api/response.rs".to_string()),
+            output_summary: None,
+            command: None,
+            file_path: Some("src/api/response.rs".to_string()),
+            evidence_text: Some(
+                "create src/api/response.rs with HttpResponse { status: u16, body: ResponseBody } and ResponseBody::UserCreated".to_string(),
+            ),
+        },
+        GuidanceToolEvidence {
+            event_type: Some("tool_result_observed".to_string()),
+            tool_kind: Some("Bash".to_string()),
+            input_summary: Some("cargo test --quiet".to_string()),
+            output_summary: Some(
+                "error[E0277]: HttpResponse doesn't implement std::fmt::Display in src/main.rs"
+                    .to_string(),
+            ),
+            command: Some("cargo test --quiet".to_string()),
+            file_path: None,
+            evidence_text: Some(
+                "cargo test failed because main.rs still formatted HttpResponse with Display"
+                    .to_string(),
+            ),
+        },
+        GuidanceToolEvidence {
+            event_type: Some("tool_result_observed".to_string()),
+            tool_kind: Some("Bash".to_string()),
+            input_summary: Some("cargo test --quiet".to_string()),
+            output_summary: Some("running 4 tests .... test result: ok. 4 passed".to_string()),
+            command: Some("cargo test --quiet".to_string()),
+            file_path: None,
+            evidence_text: Some(
+                "reran cargo test --quiet after updating main.rs debug formatting; 4 api contract tests passed"
+                    .to_string(),
+            ),
+        },
+    ];
+
+    let prompt = build_guidance_distillation_prompt(&input);
+
+    assert!(prompt.contains("high_value_tool_events:"));
+    assert!(prompt.contains("src/api/response.rs"));
+    assert!(prompt.contains("HttpResponse { status: u16, body: ResponseBody }"));
+    assert!(prompt.contains("Display"));
+    assert!(prompt.contains("4 api contract tests passed"));
+    assert!(prompt.contains("Decisions locked in: use HttpResponse"));
+}
+
+#[test]
+fn build_guidance_distillation_prompt_preserves_multiple_high_value_transcript_lines() {
+    let mut input = input_with_one_modified_file();
+    input.transcript_fragment = Some(format!(
+        "Decision: keep the early routing behavior.\n{}\nDecisions locked in: use HttpResponse and no Display shim.\n{}",
+        "middle exploration noise ".repeat(1_000),
+        "tail exploration noise ".repeat(1_000)
+    ));
+
+    let prompt = build_guidance_distillation_prompt(&input);
+
+    assert!(prompt.contains("Decision: keep the early routing behavior."));
+    assert!(prompt.contains("Decisions locked in: use HttpResponse and no Display shim."));
 }
 
 #[test]
@@ -429,6 +658,28 @@ fn build_guidance_distillation_prompt_declares_future_session_value_contract() {
     assert!(prompt.contains("invariant"));
     assert!(prompt.contains("dependency"));
     assert!(prompt.contains("ownership"));
+}
+
+#[test]
+fn build_guidance_distillation_prompt_requires_decisions_to_be_fact_candidates() {
+    let prompt = build_guidance_distillation_prompt(&input_with_one_modified_file());
+
+    assert!(
+        prompt.contains(
+            "Durable decisions in summary.decisions must also be emitted as guidanceFacts"
+        )
+    );
+    assert!(
+        prompt.contains("Every guidanceFact must include appliesTo.paths or appliesTo.symbols")
+    );
+    assert!(
+        prompt.contains(
+            "For multi-file refactors, target the production files that own the decision"
+        )
+    );
+    assert!(prompt.contains(
+        "Use tests as evidence unless the guidance is specifically about test contracts"
+    ));
 }
 
 struct FakeTextGenerationService {

--- a/bitloops/src/capability_packs/context_guidance/evidence.rs
+++ b/bitloops/src/capability_packs/context_guidance/evidence.rs
@@ -38,6 +38,8 @@ pub(super) struct GuidanceEvidenceToolEvent {
     pub input_summary: Option<String>,
     pub output_summary: Option<String>,
     pub command: Option<String>,
+    pub file_path: Option<String>,
+    pub evidence_text: Option<String>,
 }
 
 const MAX_EVIDENCE_BODY_CHARS: usize = 6_000;

--- a/bitloops/src/capability_packs/context_guidance/history_input.rs
+++ b/bitloops/src/capability_packs/context_guidance/history_input.rs
@@ -43,15 +43,26 @@ pub(crate) fn hydrate_history_guidance_input(
                 selector.turn_id.unwrap_or("<none>")
             )
         })?;
-    let events = spool.list_events(
-        &InteractionEventFilter {
-            session_id: Some(selector.session_id.to_string()),
-            turn_id: Some(turn.turn_id.clone()),
-            event_type: Some(InteractionEventType::ToolInvocationObserved),
-            since: None,
-        },
-        50,
-    )?;
+    let mut events = Vec::new();
+    for event_type in [
+        InteractionEventType::ToolInvocationObserved,
+        InteractionEventType::ToolResultObserved,
+    ] {
+        events.extend(spool.list_events(
+            &InteractionEventFilter {
+                session_id: Some(selector.session_id.to_string()),
+                turn_id: Some(turn.turn_id.clone()),
+                event_type: Some(event_type),
+                since: None,
+            },
+            100,
+        )?);
+    }
+    events.sort_by(|left, right| {
+        left.event_time
+            .cmp(&right.event_time)
+            .then_with(|| left.event_id.cmp(&right.event_id))
+    });
     Ok(GuidanceDistillationInput {
         checkpoint_id: turn
             .checkpoint_id
@@ -74,11 +85,73 @@ pub(crate) fn hydrate_history_guidance_input(
 
 fn tool_evidence_from_event(event: &InteractionEvent) -> GuidanceToolEvidence {
     GuidanceToolEvidence {
+        event_type: Some(event.event_type.as_str().to_string()),
         tool_kind: non_empty_string(event.tool_kind.clone()),
         input_summary: payload_string(&event.payload, "input_summary")
             .or_else(|| non_empty_string(event.task_description.clone())),
         output_summary: payload_string(&event.payload, "output_summary"),
         command: payload_string(&event.payload, "command"),
+        file_path: event_file_path(event),
+        evidence_text: event_evidence_text(event),
+    }
+}
+
+fn event_file_path(event: &InteractionEvent) -> Option<String> {
+    payload_string_at(&event.payload, &["tool_input", "file_path"])
+        .or_else(|| payload_string_at(&event.payload, &["tool_response", "filePath"]))
+        .or_else(|| payload_string_at(&event.payload, &["tool_response", "file", "filePath"]))
+        .or_else(|| payload_string(&event.payload, "input_summary"))
+        .filter(|value| value.contains('/'))
+}
+
+fn event_evidence_text(event: &InteractionEvent) -> Option<String> {
+    let tool = event.tool_kind.to_ascii_lowercase();
+    match tool.as_str() {
+        "write" | "edit" | "multiedit" => write_edit_evidence_text(&event.payload),
+        "bash" => bash_evidence_text(&event.payload),
+        "askuserquestion" => payload_string(&event.payload, "output_summary")
+            .or_else(|| payload_string_at(&event.payload, &["tool_response", "answers"])),
+        _ => payload_string(&event.payload, "output_summary"),
+    }
+}
+
+fn write_edit_evidence_text(payload: &serde_json::Value) -> Option<String> {
+    let path = payload_string_at(payload, &["tool_input", "file_path"])
+        .or_else(|| payload_string_at(payload, &["tool_response", "filePath"]));
+    let content = payload_string_at(payload, &["tool_input", "content"])
+        .or_else(|| payload_string_at(payload, &["tool_response", "content"]));
+    let patch = payload
+        .pointer("/tool_response/structuredPatch")
+        .and_then(|value| serde_json::to_string(value).ok())
+        .filter(|value| value != "[]");
+
+    match (path, content, patch) {
+        (Some(path), Some(content), Some(patch)) => Some(format!(
+            "path: {path}\ncontent:\n{content}\nstructuredPatch:\n{patch}"
+        )),
+        (Some(path), Some(content), None) => Some(format!("path: {path}\ncontent:\n{content}")),
+        (Some(path), None, Some(patch)) => Some(format!("path: {path}\nstructuredPatch:\n{patch}")),
+        (None, Some(content), Some(patch)) => {
+            Some(format!("content:\n{content}\nstructuredPatch:\n{patch}"))
+        }
+        (None, None, Some(patch)) => Some(format!("structuredPatch:\n{patch}")),
+        (None, Some(content), None) => Some(content),
+        (Some(path), None, None) => Some(format!("path: {path}")),
+        (None, None, None) => None,
+    }
+}
+
+fn bash_evidence_text(payload: &serde_json::Value) -> Option<String> {
+    let command = payload_string(payload, "command")
+        .or_else(|| payload_string_at(payload, &["tool_input", "command"]));
+    let output = payload_string(payload, "output_summary")
+        .or_else(|| payload_string_at(payload, &["tool_response", "stdout"]))
+        .or_else(|| payload_string_at(payload, &["tool_response", "stderr"]));
+    match (command, output) {
+        (Some(command), Some(output)) => Some(format!("command: {command}\noutput:\n{output}")),
+        (Some(command), None) => Some(format!("command: {command}")),
+        (None, Some(output)) => Some(output),
+        (None, None) => None,
     }
 }
 
@@ -91,7 +164,85 @@ fn payload_string(payload: &serde_json::Value, key: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+fn payload_string_at(payload: &serde_json::Value, path: &[&str]) -> Option<String> {
+    let mut current = payload;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    match current {
+        serde_json::Value::String(value) => non_empty_string(value.clone()),
+        value if value.is_object() || value.is_array() => {
+            serde_json::to_string(value).ok().and_then(non_empty_string)
+        }
+        _ => None,
+    }
+}
+
 fn non_empty_string(value: String) -> Option<String> {
     let trimmed = value.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn tool_evidence_extracts_lowercase_write_payload() {
+        let event = InteractionEvent {
+            event_type: InteractionEventType::ToolInvocationObserved,
+            tool_kind: "write".to_string(),
+            payload: json!({
+                "tool_input": {
+                    "file_path": "src/api/response.rs",
+                    "content": "pub struct HttpResponse;"
+                }
+            }),
+            ..InteractionEvent::default()
+        };
+
+        let evidence = tool_evidence_from_event(&event);
+
+        assert_eq!(evidence.file_path.as_deref(), Some("src/api/response.rs"));
+        assert!(
+            evidence
+                .evidence_text
+                .as_deref()
+                .is_some_and(|text| text.contains("pub struct HttpResponse;"))
+        );
+    }
+
+    #[test]
+    fn tool_evidence_extracts_lowercase_bash_output() {
+        let event = InteractionEvent {
+            event_type: InteractionEventType::ToolResultObserved,
+            tool_kind: "bash".to_string(),
+            payload: json!({
+                "tool_input": {
+                    "command": "cargo nextest run context_guidance"
+                },
+                "tool_response": {
+                    "stderr": "test result: ok. 4 passed"
+                }
+            }),
+            ..InteractionEvent::default()
+        };
+
+        let evidence = tool_evidence_from_event(&event);
+
+        assert!(
+            evidence
+                .evidence_text
+                .as_deref()
+                .is_some_and(|text| text.contains("cargo nextest run context_guidance"))
+        );
+        assert!(
+            evidence
+                .evidence_text
+                .as_deref()
+                .is_some_and(|text| text.contains("4 passed"))
+        );
+    }
 }

--- a/bitloops/src/capability_packs/context_guidance/ingesters/history.rs
+++ b/bitloops/src/capability_packs/context_guidance/ingesters/history.rs
@@ -88,9 +88,11 @@ impl IngesterHandler for ContextGuidanceHistoryDistillationIngester {
             let slot = ctx
                 .inference()
                 .describe(CONTEXT_GUIDANCE_TEXT_GENERATION_SLOT);
-            let output = GuidanceDistiller::new(service)
-                .distill(&input)
+            let distilled = GuidanceDistiller::new(service)
+                .distill_with_report(&input)
                 .context("distilling context guidance history")?;
+            let output = &distilled.output;
+            let report = &distilled.report;
             let store = ctx
                 .context_guidance_store()
                 .ok_or_else(|| anyhow!("context guidance store is not available"))?;
@@ -102,19 +104,30 @@ impl IngesterHandler for ContextGuidanceHistoryDistillationIngester {
             let outcome = store.persist_history_guidance_distillation(
                 repo_id,
                 &input,
-                &output,
+                output,
                 source_model.as_deref(),
                 source_profile.as_deref(),
             )?;
             enqueue_target_compactions(repo_id, &outcome, ctx.workplane())?;
+            log::info!(
+                "context guidance history distillation diagnostics: repo_id={} run_inserted={} facts_inserted={} raw_facts={} validation_kept={} validation_dropped={} quality_kept={} quality_dropped={}",
+                repo_id,
+                outcome.inserted_run,
+                outcome.inserted_facts,
+                report.raw_fact_count,
+                report.validation_kept_fact_count,
+                report.validation_discards.len(),
+                report.quality_kept_fact_count,
+                report.quality_discards.len(),
+            );
             Ok(IngestResult::new(
-                json!({
-                    "accepted": true,
-                    "insertedRun": outcome.inserted_run,
-                    "insertedFacts": outcome.inserted_facts,
-                    "unchanged": outcome.unchanged,
-                    "work_item_count": history_turn_work_item_count(&payload)
-                }),
+                history_distillation_result_payload(
+                    outcome.inserted_run,
+                    outcome.inserted_facts,
+                    outcome.unchanged,
+                    history_turn_work_item_count(&payload),
+                    report,
+                ),
                 "completed context guidance history distillation work",
             ))
         })
@@ -141,6 +154,45 @@ fn enqueue_target_compactions(
         )?;
     }
     Ok(())
+}
+
+fn history_distillation_result_payload(
+    inserted_run: bool,
+    inserted_facts: usize,
+    unchanged: bool,
+    work_item_count: u64,
+    report: &super::super::distillation::GuidanceDistillationReport,
+) -> serde_json::Value {
+    json!({
+        "accepted": true,
+        "insertedRun": inserted_run,
+        "insertedFacts": inserted_facts,
+        "unchanged": unchanged,
+        "work_item_count": work_item_count,
+        "distillation": {
+            "rawResponseChars": report.raw_response_chars,
+            "rawFactCount": report.raw_fact_count,
+            "validationInputFactCount": report.validation_input_fact_count,
+            "validationKeptFactCount": report.validation_kept_fact_count,
+            "validationDropped": report.validation_discards.len(),
+            "validationDropReasons": report.validation_discards.iter().map(|discard| {
+                json!({
+                    "kind": discard.kind,
+                    "reason": format!("{:?}", discard.reason),
+                })
+            }).collect::<Vec<_>>(),
+            "qualityInputFactCount": report.quality_input_fact_count,
+            "qualityKeptFactCount": report.quality_kept_fact_count,
+            "qualityDropped": report.quality_discards.len(),
+            "qualityDropReasons": report.quality_discards.iter().map(|discard| {
+                json!({
+                    "kind": discard.kind,
+                    "category": format!("{:?}", discard.category),
+                    "reason": discard.reason,
+                })
+            }).collect::<Vec<_>>(),
+        }
+    })
 }
 
 #[cfg(test)]
@@ -177,6 +229,45 @@ mod tests {
         fn mailbox_status(&self) -> anyhow::Result<BTreeMap<String, CapabilityMailboxStatus>> {
             Ok(BTreeMap::new())
         }
+    }
+
+    #[test]
+    fn history_distillation_result_payload_includes_diagnostics() {
+        let report =
+            crate::capability_packs::context_guidance::distillation::GuidanceDistillationReport {
+                raw_response_chars: 512,
+                raw_fact_count: 3,
+                validation_input_fact_count: 3,
+                validation_kept_fact_count: 2,
+                validation_discards: vec![
+                    crate::capability_packs::context_guidance::distillation::GuidanceValidationDiscard {
+                        kind: "targetless_fact".to_string(),
+                        reason: crate::capability_packs::context_guidance::distillation::GuidanceValidationDiscardReason::MissingTargetWithoutDefault,
+                    },
+                ],
+                quality_input_fact_count: 2,
+                quality_kept_fact_count: 1,
+                quality_discards: vec![
+                    crate::capability_packs::context_guidance::distillation::GuidanceQualityDiscardSummary {
+                        kind: "generic_tests_passed".to_string(),
+                        category: crate::capability_packs::context_guidance::types::GuidanceFactCategory::Verification,
+                        reason: "LowValueStatusFact".to_string(),
+                    },
+                ],
+            };
+
+        let payload = history_distillation_result_payload(true, 1, false, 1, &report);
+
+        assert_eq!(payload["accepted"], json!(true));
+        assert_eq!(payload["insertedRun"], json!(true));
+        assert_eq!(payload["insertedFacts"], json!(1));
+        assert_eq!(payload["distillation"]["rawFactCount"], json!(3));
+        assert_eq!(payload["distillation"]["validationDropped"], json!(1));
+        assert_eq!(payload["distillation"]["qualityDropped"], json!(1));
+        assert_eq!(
+            payload["distillation"]["qualityDropReasons"][0]["reason"],
+            json!("LowValueStatusFact")
+        );
     }
 
     #[test]

--- a/bitloops/src/capability_packs/context_guidance/ingesters/history.rs
+++ b/bitloops/src/capability_packs/context_guidance/ingesters/history.rs
@@ -177,7 +177,7 @@ fn history_distillation_result_payload(
             "validationDropped": report.validation_discards.len(),
             "validationDropReasons": report.validation_discards.iter().map(|discard| {
                 json!({
-                    "kind": discard.kind,
+                    "kind": discard.kind.as_str(),
                     "reason": format!("{:?}", discard.reason),
                 })
             }).collect::<Vec<_>>(),
@@ -186,9 +186,9 @@ fn history_distillation_result_payload(
             "qualityDropped": report.quality_discards.len(),
             "qualityDropReasons": report.quality_discards.iter().map(|discard| {
                 json!({
-                    "kind": discard.kind,
+                    "kind": discard.kind.as_str(),
                     "category": format!("{:?}", discard.category),
-                    "reason": discard.reason,
+                    "reason": discard.reason.as_str(),
                 })
             }).collect::<Vec<_>>(),
         }

--- a/bitloops/src/capability_packs/context_guidance/quality.rs
+++ b/bitloops/src/capability_packs/context_guidance/quality.rs
@@ -7,23 +7,92 @@ use super::types::{
 
 const MAX_SOURCES_PER_FACT: usize = 3;
 
-pub(super) fn filter_value_guidance_output(
-    mut output: GuidanceDistillationOutput,
-) -> GuidanceDistillationOutput {
-    output.guidance_facts = output
-        .guidance_facts
-        .into_iter()
-        .filter(is_valuable_fact)
-        .collect();
-    output
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GuidanceQualityDiscardReason {
+    MissingTarget,
+    GuidanceTooShort,
+    EvidenceTooShort,
+    LowValueStatusFact,
+    NonReusableVerification,
+    NonDurableContext,
 }
 
-pub(super) fn is_valuable_fact(fact: &GuidanceFactDraft) -> bool {
-    has_target(fact)
-        && has_specific_text(fact.guidance.as_str())
-        && has_specific_text(fact.evidence_excerpt.as_str())
-        && !is_low_value_status_fact(fact)
-        && is_category_valuable(fact)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GuidanceQualityDiscard {
+    pub kind: String,
+    pub category: GuidanceFactCategory,
+    pub reason: GuidanceQualityDiscardReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GuidanceQualityReport {
+    pub input_fact_count: usize,
+    pub kept_fact_count: usize,
+    pub discarded: Vec<GuidanceQualityDiscard>,
+}
+
+#[cfg(test)]
+pub(crate) fn filter_value_guidance_output(
+    output: GuidanceDistillationOutput,
+) -> GuidanceDistillationOutput {
+    filter_value_guidance_output_with_report(output).0
+}
+
+pub(super) fn filter_value_guidance_output_with_report(
+    mut output: GuidanceDistillationOutput,
+) -> (GuidanceDistillationOutput, GuidanceQualityReport) {
+    let input_fact_count = output.guidance_facts.len();
+    let mut kept = Vec::new();
+    let mut discarded = Vec::new();
+
+    for fact in output.guidance_facts {
+        match discard_reason(&fact) {
+            Some(reason) => discarded.push(GuidanceQualityDiscard {
+                kind: fact.kind.clone(),
+                category: fact.category,
+                reason,
+            }),
+            None => kept.push(fact),
+        }
+    }
+
+    let kept_fact_count = kept.len();
+    output.guidance_facts = kept;
+
+    (
+        output,
+        GuidanceQualityReport {
+            input_fact_count,
+            kept_fact_count,
+            discarded,
+        },
+    )
+}
+
+pub(super) fn discard_reason(fact: &GuidanceFactDraft) -> Option<GuidanceQualityDiscardReason> {
+    if !has_target(fact) {
+        return Some(GuidanceQualityDiscardReason::MissingTarget);
+    }
+    if !has_specific_text(fact.guidance.as_str()) {
+        return Some(GuidanceQualityDiscardReason::GuidanceTooShort);
+    }
+    if !has_specific_text(fact.evidence_excerpt.as_str()) {
+        return Some(GuidanceQualityDiscardReason::EvidenceTooShort);
+    }
+    if is_low_value_status_fact(fact) {
+        return Some(GuidanceQualityDiscardReason::LowValueStatusFact);
+    }
+    match fact.category {
+        GuidanceFactCategory::Decision
+        | GuidanceFactCategory::Constraint
+        | GuidanceFactCategory::Pattern
+        | GuidanceFactCategory::Risk => None,
+        GuidanceFactCategory::Verification => (!is_reusable_verification(fact))
+            .then_some(GuidanceQualityDiscardReason::NonReusableVerification),
+        GuidanceFactCategory::Context => {
+            (!is_durable_context(fact)).then_some(GuidanceQualityDiscardReason::NonDurableContext)
+        }
+    }
 }
 
 pub(super) fn guidance_value_score(
@@ -71,17 +140,6 @@ fn has_target(fact: &GuidanceFactDraft) -> bool {
 
 fn has_specific_text(value: &str) -> bool {
     value.split_whitespace().count() >= 5
-}
-
-fn is_category_valuable(fact: &GuidanceFactDraft) -> bool {
-    match fact.category {
-        GuidanceFactCategory::Decision
-        | GuidanceFactCategory::Constraint
-        | GuidanceFactCategory::Pattern
-        | GuidanceFactCategory::Risk => true,
-        GuidanceFactCategory::Verification => is_reusable_verification(fact),
-        GuidanceFactCategory::Context => is_durable_context(fact),
-    }
 }
 
 fn is_reusable_verification(fact: &GuidanceFactDraft) -> bool {
@@ -290,5 +348,63 @@ mod tests {
         let filtered = filter_value_guidance_output(output);
 
         assert_eq!(filtered.guidance_facts.len(), 1);
+    }
+
+    #[test]
+    fn reports_discard_reasons_for_low_value_facts() {
+        let output = GuidanceDistillationOutput {
+            summary: crate::capability_packs::context_guidance::types::GuidanceSessionSummary {
+                intent: "Capture session guidance.".to_string(),
+                outcome: "Model returned mixed quality facts.".to_string(),
+                decisions: Vec::new(),
+                rejected_approaches: Vec::new(),
+                patterns: Vec::new(),
+                verification: Vec::new(),
+                open_items: Vec::new(),
+            },
+            guidance_facts: vec![
+                GuidanceFactDraft {
+                    category: GuidanceFactCategory::Decision,
+                    kind: "missing_target".to_string(),
+                    guidance:
+                        "Keep handler responses typed so tests assert status and body directly."
+                            .to_string(),
+                    evidence_excerpt:
+                        "The session chose typed HttpResponse values for API handlers.".to_string(),
+                    applies_to: GuidanceAppliesTo::default(),
+                    confidence: GuidanceFactConfidence::High,
+                },
+                fact(
+                    GuidanceFactCategory::Verification,
+                    "generic_tests_passed",
+                    "The tests passed after the refactor completed.",
+                    "4 tests passed after the work completed.",
+                ),
+                fact(
+                    GuidanceFactCategory::Decision,
+                    "typed_api_response",
+                    "Keep API handlers returning HttpResponse so status and body are asserted directly.",
+                    "User chose a new src/api/response.rs HttpResponse and no Display compatibility shim.",
+                ),
+            ],
+        };
+
+        let (filtered, report) = filter_value_guidance_output_with_report(output);
+
+        assert_eq!(report.input_fact_count, 3);
+        assert_eq!(report.kept_fact_count, 1);
+        assert_eq!(filtered.guidance_facts.len(), 1);
+        assert_eq!(filtered.guidance_facts[0].kind, "typed_api_response");
+        assert_eq!(report.discarded.len(), 2);
+        assert_eq!(report.discarded[0].kind, "missing_target");
+        assert_eq!(
+            report.discarded[0].reason,
+            GuidanceQualityDiscardReason::MissingTarget
+        );
+        assert_eq!(report.discarded[1].kind, "generic_tests_passed");
+        assert_eq!(
+            report.discarded[1].reason,
+            GuidanceQualityDiscardReason::LowValueStatusFact
+        );
     }
 }

--- a/bitloops/src/capability_packs/context_guidance/storage_helpers.rs
+++ b/bitloops/src/capability_packs/context_guidance/storage_helpers.rs
@@ -116,10 +116,13 @@ pub fn guidance_input_hash(input: &GuidanceDistillationInput) -> String {
             .map(|path| path.trim().to_string()),
     );
     for event in &input.tool_events {
+        parts.push(event.event_type.as_deref().unwrap_or("").to_string());
         parts.push(event.tool_kind.as_deref().unwrap_or("").to_string());
         parts.push(event.input_summary.as_deref().unwrap_or("").to_string());
         parts.push(event.output_summary.as_deref().unwrap_or("").to_string());
         parts.push(event.command.as_deref().unwrap_or("").to_string());
+        parts.push(event.file_path.as_deref().unwrap_or("").to_string());
+        parts.push(event.evidence_text.as_deref().unwrap_or("").to_string());
     }
     sha256_hex(parts.join("\n").as_bytes())
 }
@@ -422,6 +425,8 @@ fn tool_event_supports_fact(event: &GuidanceToolEvidence, fact: &GuidanceFactDra
         event.command.as_deref().unwrap_or(""),
         event.input_summary.as_deref().unwrap_or(""),
         event.output_summary.as_deref().unwrap_or(""),
+        event.file_path.as_deref().unwrap_or(""),
+        event.evidence_text.as_deref().unwrap_or(""),
     ]
     .join("\n")
     .to_ascii_lowercase();
@@ -580,8 +585,9 @@ fn history_tool_source(
         title: None,
         url: None,
         excerpt: event
-            .output_summary
+            .evidence_text
             .as_deref()
+            .or(event.output_summary.as_deref())
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(str::to_string),

--- a/bitloops/src/capability_packs/context_guidance/storage_tests.rs
+++ b/bitloops/src/capability_packs/context_guidance/storage_tests.rs
@@ -30,10 +30,13 @@ fn input(path: &str) -> GuidanceDistillationInput {
         transcript_fragment: Some("Rejected std::any::type_name approach".to_string()),
         files_modified: vec![path.to_string()],
         tool_events: vec![GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
             tool_kind: Some("shell".to_string()),
             input_summary: Some("cargo nextest".to_string()),
             output_summary: Some("tests passed".to_string()),
             command: Some("cargo nextest".to_string()),
+            file_path: None,
+            evidence_text: None,
         }],
     }
 }
@@ -262,36 +265,51 @@ fn verification_sources_are_relevant_deduplicated_and_capped() {
     let mut input = input("src/target.rs");
     input.tool_events = vec![
         GuidanceToolEvidence {
+            event_type: Some("tool_result_observed".to_string()),
             tool_kind: Some("Bash".to_string()),
             input_summary: Some("cargo nextest run -p axum-macros debug_handler".to_string()),
             output_summary: Some("debug_handler Self receiver regression check passed".to_string()),
             command: Some("cargo nextest run -p axum-macros debug_handler".to_string()),
+            file_path: None,
+            evidence_text: None,
         },
         GuidanceToolEvidence {
+            event_type: Some("tool_result_observed".to_string()),
             tool_kind: Some("Bash".to_string()),
             input_summary: Some("cargo nextest run -p axum-macros debug_handler".to_string()),
             output_summary: Some("debug_handler Self receiver regression check passed".to_string()),
             command: Some("cargo nextest run -p axum-macros debug_handler".to_string()),
+            file_path: None,
+            evidence_text: None,
         },
         GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
             tool_kind: Some("Read".to_string()),
             input_summary: Some("src/unrelated.rs".to_string()),
             output_summary: Some("receiver behavior regression notes".to_string()),
             command: None,
+            file_path: Some("src/unrelated.rs".to_string()),
+            evidence_text: None,
         },
         GuidanceToolEvidence {
+            event_type: Some("tool_invocation_observed".to_string()),
             tool_kind: Some("Bash".to_string()),
             input_summary: Some("cargo clippy -p axum-macros".to_string()),
             output_summary: None,
             command: Some("cargo clippy -p axum-macros".to_string()),
+            file_path: None,
+            evidence_text: None,
         },
         GuidanceToolEvidence {
+            event_type: Some("tool_result_observed".to_string()),
             tool_kind: Some("Bash".to_string()),
             input_summary: Some(
                 "cargo nextest run -p axum-macros debug_handler secondary".to_string(),
             ),
             output_summary: Some("debug_handler secondary regression check passed".to_string()),
             command: Some("cargo nextest run -p axum-macros debug_handler secondary".to_string()),
+            file_path: None,
+            evidence_text: None,
         },
     ];
     let output = GuidanceDistillationOutput {

--- a/bitloops/src/capability_packs/context_guidance/workplane.rs
+++ b/bitloops/src/capability_packs/context_guidance/workplane.rs
@@ -298,10 +298,13 @@ mod tests {
             transcript_fragment: Some("Captured transcript".to_string()),
             files_modified: vec!["src/target.ts".to_string()],
             tool_events: vec![GuidanceToolEvidence {
+                event_type: Some("tool_invocation_observed".to_string()),
                 tool_kind: Some("shell".to_string()),
                 input_summary: Some("cargo nextest".to_string()),
                 output_summary: Some("nextest passed".to_string()),
                 command: Some("cargo nextest run --lib context_guidance".to_string()),
+                file_path: None,
+                evidence_text: None,
             }],
         }
     }

--- a/bitloops/src/daemon/enrichment/workplane/job_claim.rs
+++ b/bitloops/src/daemon/enrichment/workplane/job_claim.rs
@@ -118,38 +118,53 @@ fn load_workplane_claim_candidates(
     let mut values = Vec::new();
     match pool {
         EnrichmentWorkerPool::SummaryRefresh => {
-            let mut stmt = conn.prepare(
-                "SELECT job_id, repo_id, repo_root, config_root, capability_id, mailbox_name,
-                        init_session_id, dedupe_key, payload, status, attempts, available_at_unix, submitted_at_unix,
-                        started_at_unix, updated_at_unix, completed_at_unix, lease_owner,
-                        lease_expires_at_unix, last_error
-                 FROM capability_workplane_jobs
-                 WHERE status = ?1
-                   AND available_at_unix <= ?2
-                 ORDER BY CASE mailbox_name
-                              WHEN 'semantic_clones.embedding.code' THEN 0
-                              WHEN 'semantic_clones.embedding.identity' THEN 0
-                              WHEN 'semantic_clones.embedding.architecture' THEN 0
-                              WHEN 'semantic_clones.embedding.summary' THEN 0
-                              WHEN 'semantic_clones.summary_refresh' THEN 1
-                              WHEN 'semantic_clones.clone_rebuild' THEN 2
-                          ELSE 3
-                          END ASC,
-                          available_at_unix ASC,
-                          submitted_at_unix ASC
-                 LIMIT ?3",
-            )?;
-            let rows = stmt.query_map(
-                params![WorkplaneJobStatus::Pending.as_str(), now, limit,],
-                map_workplane_job_row,
-            )?;
-            for row in rows {
-                let job = row?;
-                if job.mailbox_name == SEMANTIC_CLONES_SUMMARY_REFRESH_MAILBOX
-                    || is_generic_inference_job(runtime_store, readiness_cache, &job)?
-                {
-                    values.push(job);
+            let mut offset = 0_i64;
+            loop {
+                let mut stmt = conn.prepare(
+                    "SELECT job_id, repo_id, repo_root, config_root, capability_id, mailbox_name,
+                            init_session_id, dedupe_key, payload, status, attempts, available_at_unix, submitted_at_unix,
+                            started_at_unix, updated_at_unix, completed_at_unix, lease_owner,
+                            lease_expires_at_unix, last_error
+                     FROM capability_workplane_jobs
+                     WHERE status = ?1
+                       AND available_at_unix <= ?2
+                     ORDER BY CASE mailbox_name
+                                  WHEN 'semantic_clones.embedding.code' THEN 0
+                                  WHEN 'semantic_clones.embedding.identity' THEN 0
+                                  WHEN 'semantic_clones.embedding.architecture' THEN 0
+                                  WHEN 'semantic_clones.embedding.summary' THEN 0
+                                  WHEN 'semantic_clones.summary_refresh' THEN 1
+                                  WHEN 'semantic_clones.clone_rebuild' THEN 2
+                              ELSE 3
+                              END ASC,
+                              available_at_unix ASC,
+                              submitted_at_unix ASC
+                     LIMIT ?3 OFFSET ?4",
+                )?;
+                let rows = stmt.query_map(
+                    params![WorkplaneJobStatus::Pending.as_str(), now, limit, offset],
+                    map_workplane_job_row,
+                )?;
+                let mut page_count = 0_i64;
+                for row in rows {
+                    page_count += 1;
+                    let job = row?;
+                    let claimable = if job.mailbox_name == SEMANTIC_CLONES_SUMMARY_REFRESH_MAILBOX {
+                        !mailbox_claim_readiness(runtime_store, readiness_cache, &job)?.blocked
+                    } else {
+                        is_generic_inference_job(runtime_store, readiness_cache, &job)?
+                    };
+                    if claimable {
+                        values.push(job);
+                        if values.len() >= WORKPLANE_JOB_CLAIM_CANDIDATE_LIMIT {
+                            return Ok(values);
+                        }
+                    }
                 }
+                if page_count < limit {
+                    break;
+                }
+                offset += page_count;
             }
         }
         EnrichmentWorkerPool::Embeddings => {

--- a/bitloops/src/daemon/enrichment/workplane/job_claim.rs
+++ b/bitloops/src/daemon/enrichment/workplane/job_claim.rs
@@ -265,6 +265,12 @@ fn is_generic_inference_job(
     if !matches!(registration.handler, CapabilityMailboxHandler::Ingester(_)) {
         return Ok(false);
     }
+    if matches!(
+        registration.readiness_policy,
+        CapabilityMailboxReadinessPolicy::None
+    ) {
+        return Ok(true);
+    }
     if !is_generic_inference_readiness_policy(registration.readiness_policy) {
         return Ok(false);
     }

--- a/bitloops/src/daemon/enrichment/workplane/maintenance.rs
+++ b/bitloops/src/daemon/enrichment/workplane/maintenance.rs
@@ -1,21 +1,90 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use rusqlite::params;
 
+use crate::capability_packs::architecture_graph::types::{
+    ARCHITECTURE_GRAPH_CAPABILITY_ID, ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_MAILBOX,
+    ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT,
+};
 use crate::daemon::types::unix_timestamp_now;
+use crate::host::inference::InferenceGateway;
 use crate::host::runtime_store::{
     DaemonSqliteRuntimeStore, SemanticMailboxItemStatus, WorkplaneJobStatus,
 };
 
 use super::super::{WORKPLANE_TERMINAL_RETENTION_SECS, WORKPLANE_TERMINAL_ROW_LIMIT};
+use super::sql::repo_identity_from_runtime_metadata;
 use super::sql::sql_i64;
 
 pub(crate) fn compact_and_prune_workplane_jobs(
     workplane_store: &DaemonSqliteRuntimeStore,
 ) -> Result<()> {
     workplane_store.with_write_connection(|conn| {
+        complete_unconfigured_architecture_role_adjudication_jobs(conn)?;
         prune_terminal_workplane_jobs(conn)?;
         Ok(())
     })
+}
+
+fn complete_unconfigured_architecture_role_adjudication_jobs(
+    conn: &rusqlite::Connection,
+) -> Result<()> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT repo_id, repo_root
+         FROM capability_workplane_jobs
+         WHERE capability_id = ?1
+           AND mailbox_name = ?2
+           AND status = ?3",
+    )?;
+    let rows = stmt.query_map(
+        params![
+            ARCHITECTURE_GRAPH_CAPABILITY_ID,
+            ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_MAILBOX,
+            WorkplaneJobStatus::Pending.as_str(),
+        ],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                PathBuf::from(row.get::<_, String>(1)?),
+            ))
+        },
+    )?;
+
+    let now = unix_timestamp_now();
+    for row in rows {
+        let (repo_id, repo_root) = row?;
+        let repo = repo_identity_from_runtime_metadata(&repo_root, &repo_id);
+        let host = crate::host::devql::build_capability_host(&repo_root, repo)?;
+        let inference = host.inference_for_capability(ARCHITECTURE_GRAPH_CAPABILITY_ID);
+        if inference.has_slot(ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT) {
+            continue;
+        }
+        conn.execute(
+            "UPDATE capability_workplane_jobs
+             SET status = ?1,
+                 updated_at_unix = ?2,
+                 completed_at_unix = ?3,
+                 last_error = ?4,
+                 lease_owner = NULL,
+                 lease_expires_at_unix = NULL
+             WHERE repo_id = ?5
+               AND capability_id = ?6
+               AND mailbox_name = ?7
+               AND status = ?8",
+            params![
+                WorkplaneJobStatus::Completed.as_str(),
+                sql_i64(now)?,
+                sql_i64(now)?,
+                "skipped: structured-generation slot `role_adjudication` is not configured",
+                repo_id,
+                ARCHITECTURE_GRAPH_CAPABILITY_ID,
+                ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_MAILBOX,
+                WorkplaneJobStatus::Pending.as_str(),
+            ],
+        )?;
+    }
+    Ok(())
 }
 
 fn prune_terminal_workplane_jobs(conn: &rusqlite::Connection) -> Result<()> {

--- a/bitloops/src/daemon/enrichment/workplane/maintenance.rs
+++ b/bitloops/src/daemon/enrichment/workplane/maintenance.rs
@@ -20,46 +20,78 @@ use super::sql::sql_i64;
 pub(crate) fn compact_and_prune_workplane_jobs(
     workplane_store: &DaemonSqliteRuntimeStore,
 ) -> Result<()> {
+    let unconfigured_role_adjudication_repos =
+        unconfigured_architecture_role_adjudication_repos(workplane_store)?;
     workplane_store.with_write_connection(|conn| {
-        complete_unconfigured_architecture_role_adjudication_jobs(conn)?;
+        complete_unconfigured_architecture_role_adjudication_jobs(
+            conn,
+            &unconfigured_role_adjudication_repos,
+        )?;
         prune_terminal_workplane_jobs(conn)?;
         Ok(())
     })
 }
 
+#[derive(Debug, Clone)]
+struct PendingArchitectureRoleAdjudicationRepo {
+    repo_id: String,
+    repo_root: PathBuf,
+    repo_root_text: String,
+}
+
+fn unconfigured_architecture_role_adjudication_repos(
+    workplane_store: &DaemonSqliteRuntimeStore,
+) -> Result<Vec<PendingArchitectureRoleAdjudicationRepo>> {
+    let candidates = load_pending_architecture_role_adjudication_repos(workplane_store)?;
+    let mut unconfigured = Vec::new();
+    for candidate in candidates {
+        let repo = repo_identity_from_runtime_metadata(&candidate.repo_root, &candidate.repo_id);
+        let host = crate::host::devql::build_capability_host(&candidate.repo_root, repo)?;
+        let inference = host.inference_for_capability(ARCHITECTURE_GRAPH_CAPABILITY_ID);
+        if !inference.has_slot(ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT) {
+            unconfigured.push(candidate);
+        }
+    }
+    Ok(unconfigured)
+}
+
+fn load_pending_architecture_role_adjudication_repos(
+    workplane_store: &DaemonSqliteRuntimeStore,
+) -> Result<Vec<PendingArchitectureRoleAdjudicationRepo>> {
+    workplane_store.with_connection(|conn| {
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT repo_id, repo_root
+             FROM capability_workplane_jobs
+             WHERE capability_id = ?1
+               AND mailbox_name = ?2
+               AND status = ?3",
+        )?;
+        let rows = stmt.query_map(
+            params![
+                ARCHITECTURE_GRAPH_CAPABILITY_ID,
+                ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_MAILBOX,
+                WorkplaneJobStatus::Pending.as_str(),
+            ],
+            |row| {
+                let repo_root_text = row.get::<_, String>(1)?;
+                Ok(PendingArchitectureRoleAdjudicationRepo {
+                    repo_id: row.get::<_, String>(0)?,
+                    repo_root: PathBuf::from(&repo_root_text),
+                    repo_root_text,
+                })
+            },
+        )?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(anyhow::Error::from)
+    })
+}
+
 fn complete_unconfigured_architecture_role_adjudication_jobs(
     conn: &rusqlite::Connection,
+    unconfigured_repos: &[PendingArchitectureRoleAdjudicationRepo],
 ) -> Result<()> {
-    let mut stmt = conn.prepare(
-        "SELECT DISTINCT repo_id, repo_root
-         FROM capability_workplane_jobs
-         WHERE capability_id = ?1
-           AND mailbox_name = ?2
-           AND status = ?3",
-    )?;
-    let rows = stmt.query_map(
-        params![
-            ARCHITECTURE_GRAPH_CAPABILITY_ID,
-            ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_MAILBOX,
-            WorkplaneJobStatus::Pending.as_str(),
-        ],
-        |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                PathBuf::from(row.get::<_, String>(1)?),
-            ))
-        },
-    )?;
-
     let now = unix_timestamp_now();
-    for row in rows {
-        let (repo_id, repo_root) = row?;
-        let repo = repo_identity_from_runtime_metadata(&repo_root, &repo_id);
-        let host = crate::host::devql::build_capability_host(&repo_root, repo)?;
-        let inference = host.inference_for_capability(ARCHITECTURE_GRAPH_CAPABILITY_ID);
-        if inference.has_slot(ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_SLOT) {
-            continue;
-        }
+    for repo in unconfigured_repos {
         conn.execute(
             "UPDATE capability_workplane_jobs
              SET status = ?1,
@@ -69,15 +101,17 @@ fn complete_unconfigured_architecture_role_adjudication_jobs(
                  lease_owner = NULL,
                  lease_expires_at_unix = NULL
              WHERE repo_id = ?5
-               AND capability_id = ?6
-               AND mailbox_name = ?7
-               AND status = ?8",
+               AND repo_root = ?6
+               AND capability_id = ?7
+               AND mailbox_name = ?8
+               AND status = ?9",
             params![
                 WorkplaneJobStatus::Completed.as_str(),
                 sql_i64(now)?,
                 sql_i64(now)?,
                 "skipped: structured-generation slot `role_adjudication` is not configured",
-                repo_id,
+                repo.repo_id.as_str(),
+                repo.repo_root_text.as_str(),
                 ARCHITECTURE_GRAPH_CAPABILITY_ID,
                 ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_MAILBOX,
                 WorkplaneJobStatus::Pending.as_str(),

--- a/bitloops/src/daemon/enrichment_tests.rs
+++ b/bitloops/src/daemon/enrichment_tests.rs
@@ -3083,6 +3083,38 @@ fn summary_refresh_pool_claims_ready_context_guidance_after_blocked_generic_jobs
 }
 
 #[test]
+fn summary_refresh_pool_claims_context_guidance_target_compaction_jobs() {
+    let temp = TempDir::new().expect("temp dir");
+    let (coordinator, target, repo_id) = new_test_coordinator(&temp);
+    insert_context_guidance_target_compaction_workplane_job(
+        &coordinator,
+        &target,
+        &repo_id,
+        "context-guidance-target-compaction",
+        10,
+    );
+
+    let claimed = claim_next_workplane_job(
+        &coordinator.workplane_store,
+        &coordinator.runtime_store,
+        &default_state(),
+        super::worker_count::EnrichmentWorkerPool::SummaryRefresh,
+    )
+    .expect("claim workplane job")
+    .expect("target compaction job should be claimable by summary refresh pool");
+
+    assert_eq!(claimed.job_id, "context-guidance-target-compaction");
+    assert_eq!(
+        claimed.capability_id,
+        crate::capability_packs::context_guidance::CONTEXT_GUIDANCE_CAPABILITY_ID
+    );
+    assert_eq!(
+        claimed.mailbox_name,
+        crate::capability_packs::context_guidance::CONTEXT_GUIDANCE_TARGET_COMPACTION_MAILBOX
+    );
+}
+
+#[test]
 fn summary_refresh_pool_leaves_context_guidance_pending_when_configured_generation_is_broken() {
     let temp = TempDir::new().expect("temp dir");
     let (coordinator, target, repo_id) = new_test_coordinator(&temp);
@@ -3948,6 +3980,51 @@ fn insert_architecture_role_adjudication_workplane_job(
             .map_err(anyhow::Error::from)
         })
         .expect("insert architecture role adjudication workplane job");
+}
+
+fn insert_context_guidance_target_compaction_workplane_job(
+    coordinator: &EnrichmentCoordinator,
+    target: &EnrichmentJobTarget,
+    repo_id: &str,
+    job_id: &str,
+    updated_at_unix: u64,
+) {
+    coordinator
+        .workplane_store
+        .with_write_connection(|conn| {
+            conn.execute(
+                "INSERT INTO capability_workplane_jobs (
+                     job_id, repo_id, repo_root, config_root, capability_id, mailbox_name,
+                     dedupe_key, payload, status, attempts, available_at_unix, submitted_at_unix,
+                     started_at_unix, updated_at_unix, completed_at_unix, lease_owner,
+                     lease_expires_at_unix, last_error
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10, ?11, NULL, ?12, NULL, NULL, NULL, NULL)",
+                rusqlite::params![
+                    job_id,
+                    repo_id,
+                    target.repo_root.to_string_lossy().to_string(),
+                    target.config_root.to_string_lossy().to_string(),
+                    crate::capability_packs::context_guidance::CONTEXT_GUIDANCE_CAPABILITY_ID,
+                    crate::capability_packs::context_guidance::CONTEXT_GUIDANCE_TARGET_COMPACTION_MAILBOX,
+                    format!("target_compaction:{repo_id}:path:src/lib.rs"),
+                    json!({
+                        "targetCompaction": {
+                            "repoId": repo_id,
+                            "targetType": "path",
+                            "targetValue": "src/lib.rs"
+                        }
+                    })
+                    .to_string(),
+                    WorkplaneJobStatus::Pending.as_str(),
+                    sql_i64(updated_at_unix)?,
+                    sql_i64(updated_at_unix)?,
+                    sql_i64(updated_at_unix)?,
+                ],
+            )
+            .map(|_| ())
+            .map_err(anyhow::Error::from)
+        })
+        .expect("insert context guidance target compaction workplane job");
 }
 
 fn insert_pending_artefact_jobs_bulk(

--- a/bitloops/src/daemon/enrichment_tests.rs
+++ b/bitloops/src/daemon/enrichment_tests.rs
@@ -3039,6 +3039,50 @@ fn summary_refresh_pool_claims_context_guidance_job_when_generation_unconfigured
 }
 
 #[test]
+fn summary_refresh_pool_claims_ready_context_guidance_after_blocked_generic_jobs() {
+    let temp = TempDir::new().expect("temp dir");
+    let (coordinator, target, repo_id) = new_test_coordinator(&temp);
+    configure_context_guidance_for_repo(&target);
+
+    for index in 0..40 {
+        insert_architecture_role_adjudication_workplane_job(
+            &coordinator,
+            &target,
+            &repo_id,
+            &format!("blocked-role-adjudication-{index}"),
+            index as u64,
+            10,
+        );
+    }
+    insert_context_guidance_workplane_job(
+        &coordinator,
+        &target,
+        &repo_id,
+        "context-guidance-ready-after-blocked",
+        20,
+    );
+
+    let claimed = claim_next_workplane_job(
+        &coordinator.workplane_store,
+        &coordinator.runtime_store,
+        &default_state(),
+        super::worker_count::EnrichmentWorkerPool::SummaryRefresh,
+    )
+    .expect("claim workplane job")
+    .expect("ready context guidance job should be claimable behind blocked architecture jobs");
+
+    assert_eq!(claimed.job_id, "context-guidance-ready-after-blocked");
+    assert_eq!(
+        claimed.capability_id,
+        crate::capability_packs::context_guidance::CONTEXT_GUIDANCE_CAPABILITY_ID
+    );
+    assert_eq!(
+        claimed.mailbox_name,
+        crate::capability_packs::context_guidance::CONTEXT_GUIDANCE_HISTORY_DISTILLATION_MAILBOX
+    );
+}
+
+#[test]
 fn summary_refresh_pool_leaves_context_guidance_pending_when_configured_generation_is_broken() {
     let temp = TempDir::new().expect("temp dir");
     let (coordinator, target, repo_id) = new_test_coordinator(&temp);
@@ -3845,6 +3889,65 @@ fn insert_context_guidance_workplane_job(
             .map_err(anyhow::Error::from)
         })
         .expect("insert context guidance workplane job");
+}
+
+fn insert_architecture_role_adjudication_workplane_job(
+    coordinator: &EnrichmentCoordinator,
+    target: &EnrichmentJobTarget,
+    repo_id: &str,
+    job_id: &str,
+    generation: u64,
+    updated_at_unix: u64,
+) {
+    let request = crate::capability_packs::architecture_graph::roles::RoleAdjudicationRequest {
+        repo_id: repo_id.to_string(),
+        generation,
+        target_kind: Some("file".to_string()),
+        artefact_id: None,
+        symbol_id: None,
+        path: Some(format!("src/blocked-{generation}.rs")),
+        language: Some("rust".to_string()),
+        canonical_kind: None,
+        reason: crate::capability_packs::architecture_graph::roles::AdjudicationReason::Unknown,
+        deterministic_confidence: None,
+        candidate_role_ids: Vec::new(),
+        current_assignment: None,
+    };
+    let dedupe_key = request.scope_key();
+    let payload =
+        crate::capability_packs::architecture_graph::roles::RoleAdjudicationMailboxPayload {
+            request,
+        };
+
+    coordinator
+        .workplane_store
+        .with_write_connection(|conn| {
+            conn.execute(
+                "INSERT INTO capability_workplane_jobs (
+                     job_id, repo_id, repo_root, config_root, capability_id, mailbox_name,
+                     dedupe_key, payload, status, attempts, available_at_unix, submitted_at_unix,
+                     started_at_unix, updated_at_unix, completed_at_unix, lease_owner,
+                     lease_expires_at_unix, last_error
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10, ?11, NULL, ?12, NULL, NULL, NULL, NULL)",
+                rusqlite::params![
+                    job_id,
+                    repo_id,
+                    target.repo_root.to_string_lossy().to_string(),
+                    target.config_root.to_string_lossy().to_string(),
+                    crate::capability_packs::architecture_graph::types::ARCHITECTURE_GRAPH_CAPABILITY_ID,
+                    crate::capability_packs::architecture_graph::types::ARCHITECTURE_GRAPH_ROLE_ADJUDICATION_MAILBOX,
+                    dedupe_key,
+                    serde_json::to_string(&payload).expect("serialize role adjudication payload"),
+                    WorkplaneJobStatus::Pending.as_str(),
+                    sql_i64(updated_at_unix)?,
+                    sql_i64(updated_at_unix)?,
+                    sql_i64(updated_at_unix)?,
+                ],
+            )
+            .map(|_| ())
+            .map_err(anyhow::Error::from)
+        })
+        .expect("insert architecture role adjudication workplane job");
 }
 
 fn insert_pending_artefact_jobs_bulk(
@@ -4850,6 +4953,36 @@ fn compaction_prunes_pending_summary_refresh_jobs_when_summary_provider_is_uncon
             .count(),
         1,
         "other pending work should be preserved"
+    );
+}
+
+#[test]
+fn maintenance_completes_unconfigured_architecture_role_adjudication_jobs() {
+    let temp = TempDir::new().expect("temp dir");
+    let (coordinator, target, repo_id) = new_test_coordinator(&temp);
+    insert_architecture_role_adjudication_workplane_job(
+        &coordinator,
+        &target,
+        &repo_id,
+        "stale-unconfigured-role-adjudication",
+        1,
+        10,
+    );
+
+    super::compact_and_prune_workplane_jobs(&coordinator.workplane_store)
+        .expect("compact workplane jobs");
+
+    let pending = load_workplane_jobs(&coordinator, WorkplaneJobStatus::Pending);
+    assert!(
+        pending.is_empty(),
+        "unconfigured role_adjudication jobs should not remain pending"
+    );
+    let completed = load_workplane_jobs(&coordinator, WorkplaneJobStatus::Completed);
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].job_id, "stale-unconfigured-role-adjudication");
+    assert_eq!(
+        completed[0].last_error.as_deref(),
+        Some("skipped: structured-generation slot `role_adjudication` is not configured")
     );
 }
 

--- a/bitloops/src/daemon/enrichment_tests.rs
+++ b/bitloops/src/daemon/enrichment_tests.rs
@@ -920,6 +920,28 @@ max_output_tokens = 200
     fs::write(&config_path, config).expect("write test daemon config with guidance profile");
 }
 
+fn configure_architecture_role_adjudication_for_repo(target: &EnrichmentJobTarget) {
+    let config_path =
+        crate::test_support::git_fixtures::write_test_daemon_config(&target.config_root);
+    crate::config::settings::write_repo_daemon_binding(
+        &target
+            .repo_root
+            .join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("bind repo root to daemon config");
+
+    let mut config = fs::read_to_string(&config_path).expect("read test daemon config");
+    config.push_str(
+        r#"
+[architecture.inference]
+role_adjudication = "role_adjudicator"
+"#,
+    );
+    fs::write(&config_path, config)
+        .expect("write test daemon config with role adjudication profile");
+}
+
 fn configure_embeddings_for_repo(target: &EnrichmentJobTarget, profile_name: &str) -> PathBuf {
     let config_path =
         crate::test_support::git_fixtures::write_test_daemon_config(&target.config_root);
@@ -5061,6 +5083,52 @@ fn maintenance_completes_unconfigured_architecture_role_adjudication_jobs() {
         completed[0].last_error.as_deref(),
         Some("skipped: structured-generation slot `role_adjudication` is not configured")
     );
+}
+
+#[test]
+fn maintenance_only_completes_unconfigured_role_adjudication_for_matching_repo_root() {
+    let temp = TempDir::new().expect("temp dir");
+    let (coordinator, unconfigured_target, repo_id) = new_test_coordinator(&temp);
+    let configured_config_root = temp.path().join("configured-config");
+    let configured_repo_root = temp.path().join("configured-repo");
+    fs::create_dir_all(&configured_config_root).expect("create configured config root");
+    fs::create_dir_all(&configured_repo_root).expect("create configured repo root");
+    init_test_repo(
+        &configured_repo_root,
+        "main",
+        "Bitloops Test",
+        "bitloops@example.com",
+    );
+    let configured_target = sample_target(configured_config_root, configured_repo_root);
+    configure_architecture_role_adjudication_for_repo(&configured_target);
+
+    insert_architecture_role_adjudication_workplane_job(
+        &coordinator,
+        &unconfigured_target,
+        &repo_id,
+        "unconfigured-role-adjudication",
+        1,
+        10,
+    );
+    insert_architecture_role_adjudication_workplane_job(
+        &coordinator,
+        &configured_target,
+        &repo_id,
+        "configured-role-adjudication",
+        2,
+        11,
+    );
+
+    super::compact_and_prune_workplane_jobs(&coordinator.workplane_store)
+        .expect("compact workplane jobs");
+
+    let pending = load_workplane_jobs(&coordinator, WorkplaneJobStatus::Pending);
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].job_id, "configured-role-adjudication");
+
+    let completed = load_workplane_jobs(&coordinator, WorkplaneJobStatus::Completed);
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].job_id, "unconfigured-role-adjudication");
 }
 
 #[tokio::test]

--- a/bitloops/src/daemon/init_runtime/orchestration.rs
+++ b/bitloops/src/daemon/init_runtime/orchestration.rs
@@ -32,9 +32,18 @@ pub(crate) fn record_task_completion_seq(session: &mut InitSessionRecord, task: 
         return;
     }
     if session.follow_up_sync_task_id.as_deref() == Some(task.task_id.as_str()) {
-        assign_completion_seq(
+        let completion_already_recorded =
+            session
+                .follow_up_sync_terminal
+                .as_ref()
+                .is_some_and(|terminal| {
+                    terminal.task_id == task.task_id
+                        && terminal.status == DevqlTaskStatus::Completed
+                });
+        assign_completion_seq_for_repeatable_task(
             &mut session.next_completion_seq,
             &mut session.follow_up_sync_completion_seq,
+            completion_already_recorded,
         );
         return;
     }
@@ -55,6 +64,18 @@ pub(crate) fn record_task_completion_seq(session: &mut InitSessionRecord, task: 
 
 fn assign_completion_seq(next_completion_seq: &mut u64, target: &mut Option<u64>) {
     if target.is_some() {
+        return;
+    }
+    *next_completion_seq += 1;
+    *target = Some(*next_completion_seq);
+}
+
+fn assign_completion_seq_for_repeatable_task(
+    next_completion_seq: &mut u64,
+    target: &mut Option<u64>,
+    completion_already_recorded: bool,
+) {
+    if completion_already_recorded {
         return;
     }
     *next_completion_seq += 1;

--- a/bitloops/src/daemon/init_runtime/tests.rs
+++ b/bitloops/src/daemon/init_runtime/tests.rs
@@ -32,8 +32,9 @@ use super::lanes::{
     derive_session_status, derive_summaries_lane, derive_summary_embeddings_lane, derive_sync_lane,
 };
 use super::orchestration::{
-    selected_session_workplane_stats, selected_sync_terminal, selected_top_level_terminal,
-    semantic_bootstrap_waiting_reason, semantic_follow_up_ready_for_sync,
+    record_task_completion_seq, selected_session_workplane_stats, selected_sync_terminal,
+    selected_top_level_terminal, semantic_bootstrap_waiting_reason,
+    semantic_follow_up_ready_for_sync,
 };
 use super::progress::load_summary_freshness_state;
 use super::session_stats::{
@@ -2503,6 +2504,145 @@ fn embeddings_can_trigger_a_second_follow_up_after_summary_follow_up_completes()
         Some(&embeddings_task),
         Some(&summary_run),
     ));
+}
+
+#[test]
+fn repeated_follow_up_sync_completion_advances_latest_sync_seq() {
+    let mut session = InitSessionRecord {
+        init_session_id: "init-session-1".to_string(),
+        repo_id: "repo-1".to_string(),
+        repo_root: PathBuf::from("/tmp/repo-1"),
+        daemon_config_root: PathBuf::from("/tmp/config-1"),
+        selections: StartInitSessionSelections {
+            run_sync: true,
+            run_ingest: false,
+            run_code_embeddings: true,
+            run_summaries: true,
+            run_summary_embeddings: true,
+            ingest_backfill: None,
+            embeddings_bootstrap: Some(InitEmbeddingsBootstrapRequest {
+                config_path: PathBuf::from("/tmp/config-1/config.toml"),
+                profile_name: "local_code".to_string(),
+                mode: crate::daemon::EmbeddingsBootstrapMode::Local,
+                gateway_url_override: None,
+                api_key_env: None,
+            }),
+            summaries_bootstrap: Some(SummaryBootstrapRequest {
+                action: SummaryBootstrapAction::ConfigureCloud,
+                message: None,
+                model_name: None,
+                gateway_url_override: None,
+                api_key_env: None,
+            }),
+        },
+        initial_sync_task_id: Some("sync-task-1".to_string()),
+        initial_sync_terminal: None,
+        ingest_task_id: None,
+        ingest_terminal: None,
+        embeddings_bootstrap_task_id: Some("bootstrap-task-1".to_string()),
+        embeddings_bootstrap_terminal: None,
+        summary_bootstrap_task_id: Some("summary-task-1".to_string()),
+        summary_bootstrap_terminal: None,
+        follow_up_sync_required: true,
+        follow_up_sync_task_id: Some("follow-up-sync-2".to_string()),
+        follow_up_sync_terminal: None,
+        next_completion_seq: 4,
+        initial_sync_completion_seq: Some(1),
+        embeddings_bootstrap_completion_seq: Some(4),
+        summary_bootstrap_completion_seq: Some(2),
+        follow_up_sync_completion_seq: Some(3),
+        submitted_at_unix: 1,
+        updated_at_unix: 1,
+        terminal_status: None,
+        terminal_error: None,
+    };
+    let initial_sync = completed_sync_task("sync-task-1", 10);
+    let second_follow_up_sync = completed_sync_task("follow-up-sync-2", 18);
+    let embeddings_task = DevqlTaskRecord {
+        task_id: "bootstrap-task-1".to_string(),
+        repo_id: "repo-1".to_string(),
+        repo_name: "repo".to_string(),
+        repo_provider: "local".to_string(),
+        repo_organisation: "local".to_string(),
+        repo_identity: "repo".to_string(),
+        daemon_config_root: PathBuf::from("/tmp/config-1"),
+        repo_root: PathBuf::from("/tmp/repo-1"),
+        init_session_id: Some("init-session-1".to_string()),
+        kind: DevqlTaskKind::EmbeddingsBootstrap,
+        source: DevqlTaskSource::Init,
+        spec: crate::daemon::DevqlTaskSpec::EmbeddingsBootstrap(EmbeddingsBootstrapTaskSpec {
+            config_path: PathBuf::from("/tmp/config-1/config.toml"),
+            profile_name: "local_code".to_string(),
+            mode: crate::daemon::EmbeddingsBootstrapMode::Local,
+            gateway_url_override: None,
+            api_key_env: None,
+        }),
+        status: DevqlTaskStatus::Completed,
+        submitted_at_unix: 1,
+        started_at_unix: Some(1),
+        updated_at_unix: 20,
+        completed_at_unix: Some(20),
+        queue_position: None,
+        tasks_ahead: None,
+        error: None,
+        progress: crate::daemon::DevqlTaskProgress::EmbeddingsBootstrap(
+            crate::daemon::EmbeddingsBootstrapProgress::default(),
+        ),
+        result: None,
+    };
+    let summary_run = SummaryBootstrapRunRecord {
+        run_id: "summary-task-1".to_string(),
+        repo_id: "repo-1".to_string(),
+        repo_root: PathBuf::from("/tmp/repo-1"),
+        init_session_id: "init-session-1".to_string(),
+        request: SummaryBootstrapRequest {
+            action: SummaryBootstrapAction::ConfigureCloud,
+            message: None,
+            model_name: None,
+            gateway_url_override: None,
+            api_key_env: None,
+        },
+        status: SummaryBootstrapStatus::Completed,
+        progress: SummaryBootstrapProgress::default(),
+        result: None,
+        error: None,
+        submitted_at_unix: 1,
+        started_at_unix: Some(1),
+        updated_at_unix: 12,
+        completed_at_unix: Some(12),
+    };
+
+    assert!(semantic_follow_up_ready_for_sync(
+        &session,
+        Some(&initial_sync),
+        Some(&second_follow_up_sync),
+        Some(&embeddings_task),
+        Some(&summary_run),
+    ));
+
+    record_task_completion_seq(&mut session, &second_follow_up_sync);
+
+    assert_eq!(session.next_completion_seq, 5);
+    assert_eq!(session.follow_up_sync_completion_seq, Some(5));
+    assert!(!semantic_follow_up_ready_for_sync(
+        &session,
+        Some(&initial_sync),
+        Some(&second_follow_up_sync),
+        Some(&embeddings_task),
+        Some(&summary_run),
+    ));
+
+    session.follow_up_sync_terminal = Some(InitSessionTaskTerminalSnapshot {
+        task_id: second_follow_up_sync.task_id.clone(),
+        status: DevqlTaskStatus::Completed,
+        updated_at_unix: second_follow_up_sync.updated_at_unix,
+        completed_at_unix: second_follow_up_sync.completed_at_unix,
+        error: None,
+    });
+    record_task_completion_seq(&mut session, &second_follow_up_sync);
+
+    assert_eq!(session.next_completion_seq, 5);
+    assert_eq!(session.follow_up_sync_completion_seq, Some(5));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Prevent unconfigured architecture role adjudication from blocking enrichment queues.
- Improve context-guidance distillation so it keeps richer tool evidence, filters low-value facts with diagnostics, and targets multi-file guidance more accurately.
- Fix repeated semantic follow-up sync sequencing so init lanes do not stay blocked after later follow-up syncs complete.

## Beginner Explanation

Bitloops runs a lot of background jobs after repo sync, including architecture-role classification, context-guidance generation, embeddings, summaries, and follow-up syncs. Before this change, role-adjudication jobs could sit pending when the required structured-generation slot was not configured. Because those jobs stayed at the front of the queue, other ready work could be stuck behind them.

This branch makes the system skip or complete those unconfigured adjudication jobs instead of letting them block the queue. It also makes context guidance smarter about what evidence it sends to the model, records why weak guidance facts were dropped, and preserves better tool/output excerpts for future sessions.

## Validation

- [X] I ran the relevant tests locally.
- [ ] Linked Jira issue(s) are updated with implementation notes and test results.
- [ ] Final status transitions match the task definition of done.

