### PR TITLE
Cli 1865 ignore non utf 8 files from test harness

### DIFF
--- a/bitloops/src/adapters/languages/cpp/test_support.rs
+++ b/bitloops/src/adapters/languages/cpp/test_support.rs
@@ -42,7 +42,16 @@ fn supports_cpp_test_path(relative_path: &str) -> bool {
     lower.ends_with("_test.cpp")
         || lower.ends_with("_test.cc")
         || lower.ends_with("_test.cxx")
-        || lower.contains("/tests/")
+        || (lower.contains("/tests/") && has_cpp_source_extension(&lower))
+}
+
+fn has_cpp_source_extension(relative_path: &str) -> bool {
+    matches!(
+        Path::new(relative_path)
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some("cc" | "cpp" | "cxx" | "h" | "hh" | "hpp" | "hxx")
+    )
 }
 
 fn discover_cpp_tests_from_source(relative_path: &str, content: &str) -> DiscoveredTestFile {
@@ -106,6 +115,7 @@ mod tests {
     fn cpp_test_support_recognizes_test_paths() {
         assert!(supports_cpp_test_path("tests/user_service_test.cpp"));
         assert!(supports_cpp_test_path("src/module/component_test.cc"));
+        assert!(!supports_cpp_test_path("tests/fixtures/snapshot.png"));
         assert!(!supports_cpp_test_path("src/main.cpp"));
     }
 

--- a/bitloops/src/adapters/languages/java/test_support.rs
+++ b/bitloops/src/adapters/languages/java/test_support.rs
@@ -26,10 +26,11 @@ impl LanguageTestSupport for JavaLanguageTestSupport {
     }
 
     fn supports_path(&self, _absolute_path: &Path, relative_path: &str) -> bool {
-        relative_path.ends_with("Test.java")
-            || relative_path.ends_with("Tests.java")
-            || relative_path.ends_with("IT.java")
-            || relative_path.contains("src/test/java/")
+        relative_path.ends_with(".java")
+            && (relative_path.ends_with("Test.java")
+                || relative_path.ends_with("Tests.java")
+                || relative_path.ends_with("IT.java")
+                || relative_path.contains("src/test/java/"))
     }
 
     fn discover_tests(
@@ -545,6 +546,10 @@ mod tests {
             "src/test/java/com/acme/GreeterSpec.java"
         ));
         assert!(support.supports_path(std::path::Path::new(""), "app/GreeterIT.java"));
+        assert!(!support.supports_path(
+            std::path::Path::new(""),
+            "src/test/java/com/acme/fixtures/snapshot.png"
+        ));
         assert!(!support.supports_path(
             std::path::Path::new(""),
             "src/main/java/com/acme/Greeter.java"

--- a/bitloops/src/adapters/languages/ts_js/test_support.rs
+++ b/bitloops/src/adapters/languages/ts_js/test_support.rs
@@ -57,7 +57,8 @@ impl TypeScriptTestMappingHelper {
     pub(crate) fn supports_path(_absolute_path: &Path, relative_path: &str) -> bool {
         relative_path.ends_with(".test.ts")
             || relative_path.ends_with(".spec.ts")
-            || relative_path.contains("/__tests__/")
+            || (relative_path.contains("/__tests__/")
+                && has_typescript_or_javascript_extension(relative_path))
     }
 
     pub(crate) fn discover_tests(
@@ -308,6 +309,15 @@ fn read_source_file(path: &Path) -> Result<String> {
     fs::read_to_string(path).with_context(|| format!("failed reading test file {}", path.display()))
 }
 
+fn has_typescript_or_javascript_extension(relative_path: &str) -> bool {
+    matches!(
+        Path::new(relative_path)
+            .extension()
+            .and_then(|extension| extension.to_str()),
+        Some("js" | "jsx" | "mjs" | "cjs" | "ts" | "tsx" | "mts" | "cts")
+    )
+}
+
 fn normalize_join(base: &Path, relative: &Path) -> PathBuf {
     let joined = base.join(relative);
     let mut normalized = PathBuf::new();
@@ -328,4 +338,38 @@ fn normalize_join(base: &Path, relative: &Path) -> PathBuf {
 
 fn normalize_rel_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypeScriptTestMappingHelper;
+    use std::path::Path;
+
+    #[test]
+    fn supports_typescript_and_javascript_source_files_in_test_locations() {
+        assert!(TypeScriptTestMappingHelper::supports_path(
+            Path::new(""),
+            "src/__tests__/report.spec.js"
+        ));
+        assert!(TypeScriptTestMappingHelper::supports_path(
+            Path::new(""),
+            "src/__tests__/report.spec.tsx"
+        ));
+        assert!(TypeScriptTestMappingHelper::supports_path(
+            Path::new(""),
+            "tests/report.test.ts"
+        ));
+    }
+
+    #[test]
+    fn rejects_non_source_fixtures_inside_tests_directory() {
+        assert!(!TypeScriptTestMappingHelper::supports_path(
+            Path::new(""),
+            "src/__tests__/fixtures/report.xlsx"
+        ));
+        assert!(!TypeScriptTestMappingHelper::supports_path(
+            Path::new(""),
+            "src/__tests__/fixtures/snapshot.png"
+        ));
+    }
 }

--- a/bitloops/src/capability_packs/test_harness/event_handlers/delta.rs
+++ b/bitloops/src/capability_packs/test_harness/event_handlers/delta.rs
@@ -54,6 +54,9 @@ pub(super) async fn reconcile_delta(
                 discovered_files.push(discovered);
             }
             Err(err) => {
+                if mapping::is_non_utf8_discovery_error(&err) {
+                    continue;
+                }
                 log::warn!(
                     "test_harness current-state reconcile: failed discovering tests for {}: {err}",
                     file.path

--- a/bitloops/src/capability_packs/test_harness/event_handlers/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/event_handlers/tests.rs
@@ -28,6 +28,7 @@ use crate::host::language_adapter::{
 };
 use crate::models::ProductionArtefact;
 use crate::models::TestArtefactCurrentRecord;
+use crate::test_support::log_capture::capture_logs_async;
 
 #[derive(Default)]
 struct NoopWorkplaneGateway;
@@ -82,7 +83,7 @@ impl RelationalGateway for FakeRelationalGateway {
 
 #[derive(Clone)]
 struct FakeLanguageServicesGateway {
-    support: Arc<FakeLanguageTestSupport>,
+    support: Arc<dyn LanguageTestSupport>,
 }
 
 impl LanguageServicesGateway for FakeLanguageServicesGateway {
@@ -95,8 +96,8 @@ impl LanguageServicesGateway for FakeLanguageServicesGateway {
         relative_path: &str,
     ) -> Option<Arc<dyn LanguageTestSupport>> {
         self.support
-            .supports_any(relative_path)
-            .then(|| self.support.clone() as Arc<dyn LanguageTestSupport>)
+            .supports_path(Path::new(relative_path), relative_path)
+            .then(|| self.support.clone())
     }
 }
 
@@ -149,6 +150,34 @@ impl LanguageTestSupport for FakeLanguageTestSupport {
         ReconciledDiscovery {
             enumerated_scenarios: enumeration.scenarios,
         }
+    }
+}
+
+#[derive(Clone)]
+struct InvalidUtf8LanguageTestSupport;
+
+impl LanguageTestSupport for InvalidUtf8LanguageTestSupport {
+    fn language_id(&self) -> &'static str {
+        "fake"
+    }
+
+    fn priority(&self) -> u8 {
+        0
+    }
+
+    fn supports_path(&self, _absolute_path: &Path, relative_path: &str) -> bool {
+        relative_path == "tests/non_utf8.fake"
+    }
+
+    fn discover_tests(
+        &self,
+        _absolute_path: &Path,
+        _relative_path: &str,
+    ) -> Result<DiscoveredTestFile> {
+        Err(anyhow!(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "stream did not contain valid UTF-8",
+        )))
     }
 }
 
@@ -219,6 +248,53 @@ async fn merged_delta_materializes_enumerated_scenarios_only_for_changed_paths()
         )]
     );
     assert_eq!(count_test_edges(fixture.db_path())?, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn merged_delta_silently_ignores_non_utf8_test_files() -> Result<()> {
+    let fixture = TestFixture::new()?;
+    fixture.write_file("tests/non_utf8.fake", "placeholder")?;
+    let context = fixture.context(
+        Arc::new(InvalidUtf8LanguageTestSupport),
+        vec![production_artefact()],
+    )?;
+    let request = CurrentStateConsumerRequest {
+        run_id: None,
+        repo_id: "repo-1".to_string(),
+        repo_root: fixture.repo_root(),
+        active_branch: Some("main".to_string()),
+        head_commit_sha: Some("HEAD".to_string()),
+        from_generation_seq_exclusive: 0,
+        to_generation_seq_inclusive: 1,
+        reconcile_mode: ReconcileMode::MergedDelta,
+        file_upserts: vec![ChangedFile {
+            path: "tests/non_utf8.fake".to_string(),
+            language: "fake".to_string(),
+            content_id: "content-a".to_string(),
+        }],
+        file_removals: Vec::new(),
+        affected_paths: Vec::new(),
+        artefact_upserts: Vec::new(),
+        artefact_removals: Vec::new(),
+    };
+
+    let (result, logs) = capture_logs_async(TestHarnessCurrentStateConsumer.reconcile(
+        &request,
+        &context,
+    ))
+    .await;
+    result?;
+
+    assert!(
+        load_test_scenarios(fixture.db_path())?.is_empty(),
+        "non-UTF-8 delta file should not persist discovered scenarios"
+    );
+    assert!(
+        logs.is_empty(),
+        "non-UTF-8 delta file should not emit warnings: {logs:?}"
+    );
 
     Ok(())
 }
@@ -720,7 +796,7 @@ impl TestFixture {
 
     fn context(
         &self,
-        support: Arc<FakeLanguageTestSupport>,
+        support: Arc<dyn LanguageTestSupport>,
         production: Vec<ProductionArtefact>,
     ) -> Result<CurrentStateConsumerContext> {
         Ok(CurrentStateConsumerContext {

--- a/bitloops/src/capability_packs/test_harness/event_handlers/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/event_handlers/tests.rs
@@ -280,11 +280,8 @@ async fn merged_delta_silently_ignores_non_utf8_test_files() -> Result<()> {
         artefact_removals: Vec::new(),
     };
 
-    let (result, logs) = capture_logs_async(TestHarnessCurrentStateConsumer.reconcile(
-        &request,
-        &context,
-    ))
-    .await;
+    let (result, logs) =
+        capture_logs_async(TestHarnessCurrentStateConsumer.reconcile(&request, &context)).await;
     result?;
 
     assert!(

--- a/bitloops/src/capability_packs/test_harness/mapping.rs
+++ b/bitloops/src/capability_packs/test_harness/mapping.rs
@@ -9,7 +9,9 @@ mod tests;
 
 use std::collections::HashMap;
 use std::fs;
+use std::io::ErrorKind;
 use std::path::Path;
+use std::str::Utf8Error;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
@@ -90,6 +92,9 @@ pub(crate) fn execute_with_existing(
                 discovery_batch.files.push(discovered);
             }
             Err(err) => {
+                if is_non_utf8_discovery_error(&err) {
+                    continue;
+                }
                 record_discovery_issue(
                     &mut discovery_batch,
                     &candidate.relative_path,
@@ -252,6 +257,16 @@ fn find_language_support<'a>(
         .find(|support| support.language_id() == language_id)
         .map(Arc::as_ref)
         .ok_or_else(|| anyhow!("language test support `{language_id}` is not registered"))
+}
+
+pub(crate) fn is_non_utf8_discovery_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io_err| io_err.kind() == ErrorKind::InvalidData)
+            || cause.downcast_ref::<Utf8Error>().is_some()
+            || cause.to_string().contains("valid UTF-8")
+    })
 }
 
 fn record_discovery_issue(batch: &mut TestDiscoveryBatch, path: &str, message: String) {

--- a/bitloops/src/capability_packs/test_harness/mapping/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/mapping/tests.rs
@@ -31,6 +31,7 @@ use super::model::{ReferenceCandidate, ScenarioDiscoverySource};
 use crate::host::capability_host::gateways::LanguageServicesGateway;
 use crate::host::language_adapter::{DiscoveredTestFile, EnumerationResult, LanguageTestSupport};
 use crate::models::ProductionArtefact;
+use crate::test_support::log_capture::capture_logs;
 
 #[test]
 fn extracts_import_specifier_from_statement() {
@@ -1264,7 +1265,7 @@ pub fn evaluate(value: &str) -> bool {
 }
 
 #[test]
-fn execute_records_issue_for_non_utf8_python_test_file_and_continues() {
+fn execute_silently_ignores_non_utf8_python_test_file_and_continues() {
     let temp = TempDir::new().expect("failed creating temp repo");
     let repo_root = temp.path();
     fs::create_dir_all(repo_root.join("tests")).expect("failed creating tests directory");
@@ -1288,8 +1289,10 @@ fn execute_records_issue_for_non_utf8_python_test_file_and_continues() {
     let gateway = SourceOnlyLanguageServicesGateway {
         support: python_test_support(),
     };
-    let output = execute("repo-1", repo_root, "commit-1", &[], &gateway)
-        .expect("mapping execution should degrade non-UTF-8 files");
+    let (output, logs) = capture_logs(|| {
+        execute("repo-1", repo_root, "commit-1", &[], &gateway)
+            .expect("mapping execution should silently ignore non-UTF-8 files")
+    });
 
     assert!(
         output
@@ -1298,12 +1301,117 @@ fn execute_records_issue_for_non_utf8_python_test_file_and_continues() {
             .any(|artefact| artefact.path == "tests/test_good.py"),
         "UTF-8 test file should still be discovered"
     );
-    assert_eq!(output.issues.len(), 1);
-    assert_eq!(output.issues[0].path, "tests/test_big5.py");
     assert!(
-        output.issues[0].message.contains("valid UTF-8"),
-        "issue should preserve the UTF-8 decoding failure: {}",
-        output.issues[0].message
+        !output
+            .test_artefacts
+            .iter()
+            .any(|artefact| artefact.path == "tests/test_big5.py"),
+        "non-UTF-8 file should be ignored"
+    );
+    assert!(output.issues.is_empty(), "non-UTF-8 file should not create issues");
+    assert!(
+        logs.is_empty(),
+        "non-UTF-8 file should not emit discovery warnings: {logs:?}"
+    );
+}
+
+#[test]
+fn execute_ignores_xlsx_fixture_inside_typescript_tests_directory() {
+    let temp = TempDir::new().expect("failed creating temp repo");
+    let repo_root = temp.path();
+    fs::create_dir_all(repo_root.join("backend/bl-output/__tests__/mocks"))
+        .expect("failed creating __tests__ fixture directory");
+    fs::write(
+        repo_root.join("backend/bl-output/__tests__/report.spec.ts"),
+        "describe('report', () => { it('works', () => {}); });\n",
+    )
+    .expect("failed writing TypeScript fixture");
+    fs::write(
+        repo_root.join("backend/bl-output/__tests__/mocks/4.1.BankStatement.xlsx"),
+        [0xff, 0xfe, 0x00, 0x81, 0x82, 0x83],
+    )
+    .expect("failed writing XLSX fixture");
+
+    let gateway = SourceOnlyLanguageServicesGateway {
+        support: ts_js_test_support(),
+    };
+    let (output, logs) = capture_logs(|| {
+        execute("repo-1", repo_root, "commit-1", &[], &gateway)
+            .expect("mapping execution should ignore binary fixtures under __tests__")
+    });
+
+    assert!(
+        output
+            .test_artefacts
+            .iter()
+            .any(|artefact| artefact.path == "backend/bl-output/__tests__/report.spec.ts"),
+        "TypeScript source test file should still be discovered"
+    );
+    assert!(
+        !output
+            .test_artefacts
+            .iter()
+            .any(|artefact| artefact.path.ends_with(".xlsx")),
+        "xlsx fixture should not be discovered as a test file"
+    );
+    assert_eq!(
+        output.stats.files, 1,
+        "xlsx fixture should not count as a discovered file"
+    );
+    assert!(output.issues.is_empty(), "xlsx fixture should not create issues");
+    assert!(
+        logs.is_empty(),
+        "xlsx fixture should not emit discovery warnings: {logs:?}"
+    );
+}
+
+#[test]
+fn execute_ignores_png_fixture_inside_cpp_tests_directory() {
+    let temp = TempDir::new().expect("failed creating temp repo");
+    let repo_root = temp.path();
+    fs::create_dir_all(repo_root.join("src/tests/fixtures"))
+        .expect("failed creating C++ tests directory");
+    fs::write(
+        repo_root.join("src/tests/user_service_test.cpp"),
+        "TEST(UserServiceTest, ReturnsUser) {}\n",
+    )
+    .expect("failed writing C++ source fixture");
+    fs::write(
+        repo_root.join("src/tests/fixtures/snapshot.png"),
+        [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+    )
+    .expect("failed writing PNG fixture");
+
+    let gateway = SourceOnlyLanguageServicesGateway {
+        support: crate::adapters::languages::cpp::test_support::cpp_test_support(),
+    };
+    let (output, logs) = capture_logs(|| {
+        execute("repo-1", repo_root, "commit-1", &[], &gateway)
+            .expect("mapping execution should ignore binary fixtures under /tests/")
+    });
+
+    assert!(
+        output
+            .test_artefacts
+            .iter()
+            .any(|artefact| artefact.path == "src/tests/user_service_test.cpp"),
+        "C++ source test file should still be discovered"
+    );
+    assert!(
+        !output
+            .test_artefacts
+            .iter()
+            .any(|artefact| artefact.path.ends_with(".png")),
+        "png fixture should not be discovered as a test file"
+    );
+    assert_eq!(
+        output.stats.files, 1,
+        "png fixture should not count as a discovered file"
+    );
+    assert!(output.issues.is_empty(), "png fixture should not create issues");
+    assert!(
+        logs.is_empty(),
+        "png fixture should not emit discovery warnings: {logs:?}"
     );
 }
 

--- a/bitloops/src/capability_packs/test_harness/mapping/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/mapping/tests.rs
@@ -1308,7 +1308,10 @@ fn execute_silently_ignores_non_utf8_python_test_file_and_continues() {
             .any(|artefact| artefact.path == "tests/test_big5.py"),
         "non-UTF-8 file should be ignored"
     );
-    assert!(output.issues.is_empty(), "non-UTF-8 file should not create issues");
+    assert!(
+        output.issues.is_empty(),
+        "non-UTF-8 file should not create issues"
+    );
     assert!(
         logs.is_empty(),
         "non-UTF-8 file should not emit discovery warnings: {logs:?}"
@@ -1358,7 +1361,10 @@ fn execute_ignores_xlsx_fixture_inside_typescript_tests_directory() {
         output.stats.files, 1,
         "xlsx fixture should not count as a discovered file"
     );
-    assert!(output.issues.is_empty(), "xlsx fixture should not create issues");
+    assert!(
+        output.issues.is_empty(),
+        "xlsx fixture should not create issues"
+    );
     assert!(
         logs.is_empty(),
         "xlsx fixture should not emit discovery warnings: {logs:?}"
@@ -1408,7 +1414,10 @@ fn execute_ignores_png_fixture_inside_cpp_tests_directory() {
         output.stats.files, 1,
         "png fixture should not count as a discovered file"
     );
-    assert!(output.issues.is_empty(), "png fixture should not create issues");
+    assert!(
+        output.issues.is_empty(),
+        "png fixture should not create issues"
+    );
     assert!(
         logs.is_empty(),
         "png fixture should not emit discovery warnings: {logs:?}"


### PR DESCRIPTION
## Summary

This PR makes `test_harness` silently ignore non-UTF-8 test files instead of warning or recording discovery issues, and tightens a few language test-file matchers so binary fixtures are not treated as source tests.

## What Changed

- Added shared `test_harness` handling for non-UTF-8 / text-decoding discovery failures.
- Updated full structural mapping to silently skip non-UTF-8 test files.
- Updated delta/current-state reconcile to silently skip non-UTF-8 changed test files as well.
- Tightened TS/JS test discovery so `__tests__` only matches JS/TS source extensions.
- Tightened Java test discovery so `src/test/java/...` only matches `.java` files.
- Tightened C++ test discovery so `/tests/` directory matching only applies to C++ source/header extensions.

## Why

We were incorrectly trying to parse binary fixtures such as `.xlsx` and `.png` when they lived under test directories, which produced noisy UTF-8 warnings during `bitloops init` / `test_harness` discovery. These files are not useful to `test_harness` source parsing and should be ignored.

## Validation

- [x] I ran the relevant tests locally.
- [x] Linked Jira issue(s) are updated with implementation notes and test results.
- [x] Final status transitions match the task definition of done.

