### PR TITLE
[codex] Make init choices repo-local

### DIFF
--- a/.bitloopsignore
+++ b/.bitloopsignore
@@ -1,0 +1,1 @@
+third_party/**

--- a/bitloops/src/cli/embeddings/args.rs
+++ b/bitloops/src/cli/embeddings/args.rs
@@ -121,10 +121,12 @@ pub(crate) async fn run_async(args: EmbeddingsArgs) -> Result<()> {
                 let local_plan = prepare_daemon_local_embeddings_profile_install(&config_path)?;
                 local_plan.apply()?;
                 let install_result = async {
-                    set_repo_semantic_embedding_policy(
-                        &settings_local_path(&repo_root),
-                        &RepoSemanticEmbeddingPolicy::enabled_with_profile("local_code"),
-                    )?;
+                    let policy =
+                        RepoSemanticEmbeddingPolicy::enabled_with_profile_preserving_summaries(
+                            "local_code",
+                            &previous_policy,
+                        );
+                    set_repo_semantic_embedding_policy(&settings_local_path(&repo_root), &policy)?;
                     activate_embedding_pipeline_mailboxes(&repo_root, "embeddings_install")
                         .context(
                             "activating semantic clones embedding mailboxes for embeddings install",

--- a/bitloops/src/cli/embeddings/managed/install.rs
+++ b/bitloops/src/cli/embeddings/managed/install.rs
@@ -14,8 +14,8 @@ use std::rc::Rc;
 use crate::config::settings::settings_local_path;
 use crate::config::{
     DaemonEmbeddingsInstallMode, RepoSemanticEmbeddingPolicy, prepare_daemon_embeddings_install,
-    resolve_bound_daemon_config_path_for_repo, resolve_daemon_config_path_for_repo,
-    set_repo_semantic_embedding_policy,
+    repo_semantic_embedding_policy, resolve_bound_daemon_config_path_for_repo,
+    resolve_daemon_config_path_for_repo, set_repo_semantic_embedding_policy,
 };
 
 use super::super::profiles::{embedding_capability_for_config_path, pull_profile_with_config_path};
@@ -180,10 +180,7 @@ pub(crate) fn install_or_bootstrap_embeddings(repo_root: &Path) -> Result<Vec<St
                 .as_deref()
                 .map(|driver| format!(" (driver `{driver}`)"))
                 .unwrap_or_default();
-            set_repo_semantic_embedding_policy(
-                &settings_local_path(repo_root),
-                &RepoSemanticEmbeddingPolicy::enabled_with_profile(&plan.profile_name),
-            )?;
+            enable_repo_embedding_profile_preserving_summaries(repo_root, &plan.profile_name)?;
             return Ok(vec![format!(
                 "Embeddings are already configured via profile `{}`{}; skipped local runtime bootstrap.",
                 plan.profile_name, profile_driver
@@ -198,10 +195,7 @@ pub(crate) fn install_or_bootstrap_embeddings(repo_root: &Path) -> Result<Vec<St
             pull_profile_with_config_path(repo_root, &config_path, &capability, &plan.profile_name);
         return match result {
             Ok(mut lines) => {
-                set_repo_semantic_embedding_policy(
-                    &settings_local_path(repo_root),
-                    &RepoSemanticEmbeddingPolicy::enabled_with_profile(&plan.profile_name),
-                )?;
+                enable_repo_embedding_profile_preserving_summaries(repo_root, &plan.profile_name)?;
                 lines.insert(
                     0,
                     format!(
@@ -227,10 +221,7 @@ pub(crate) fn install_or_bootstrap_embeddings(repo_root: &Path) -> Result<Vec<St
         pull_profile_with_config_path(repo_root, &config_path, &capability, &plan.profile_name);
     match result {
         Ok(mut lines) => {
-            set_repo_semantic_embedding_policy(
-                &settings_local_path(repo_root),
-                &RepoSemanticEmbeddingPolicy::enabled_with_profile(&plan.profile_name),
-            )?;
+            enable_repo_embedding_profile_preserving_summaries(repo_root, &plan.profile_name)?;
             lines.splice(
                 0..0,
                 format_managed_embeddings_runtime_lines(&ensure, Some(&config_path)),
@@ -248,6 +239,18 @@ pub(crate) fn install_or_bootstrap_embeddings(repo_root: &Path) -> Result<Vec<St
             Err(err)
         }
     }
+}
+
+fn enable_repo_embedding_profile_preserving_summaries(
+    repo_root: &Path,
+    profile_name: &str,
+) -> Result<()> {
+    let existing_policy = repo_semantic_embedding_policy(repo_root)?;
+    let policy = RepoSemanticEmbeddingPolicy::enabled_with_profile_preserving_summaries(
+        profile_name,
+        &existing_policy,
+    );
+    set_repo_semantic_embedding_policy(&settings_local_path(repo_root), &policy)
 }
 
 #[allow(dead_code)]

--- a/bitloops/src/cli/embeddings/managed/install.rs
+++ b/bitloops/src/cli/embeddings/managed/install.rs
@@ -13,9 +13,9 @@ use std::rc::Rc;
 
 use crate::config::settings::settings_local_path;
 use crate::config::{
-    DaemonEmbeddingsInstallMode, RepoSemanticEmbeddingPolicy, prepare_daemon_embeddings_install,
-    repo_semantic_embedding_policy, resolve_bound_daemon_config_path_for_repo,
-    resolve_daemon_config_path_for_repo, set_repo_semantic_embedding_policy,
+    RepoSemanticEmbeddingPolicy, prepare_daemon_embeddings_install, repo_semantic_embedding_policy,
+    resolve_bound_daemon_config_path_for_repo, resolve_daemon_config_path_for_repo,
+    set_repo_semantic_embedding_policy,
 };
 
 use super::super::profiles::{embedding_capability_for_config_path, pull_profile_with_config_path};
@@ -172,48 +172,6 @@ pub(crate) fn install_or_bootstrap_embeddings(repo_root: &Path) -> Result<Vec<St
     let config_path = resolve_bound_daemon_config_path_for_repo(repo_root)
         .or_else(|_| resolve_daemon_config_path_for_repo(repo_root))?;
     let plan = prepare_daemon_embeddings_install(&config_path)?;
-
-    match plan.mode {
-        DaemonEmbeddingsInstallMode::SkipHosted => {
-            let profile_driver = plan
-                .profile_driver
-                .as_deref()
-                .map(|driver| format!(" (driver `{driver}`)"))
-                .unwrap_or_default();
-            enable_repo_embedding_profile_preserving_summaries(repo_root, &plan.profile_name)?;
-            return Ok(vec![format!(
-                "Embeddings are already configured via profile `{}`{}; skipped local runtime bootstrap.",
-                plan.profile_name, profile_driver
-            )]);
-        }
-        DaemonEmbeddingsInstallMode::WarmExisting | DaemonEmbeddingsInstallMode::Bootstrap => {}
-    }
-
-    if matches!(plan.mode, DaemonEmbeddingsInstallMode::WarmExisting) {
-        let capability = embedding_capability_for_config_path(&config_path)?;
-        let result =
-            pull_profile_with_config_path(repo_root, &config_path, &capability, &plan.profile_name);
-        return match result {
-            Ok(mut lines) => {
-                enable_repo_embedding_profile_preserving_summaries(repo_root, &plan.profile_name)?;
-                lines.insert(
-                    0,
-                    format!(
-                        "Embeddings already configured via profile `{}`; warming local cache.",
-                        plan.profile_name
-                    ),
-                );
-                Ok(lines)
-            }
-            Err(err) => {
-                if plan.config_modified {
-                    plan.rollback()?;
-                }
-                Err(err)
-            }
-        };
-    }
-
     let ensure = ensure_managed_embeddings_runtime_with_progress(repo_root, None, |_| Ok(()))?;
     plan.apply_with_managed_runtime_path(&ensure.install.binary_path)?;
     let capability = embedding_capability_for_config_path(&config_path)?;

--- a/bitloops/src/cli/embeddings/managed/platform.rs
+++ b/bitloops/src/cli/embeddings/managed/platform.rs
@@ -16,8 +16,8 @@ use toml_edit::{DocumentMut, Item};
 use crate::config::settings::settings_local_path;
 use crate::config::{
     RepoSemanticEmbeddingPolicy, prepare_daemon_platform_embeddings_install,
-    resolve_bound_daemon_config_path_for_repo, resolve_daemon_config_path_for_repo,
-    set_repo_semantic_embedding_policy,
+    repo_semantic_embedding_policy, resolve_bound_daemon_config_path_for_repo,
+    resolve_daemon_config_path_for_repo, set_repo_semantic_embedding_policy,
 };
 use crate::host::inference::BITLOOPS_PLATFORM_EMBEDDINGS_RUNTIME_ID;
 use crate::utils::platform_dirs::bitloops_data_dir;
@@ -107,10 +107,7 @@ pub(crate) fn install_or_configure_platform_embeddings(
     let apply_result = plan.apply_with_managed_runtime_path(&install.binary_path);
     match apply_result {
         Ok(()) => {
-            set_repo_semantic_embedding_policy(
-                &settings_local_path(repo_root),
-                &RepoSemanticEmbeddingPolicy::enabled_with_profile(&plan.profile_name),
-            )?;
+            enable_repo_embedding_profile_preserving_summaries(repo_root, &plan.profile_name)?;
             let mut lines = vec![format!(
                 "Configured platform embeddings in {}.",
                 config_path.display()
@@ -134,6 +131,18 @@ pub(crate) fn install_or_configure_platform_embeddings(
             Err(err)
         }
     }
+}
+
+fn enable_repo_embedding_profile_preserving_summaries(
+    repo_root: &Path,
+    profile_name: &str,
+) -> Result<()> {
+    let existing_policy = repo_semantic_embedding_policy(repo_root)?;
+    let policy = RepoSemanticEmbeddingPolicy::enabled_with_profile_preserving_summaries(
+        profile_name,
+        &existing_policy,
+    );
+    set_repo_semantic_embedding_policy(&settings_local_path(repo_root), &policy)
 }
 
 pub(crate) fn managed_platform_runtime_version_for_command(

--- a/bitloops/src/cli/embeddings/profiles.rs
+++ b/bitloops/src/cli/embeddings/profiles.rs
@@ -7,7 +7,8 @@ use std::path::{Path, PathBuf};
 use crate::config::BITLOOPS_CONFIG_RELATIVE_PATH;
 use crate::config::unified_config::resolve_embedding_capability_from_unified;
 use crate::config::{
-    EmbeddingCapabilityConfig, EmbeddingProfileConfig, InferenceTask, load_daemon_settings,
+    EmbeddingCapabilityConfig, EmbeddingProfileConfig, InferenceTask, SemanticCloneEmbeddingMode,
+    load_daemon_settings, repo_semantic_embedding_policy,
     resolve_bound_daemon_config_path_for_repo, resolve_daemon_config_path_for_repo,
     resolve_embedding_capability_config_for_repo,
 };
@@ -57,20 +58,22 @@ pub(crate) fn inspect_embeddings_install_state(repo_root: &Path) -> EmbeddingsIn
         return EmbeddingsInstallState::NotConfigured;
     }
     let capability = resolve_embedding_capability_config_for_repo(repo_root);
-    let Some(profile_name) = selected_inference_profile_name(&capability).map(ToOwned::to_owned)
-    else {
+    let Some(profile_name) = selected_repo_embedding_profile_name(repo_root) else {
         return EmbeddingsInstallState::NotConfigured;
     };
-    let kind = capability
-        .inference
-        .profiles
-        .get(&profile_name)
-        .map(|profile| profile.driver.clone());
-    let runtime = capability
-        .inference
-        .profiles
-        .get(&profile_name)
-        .and_then(|profile| profile.runtime.clone());
+    let Some(profile) = capability.inference.profiles.get(&profile_name) else {
+        return EmbeddingsInstallState::NotConfigured;
+    };
+    let kind = Some(profile.driver.clone());
+    let runtime = profile.runtime.clone();
+    if kind.as_deref() == Some(BITLOOPS_EMBEDDINGS_IPC_DRIVER) {
+        let Some(runtime_name) = runtime.as_deref() else {
+            return EmbeddingsInstallState::NotConfigured;
+        };
+        if !capability.inference.runtimes.contains_key(runtime_name) {
+            return EmbeddingsInstallState::NotConfigured;
+        }
+    }
     if kind.as_deref() == Some(BITLOOPS_EMBEDDINGS_IPC_DRIVER)
         && runtime.as_deref() == Some(BITLOOPS_LOCAL_EMBEDDINGS_RUNTIME_ID)
     {
@@ -82,6 +85,29 @@ pub(crate) fn inspect_embeddings_install_state(repo_root: &Path) -> EmbeddingsIn
     } else {
         EmbeddingsInstallState::ConfiguredNonLocal { profile_name, kind }
     }
+}
+
+fn selected_repo_embedding_profile_name(repo_root: &Path) -> Option<String> {
+    let policy = repo_semantic_embedding_policy(repo_root).ok()?;
+    if policy.embedding_mode == Some(SemanticCloneEmbeddingMode::Off) {
+        return None;
+    }
+    policy
+        .inference
+        .code_embeddings
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            policy
+                .inference
+                .summary_embeddings
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
 }
 
 #[cfg(test)]

--- a/bitloops/src/cli/embeddings/tests.rs
+++ b/bitloops/src/cli/embeddings/tests.rs
@@ -99,9 +99,21 @@ task = "embeddings"
 driver = "openai"
 model = "text-embedding-3-large"
 api_key = "secret"
-"#,
+	"#,
     )
     .expect("write config");
+    fs::write(
+        repo_root.join(REPO_POLICY_LOCAL_FILE_NAME),
+        r#"
+[semantic_clones]
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+code_embeddings = "local"
+summary_embeddings = "local"
+"#,
+    )
+    .expect("write repo semantic policy");
 }
 
 fn seed_repo() -> TempDir {
@@ -855,7 +867,7 @@ fn install_or_bootstrap_embeddings_writes_local_profile_and_warms_runtime() {
             assert!(!config.contains("code_embeddings = \"local_code\""));
             assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
             assert!(repo_policy.contains("code_embeddings = \"local_code\""));
-            assert!(repo_policy.contains("summary_embeddings = \"local_code\""));
+            assert!(!repo_policy.contains("summary_embeddings = "));
             assert!(config.contains("[inference.profiles.local_code]"));
             assert!(config.contains("driver = \"bitloops_embeddings_ipc\""));
             assert!(
@@ -944,7 +956,7 @@ summary_generation = "summary_local"
             assert!(repo_policy.contains("summary_generation = \"summary_local\""));
             assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
             assert!(repo_policy.contains("code_embeddings = \"local_code\""));
-            assert!(repo_policy.contains("summary_embeddings = \"local_code\""));
+            assert!(!repo_policy.contains("summary_embeddings = "));
         },
     );
 }
@@ -1108,7 +1120,7 @@ fn install_or_configure_platform_embeddings_persists_repo_policy() {
             assert!(!config.contains("code_embeddings = \"platform_code\""));
             assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
             assert!(repo_policy.contains("code_embeddings = \"platform_code\""));
-            assert!(repo_policy.contains("summary_embeddings = \"platform_code\""));
+            assert!(!repo_policy.contains("summary_embeddings = "));
         },
     );
 }
@@ -1162,7 +1174,7 @@ summary_generation = "summary_llm"
             assert!(repo_policy.contains("summary_generation = \"summary_llm\""));
             assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
             assert!(repo_policy.contains("code_embeddings = \"platform_code\""));
-            assert!(repo_policy.contains("summary_embeddings = \"platform_code\""));
+            assert!(!repo_policy.contains("summary_embeddings = "));
         },
     );
 }
@@ -1366,7 +1378,7 @@ model = "bge-m3"
                                 .expect("read local repo policy");
                         assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
                         assert!(repo_policy.contains("code_embeddings = \"local_code\""));
-                        assert!(repo_policy.contains("summary_embeddings = \"local_code\""));
+                        assert!(!repo_policy.contains("summary_embeddings = "));
 
                         let daemon_config =
                             fs::read_to_string(repo.path().join(BITLOOPS_CONFIG_RELATIVE_PATH))
@@ -1532,8 +1544,9 @@ fn install_or_bootstrap_embeddings_rolls_back_when_runtime_bootstrap_fails() {
 }
 
 #[test]
-fn install_or_bootstrap_embeddings_preserves_existing_hosted_profile() {
+fn install_or_bootstrap_embeddings_preserves_hosted_profile_but_ignores_daemon_binding() {
     let repo = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("data tempdir");
     crate::test_support::git_fixtures::init_test_repo(
         repo.path(),
         "main",
@@ -1557,18 +1570,48 @@ model = "text-embedding-3-large"
 "#,
     )
     .expect("write hosted config");
-    let original = fs::read_to_string(&config_path).expect("read original config");
+    let data_root = data.path().to_string_lossy().to_string();
+    let _guard = enter_process_state(
+        Some(repo.path()),
+        &[("BITLOOPS_TEST_DATA_DIR_OVERRIDE", Some(data_root.as_str()))],
+    );
 
-    let lines =
-        install_or_bootstrap_embeddings(repo.path()).expect("existing hosted profile result");
-    let after = fs::read_to_string(&config_path).expect("read final config");
+    with_managed_embeddings_install_hook(
+        move |repo_root| {
+            Ok(ManagedEmbeddingsBinaryInstallOutcome {
+                version: TEST_MANAGED_EMBEDDINGS_VERSION.to_string(),
+                binary_path: fake_managed_runtime_path(repo_root),
+                freshly_installed: true,
+            })
+        },
+        || {
+            let lines =
+                install_or_bootstrap_embeddings(repo.path()).expect("managed bootstrap result");
+            let after = fs::read_to_string(&config_path).expect("read final config");
+            let repo_policy = fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+                .expect("read local repo policy");
 
-    assert_eq!(after, original);
-    assert!(
-        lines
-            .iter()
-            .any(|line| line.contains("skipped local runtime bootstrap")),
-        "expected hosted skip line, got: {lines:?}"
+            assert!(
+                after.contains("[inference.profiles.openai]"),
+                "expected hosted profile to remain registered:\n{after}"
+            );
+            assert!(
+                after.contains("[inference.profiles.local_code]"),
+                "expected local profile to be registered:\n{after}"
+            );
+            assert!(
+                !after.contains("[semantic_clones"),
+                "expected daemon semantic bindings to be stripped:\n{after}"
+            );
+            assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
+            assert!(repo_policy.contains("code_embeddings = \"local_code\""));
+            assert!(
+                lines
+                    .iter()
+                    .any(|line| line.contains("Configured embeddings")),
+                "expected configured embeddings line, got: {lines:?}"
+            );
+        },
     );
 }
 

--- a/bitloops/src/cli/embeddings/tests.rs
+++ b/bitloops/src/cli/embeddings/tests.rs
@@ -898,6 +898,58 @@ fn install_or_bootstrap_embeddings_writes_local_profile_and_warms_runtime() {
 }
 
 #[test]
+fn install_or_bootstrap_embeddings_preserves_existing_summary_policy() {
+    let repo = TempDir::new().expect("tempdir");
+    let data = TempDir::new().expect("data tempdir");
+    crate::test_support::git_fixtures::init_test_repo(
+        repo.path(),
+        "main",
+        "Alice",
+        "alice@example.com",
+    );
+    write_runtime_only_config(repo.path(), "bitloops-local-embeddings", &[]);
+    fs::write(
+        repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+        r#"
+[semantic_clones]
+summary_mode = "off"
+embedding_mode = "off"
+
+[semantic_clones.inference]
+summary_generation = "summary_local"
+"#,
+    )
+    .expect("write local summary policy");
+    let data_root = data.path().to_string_lossy().to_string();
+    let _guard = enter_process_state(
+        Some(repo.path()),
+        &[("BITLOOPS_TEST_DATA_DIR_OVERRIDE", Some(data_root.as_str()))],
+    );
+
+    with_managed_embeddings_install_hook(
+        move |repo_root| {
+            Ok(ManagedEmbeddingsBinaryInstallOutcome {
+                version: TEST_MANAGED_EMBEDDINGS_VERSION.to_string(),
+                binary_path: fake_managed_runtime_path(repo_root),
+                freshly_installed: true,
+            })
+        },
+        || {
+            install_or_bootstrap_embeddings(repo.path())
+                .expect("install embeddings via managed runtime");
+            let repo_policy = fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+                .expect("read local repo policy");
+
+            assert!(repo_policy.contains("summary_mode = \"off\""));
+            assert!(repo_policy.contains("summary_generation = \"summary_local\""));
+            assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
+            assert!(repo_policy.contains("code_embeddings = \"local_code\""));
+            assert!(repo_policy.contains("summary_embeddings = \"local_code\""));
+        },
+    );
+}
+
+#[test]
 fn install_or_bootstrap_embeddings_uses_repo_bound_daemon_config() {
     let repo = TempDir::new().expect("tempdir");
     let app_dirs = TempDir::new().expect("app tempdir");
@@ -1054,6 +1106,60 @@ fn install_or_configure_platform_embeddings_persists_repo_policy() {
                 .expect("read local repo policy");
 
             assert!(!config.contains("code_embeddings = \"platform_code\""));
+            assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
+            assert!(repo_policy.contains("code_embeddings = \"platform_code\""));
+            assert!(repo_policy.contains("summary_embeddings = \"platform_code\""));
+        },
+    );
+}
+
+#[test]
+fn install_or_configure_platform_embeddings_preserves_existing_summary_policy() {
+    let repo = TempDir::new().expect("tempdir");
+    crate::test_support::git_fixtures::init_test_repo(
+        repo.path(),
+        "main",
+        "Alice",
+        "alice@example.com",
+    );
+    write_runtime_only_config(repo.path(), "bitloops-platform-embeddings", &[]);
+    fs::write(
+        repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+        r#"
+[semantic_clones]
+summary_mode = "auto"
+embedding_mode = "off"
+
+[semantic_clones.inference]
+summary_generation = "summary_llm"
+"#,
+    )
+    .expect("write local summary policy");
+
+    with_managed_platform_embeddings_install_hook(
+        {
+            let repo_root = repo.path().to_path_buf();
+            move || {
+                Ok(ManagedPlatformEmbeddingsBinaryInstallOutcome {
+                    version: TEST_MANAGED_EMBEDDINGS_VERSION.to_string(),
+                    binary_path: repo_root.join(".bitloops/test-bin/bitloops-platform-embeddings"),
+                    freshly_installed: true,
+                })
+            }
+        },
+        || {
+            install_or_configure_platform_embeddings(
+                repo.path(),
+                Some("https://gateway.example/v1/embeddings"),
+                "BITLOOPS_PLATFORM_GATEWAY_TOKEN",
+            )
+            .expect("install platform embeddings");
+
+            let repo_policy = fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+                .expect("read local repo policy");
+
+            assert!(repo_policy.contains("summary_mode = \"auto\""));
+            assert!(repo_policy.contains("summary_generation = \"summary_llm\""));
             assert!(repo_policy.contains("embedding_mode = \"semantic_aware_once\""));
             assert!(repo_policy.contains("code_embeddings = \"platform_code\""));
             assert!(repo_policy.contains("summary_embeddings = \"platform_code\""));

--- a/bitloops/src/cli/inference/setup/profiles.rs
+++ b/bitloops/src/cli/inference/setup/profiles.rs
@@ -3,9 +3,12 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use toml_edit::{DocumentMut, Item, Table};
 
+use crate::config::settings::settings_local_path;
 use crate::config::{
-    BITLOOPS_CONFIG_RELATIVE_PATH, InferenceTask, SemanticSummaryMode,
+    InferenceTask, RepoSemanticEmbeddingPolicy, SemanticClonesInferenceBindings,
+    SemanticSummaryMode, repo_semantic_embedding_policy,
     resolve_inference_capability_config_for_repo, resolve_preferred_daemon_config_path_for_repo,
+    set_repo_semantic_embedding_policy,
 };
 use crate::host::inference::{BITLOOPS_INFERENCE_RUNTIME_ID, BITLOOPS_PLATFORM_CHAT_DRIVER};
 
@@ -252,9 +255,8 @@ pub(super) fn write_summary_profile(repo_root: &Path, model_name: &str) -> Resul
         profile.remove("cache_dir");
     }
 
-    update_summary_generation_binding(&mut doc, &profile_name);
     write_daemon_config_document(&config_path, &doc)?;
-    maybe_sync_repo_local_summary_mode(repo_root, "auto")
+    write_repo_summary_generation_binding(repo_root, &profile_name)
 }
 
 pub(super) fn write_context_guidance_profile(repo_root: &Path, model_name: &str) -> Result<()> {
@@ -340,9 +342,8 @@ fn write_platform_summary_profile_with_api_key(
         profile.remove("cache_dir");
     }
 
-    update_summary_generation_binding(&mut doc, &profile_name);
     write_daemon_config_document(&config_path, &doc)?;
-    maybe_sync_repo_local_summary_mode(repo_root, "auto")
+    write_repo_summary_generation_binding(repo_root, &profile_name)
 }
 
 pub(super) fn write_platform_context_guidance_profile(
@@ -569,31 +570,57 @@ fn write_daemon_config_document(config_path: &Path, doc: &DocumentMut) -> Result
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating Bitloops config directory {}", parent.display()))?;
     }
+    let mut doc = doc.clone();
+    strip_daemon_semantic_enablement(&mut doc);
     std::fs::write(config_path, doc.to_string())
         .with_context(|| format!("writing Bitloops daemon config {}", config_path.display()))
 }
 
-fn maybe_sync_repo_local_summary_mode(repo_root: &Path, mode: &str) -> Result<()> {
-    let repo_config_path = repo_root.join(BITLOOPS_CONFIG_RELATIVE_PATH);
-    if !repo_config_path.exists() {
-        return Ok(());
+fn strip_daemon_semantic_enablement(doc: &mut DocumentMut) {
+    let Some(semantic_item) = doc.as_table_mut().get_mut("semantic_clones") else {
+        return;
+    };
+    let Some(semantic) = semantic_item.as_table_mut() else {
+        return;
+    };
+
+    for key in ["summary_mode", "embedding_mode"] {
+        semantic.remove(key);
     }
-    write_summary_mode(&repo_config_path, mode)
-}
-
-fn write_summary_mode(config_path: &Path, mode: &str) -> Result<()> {
-    let mut doc = read_daemon_config_document(config_path)?;
-    let semantic_clones = ensure_table(&mut doc, "semantic_clones");
-    semantic_clones["summary_mode"] = Item::Value(mode.into());
-    write_daemon_config_document(config_path, &doc)
-}
-
-fn update_summary_generation_binding(doc: &mut DocumentMut, profile_name: &str) {
+    if let Some(inference) = semantic.get_mut("inference").and_then(Item::as_table_mut) {
+        for key in [
+            "summary_generation",
+            "code_embeddings",
+            "summary_embeddings",
+        ] {
+            inference.remove(key);
+        }
+    }
+    if semantic
+        .get("inference")
+        .and_then(Item::as_table)
+        .is_some_and(Table::is_empty)
     {
-        let semantic_clones = ensure_table(doc, "semantic_clones");
-        semantic_clones["summary_mode"] = Item::Value("auto".into());
+        semantic.remove("inference");
     }
-    update_text_generation_binding(doc, "semantic_clones", "summary_generation", profile_name);
+    if semantic.is_empty() {
+        doc.as_table_mut().remove("semantic_clones");
+    }
+}
+
+fn write_repo_summary_generation_binding(repo_root: &Path, profile_name: &str) -> Result<()> {
+    let existing_policy = repo_semantic_embedding_policy(repo_root)?;
+    let policy = RepoSemanticEmbeddingPolicy {
+        present: true,
+        summary_mode: Some(SemanticSummaryMode::Auto),
+        embedding_mode: existing_policy.embedding_mode,
+        inference: SemanticClonesInferenceBindings {
+            summary_generation: Some(profile_name.to_string()),
+            code_embeddings: existing_policy.inference.code_embeddings,
+            summary_embeddings: existing_policy.inference.summary_embeddings,
+        },
+    };
+    set_repo_semantic_embedding_policy(&settings_local_path(repo_root), &policy)
 }
 
 fn update_context_guidance_generation_binding(doc: &mut DocumentMut, profile_name: &str) {

--- a/bitloops/src/cli/inference/tests.rs
+++ b/bitloops/src/cli/inference/tests.rs
@@ -17,7 +17,10 @@ use crate::cli::inference::{
     summary_generation_configured, with_managed_inference_install_hook, with_ollama_probe_hook,
 };
 use crate::cli::terminal_picker::with_single_select_hook;
-use crate::config::{BITLOOPS_CONFIG_RELATIVE_PATH, resolve_inference_capability_config_for_repo};
+use crate::config::{
+    BITLOOPS_CONFIG_RELATIVE_PATH, REPO_POLICY_LOCAL_FILE_NAME,
+    resolve_inference_capability_config_for_repo,
+};
 
 #[test]
 fn cloud_bitloops_inference_setup_configures_all_generation_slots() {
@@ -56,12 +59,23 @@ fn cloud_bitloops_inference_setup_configures_all_generation_slots() {
 
     let rendered = std::fs::read_to_string(repo_root.join(BITLOOPS_CONFIG_RELATIVE_PATH))
         .expect("read config");
-    assert!(rendered.contains("summary_generation = \"summary_llm\""));
+    assert!(
+        !rendered.contains("summary_generation = \"summary_llm\""),
+        "semantic summary binding should be repo-local:\n{rendered}"
+    );
     assert!(rendered.contains("guidance_generation = \"guidance_llm\""));
     assert!(rendered.contains("fact_synthesis = \"architecture_fact_synthesis\""));
     assert!(rendered.contains("role_adjudication = \"architecture_role_adjudication\""));
     assert!(rendered.contains("task = \"structured_generation\""));
     assert!(rendered.contains("max_output_tokens = 1024"));
+    let repo_policy =
+        std::fs::read_to_string(repo_root.join(REPO_POLICY_LOCAL_FILE_NAME)).expect("read policy");
+    assert!(repo_policy.contains("summary_mode = \"auto\""));
+    assert!(repo_policy.contains("summary_generation = \"summary_llm\""));
+    assert!(
+        !repo_policy.contains("embedding_mode = "),
+        "summary setup should not write embedding choices:\n{repo_policy}"
+    );
 }
 
 #[test]
@@ -108,12 +122,19 @@ fn local_bitloops_inference_setup_configures_all_generation_slots() {
 
     let rendered = std::fs::read_to_string(repo_root.join(BITLOOPS_CONFIG_RELATIVE_PATH))
         .expect("read config");
-    assert!(rendered.contains("summary_generation = \"summary_local\""));
+    assert!(
+        !rendered.contains("summary_generation = \"summary_local\""),
+        "semantic summary binding should be repo-local:\n{rendered}"
+    );
     assert!(rendered.contains("guidance_generation = \"guidance_local\""));
     assert!(rendered.contains("fact_synthesis = \"architecture_fact_synthesis_local\""));
     assert!(rendered.contains("role_adjudication = \"architecture_role_adjudication_local\""));
     assert!(rendered.contains("driver = \"ollama_chat\""));
     assert!(rendered.contains("base_url = \"http://127.0.0.1:11434/api/chat\""));
+    let repo_policy =
+        std::fs::read_to_string(repo_root.join(REPO_POLICY_LOCAL_FILE_NAME)).expect("read policy");
+    assert!(repo_policy.contains("summary_mode = \"auto\""));
+    assert!(repo_policy.contains("summary_generation = \"summary_local\""));
 }
 
 #[test]
@@ -362,7 +383,10 @@ fn summary_setup_can_write_platform_profile() {
     assert!(summary_generation_configured(&repo_root));
 
     let rendered = std::fs::read_to_string(&config_path).expect("read config");
-    assert!(rendered.contains("summary_generation = \"summary_llm\""));
+    assert!(
+        !rendered.contains("[semantic_clones"),
+        "daemon config should only hold summary profile/runtime definitions:\n{rendered}"
+    );
     assert!(rendered.contains("[inference.runtimes.bitloops_inference]"));
     assert!(rendered.contains(&format!(
         "command = \"{}\"",
@@ -376,6 +400,11 @@ fn summary_setup_can_write_platform_profile() {
     assert!(rendered.contains("api_key = \"${BITLOOPS_PLATFORM_GATEWAY_TOKEN}\""));
     assert!(rendered.contains("max_output_tokens = 200"));
     assert!(!rendered.contains("base_url = "));
+
+    let repo_policy =
+        std::fs::read_to_string(repo_root.join(REPO_POLICY_LOCAL_FILE_NAME)).expect("read policy");
+    assert!(repo_policy.contains("summary_mode = \"auto\""));
+    assert!(repo_policy.contains("summary_generation = \"summary_llm\""));
 }
 
 #[test]
@@ -462,14 +491,15 @@ fn summary_setup_reenables_summary_mode_after_off_opt_out() {
     let config_path = repo_root.join(BITLOOPS_CONFIG_RELATIVE_PATH);
     std::fs::create_dir_all(config_path.parent().expect("config parent"))
         .expect("create config parent");
+    std::fs::write(&config_path, "").expect("write config");
     std::fs::write(
-        &config_path,
+        repo_root.join(REPO_POLICY_LOCAL_FILE_NAME),
         r#"
 [semantic_clones]
 summary_mode = "off"
 "#,
     )
-    .expect("write config");
+    .expect("write policy");
     let install_root = repo_root.clone();
     let configure_root = repo_root.clone();
 
@@ -490,8 +520,14 @@ summary_mode = "off"
     assert!(summary_generation_configured(&repo_root));
 
     let rendered = std::fs::read_to_string(&config_path).expect("read config");
-    assert!(rendered.contains("summary_mode = \"auto\""));
-    assert!(rendered.contains("summary_generation = \"summary_llm\""));
+    assert!(
+        !rendered.contains("[semantic_clones"),
+        "daemon config should not hold summary enablement:\n{rendered}"
+    );
+    let repo_policy =
+        std::fs::read_to_string(repo_root.join(REPO_POLICY_LOCAL_FILE_NAME)).expect("read policy");
+    assert!(repo_policy.contains("summary_mode = \"auto\""));
+    assert!(repo_policy.contains("summary_generation = \"summary_llm\""));
 }
 
 #[test]
@@ -583,12 +619,19 @@ fn cloud_summary_setup_prepared_plan_reports_progress_and_writes_profile() {
     assert!(summary_generation_configured(&repo_root));
 
     let rendered = std::fs::read_to_string(&config_path).expect("read config");
-    assert!(rendered.contains("summary_generation = \"summary_llm\""));
+    assert!(
+        !rendered.contains("[semantic_clones"),
+        "daemon config should not hold summary enablement:\n{rendered}"
+    );
     assert!(rendered.contains("driver = \"bitloops_platform_chat\""));
     assert!(rendered.contains("model = \"ministral-3-3b-instruct\""));
     assert!(rendered.contains("api_key = \"${BITLOOPS_PLATFORM_GATEWAY_TOKEN}\""));
     assert!(rendered.contains("max_output_tokens = 200"));
     assert!(rendered.contains("base_url = \"https://platform.example.com/v1/chat/completions\""));
+    let repo_policy =
+        std::fs::read_to_string(repo_root.join(REPO_POLICY_LOCAL_FILE_NAME)).expect("read policy");
+    assert!(repo_policy.contains("summary_mode = \"auto\""));
+    assert!(repo_policy.contains("summary_generation = \"summary_llm\""));
 }
 
 #[test]
@@ -884,11 +927,14 @@ max_output_tokens = 200
     let doc = rendered
         .parse::<DocumentMut>()
         .expect("parse updated config");
-    let summary_generation = doc["semantic_clones"]["inference"]["summary_generation"]
-        .as_value()
-        .and_then(|value| value.as_str())
-        .expect("summary generation binding");
-    assert_eq!(summary_generation, "summary_local_1");
+    assert!(
+        doc.get("semantic_clones").is_none(),
+        "daemon config should not hold summary enablement:\n{rendered}"
+    );
+    let repo_policy =
+        std::fs::read_to_string(repo_root.join(REPO_POLICY_LOCAL_FILE_NAME)).expect("read policy");
+    assert!(repo_policy.contains("summary_mode = \"auto\""));
+    assert!(repo_policy.contains("summary_generation = \"summary_local_1\""));
 
     let legacy_profile = doc["inference"]["profiles"]["summary_local"]
         .as_table()
@@ -1025,7 +1071,7 @@ max_output_tokens = 200
     );
     assert!(
         summary_generation_configured(&repo_root),
-        "summary generation should resolve from the bound daemon config"
+        "summary generation should resolve from repo policy plus bound daemon profiles"
     );
 
     let capability = resolve_inference_capability_config_for_repo(&repo_root);
@@ -1036,18 +1082,16 @@ max_output_tokens = 200
             .summary_generation
             .as_deref(),
         Some("summary_local"),
-        "capability resolution should prefer the bound daemon config"
+        "capability resolution should use the repo policy binding"
     );
 
     let bound_rendered = std::fs::read_to_string(&bound_config_path).expect("read bound config");
     let bound_doc = bound_rendered
         .parse::<DocumentMut>()
         .expect("parse bound config");
-    assert_eq!(
-        bound_doc["semantic_clones"]["inference"]["summary_generation"]
-            .as_value()
-            .and_then(|value| value.as_str()),
-        Some("summary_local")
+    assert!(
+        bound_doc.get("semantic_clones").is_none(),
+        "bound daemon config should not hold summary enablement:\n{bound_rendered}"
     );
     assert_eq!(
         bound_doc["inference"]["profiles"]["summary_local"]["runtime"]
@@ -1055,6 +1099,11 @@ max_output_tokens = 200
             .and_then(|value| value.as_str()),
         Some("bitloops_inference")
     );
+
+    let repo_policy =
+        std::fs::read_to_string(repo_root.join(REPO_POLICY_LOCAL_FILE_NAME)).expect("read policy");
+    assert!(repo_policy.contains("summary_mode = \"auto\""));
+    assert!(repo_policy.contains("summary_generation = \"summary_local\""));
 
     let local_rendered = std::fs::read_to_string(&local_config_path).expect("read local config");
     assert!(

--- a/bitloops/src/cli/init.rs
+++ b/bitloops/src/cli/init.rs
@@ -42,8 +42,6 @@ pub(super) use embeddings_setup::prompt_install_embeddings_setup_selection;
 pub(super) use embeddings_setup::{
     InitEmbeddingsSetupSelection, should_install_embeddings_during_init,
 };
-#[cfg(test)]
-pub(super) use final_setup::InitFinalSetupSelection;
 pub(super) use final_setup::{InitFinalSetupPromptOptions, choose_final_setup_options};
 pub(super) use repo_excludes::ensure_repo_init_files_excluded;
 pub(crate) use repo_excludes::{

--- a/bitloops/src/cli/init/embeddings_setup.rs
+++ b/bitloops/src/cli/init/embeddings_setup.rs
@@ -29,7 +29,7 @@ pub(crate) fn should_install_embeddings_during_init(
     out: &mut dyn Write,
     input: &mut dyn BufRead,
 ) -> Result<InitEmbeddingsSetupSelection> {
-    if args.no_embeddings || !repo_selected_embedding_lanes {
+    if args.no_embeddings {
         return Ok(InitEmbeddingsSetupSelection::Skip);
     }
 
@@ -38,6 +38,10 @@ pub(crate) fn should_install_embeddings_during_init(
             EmbeddingsRuntime::Local => InitEmbeddingsSetupSelection::Local,
             EmbeddingsRuntime::Platform => InitEmbeddingsSetupSelection::Cloud,
         });
+    }
+
+    if !repo_selected_embedding_lanes {
+        return Ok(InitEmbeddingsSetupSelection::Skip);
     }
 
     if !matches!(

--- a/bitloops/src/cli/init/embeddings_setup.rs
+++ b/bitloops/src/cli/init/embeddings_setup.rs
@@ -25,10 +25,11 @@ pub(crate) enum InitEmbeddingsSetupSelection {
 pub(crate) fn should_install_embeddings_during_init(
     repo_root: &Path,
     args: &InitArgs,
+    repo_selected_embedding_lanes: bool,
     out: &mut dyn Write,
     input: &mut dyn BufRead,
 ) -> Result<InitEmbeddingsSetupSelection> {
-    if args.no_embeddings {
+    if args.no_embeddings || !repo_selected_embedding_lanes {
         return Ok(InitEmbeddingsSetupSelection::Skip);
     }
 

--- a/bitloops/src/cli/init/final_setup.rs
+++ b/bitloops/src/cli/init/final_setup.rs
@@ -13,6 +13,9 @@ use anyhow::{Context, Result, bail};
 pub(crate) struct InitFinalSetupSelection {
     pub sync: bool,
     pub ingest: bool,
+    pub code_embeddings: bool,
+    pub summaries: bool,
+    pub summary_embeddings: bool,
     pub telemetry: bool,
     pub auto_start_daemon: bool,
 }
@@ -27,6 +30,9 @@ pub(crate) struct InitFinalSetupPromptOptions {
 enum InitFinalSetupOptionKind {
     Sync,
     Ingest,
+    CodeEmbeddings,
+    Summaries,
+    SummaryEmbeddings,
     Telemetry,
     AutoStartDaemon,
 }
@@ -46,14 +52,19 @@ pub(crate) fn choose_final_setup_options(
     prompt_options: InitFinalSetupPromptOptions,
 ) -> Result<InitFinalSetupSelection> {
     let can_prompt = telemetry_consent::can_prompt_interactively();
+    let code_embeddings_default = sync.unwrap_or(true) || ingest.unwrap_or(true);
     let defaults = InitFinalSetupSelection {
         sync: sync.unwrap_or(true),
         ingest: ingest.unwrap_or(true),
+        code_embeddings: code_embeddings_default,
+        summaries: false,
+        summary_embeddings: false,
         telemetry: prompt_options.show_telemetry,
         auto_start_daemon: prompt_options.show_auto_start_daemon && can_prompt,
     };
     let requires_prompt = sync.is_none()
         || ingest.is_none()
+        || can_prompt
         || prompt_options.show_telemetry
         || (prompt_options.show_auto_start_daemon && can_prompt);
 
@@ -137,12 +148,16 @@ fn prompt_final_setup_selection_with_picker(
     let mut selection = InitFinalSetupSelection {
         sync: false,
         ingest: false,
+        code_embeddings: false,
+        summaries: false,
+        summary_embeddings: false,
         telemetry: false,
         auto_start_daemon: false,
     };
     for (option, is_selected) in options.iter().zip(selected) {
         set_final_setup_selection_value(&mut selection, option.kind, is_selected);
     }
+    normalize_final_setup_dependencies(&mut selection);
     Ok(selection)
 }
 
@@ -198,13 +213,18 @@ fn prompt_final_setup_selection_with_text_input(
             .context("reading final setup selection for `bitloops init`")?;
         let response = response.trim().to_ascii_lowercase();
         if response.is_empty() {
-            return Ok(defaults);
+            let mut selection = defaults;
+            normalize_final_setup_dependencies(&mut selection);
+            return Ok(selection);
         }
 
         if matches!(response.as_str(), "none" | "skip") {
             return Ok(InitFinalSetupSelection {
                 sync: false,
                 ingest: false,
+                code_embeddings: false,
+                summaries: false,
+                summary_embeddings: false,
                 telemetry: false,
                 auto_start_daemon: false,
             });
@@ -213,6 +233,9 @@ fn prompt_final_setup_selection_with_text_input(
         let mut selection = InitFinalSetupSelection {
             sync: false,
             ingest: false,
+            code_embeddings: false,
+            summaries: false,
+            summary_embeddings: false,
             telemetry: false,
             auto_start_daemon: false,
         };
@@ -243,6 +266,7 @@ fn prompt_final_setup_selection_with_text_input(
         }
 
         if !invalid {
+            normalize_final_setup_dependencies(&mut selection);
             return Ok(selection);
         }
 
@@ -265,6 +289,21 @@ fn final_setup_option_specs(
         InitFinalSetupOptionSpec {
             kind: InitFinalSetupOptionKind::Ingest,
             label: "Import commit history",
+            insert_spacing_before: false,
+        },
+        InitFinalSetupOptionSpec {
+            kind: InitFinalSetupOptionKind::CodeEmbeddings,
+            label: "Code embeddings",
+            insert_spacing_before: false,
+        },
+        InitFinalSetupOptionSpec {
+            kind: InitFinalSetupOptionKind::Summaries,
+            label: "Summaries",
+            insert_spacing_before: false,
+        },
+        InitFinalSetupOptionSpec {
+            kind: InitFinalSetupOptionKind::SummaryEmbeddings,
+            label: "Summary embeddings",
             insert_spacing_before: false,
         },
     ];
@@ -296,6 +335,9 @@ fn final_setup_selection_value(
     match kind {
         InitFinalSetupOptionKind::Sync => selection.sync,
         InitFinalSetupOptionKind::Ingest => selection.ingest,
+        InitFinalSetupOptionKind::CodeEmbeddings => selection.code_embeddings,
+        InitFinalSetupOptionKind::Summaries => selection.summaries,
+        InitFinalSetupOptionKind::SummaryEmbeddings => selection.summary_embeddings,
         InitFinalSetupOptionKind::Telemetry => selection.telemetry,
         InitFinalSetupOptionKind::AutoStartDaemon => selection.auto_start_daemon,
     }
@@ -309,8 +351,20 @@ fn set_final_setup_selection_value(
     match kind {
         InitFinalSetupOptionKind::Sync => selection.sync = value,
         InitFinalSetupOptionKind::Ingest => selection.ingest = value,
+        InitFinalSetupOptionKind::CodeEmbeddings => selection.code_embeddings = value,
+        InitFinalSetupOptionKind::Summaries => selection.summaries = value,
+        InitFinalSetupOptionKind::SummaryEmbeddings => selection.summary_embeddings = value,
         InitFinalSetupOptionKind::Telemetry => selection.telemetry = value,
         InitFinalSetupOptionKind::AutoStartDaemon => selection.auto_start_daemon = value,
+    }
+}
+
+fn normalize_final_setup_dependencies(selection: &mut InitFinalSetupSelection) {
+    if selection.summary_embeddings {
+        selection.summaries = true;
+    }
+    if !selection.summaries {
+        selection.summary_embeddings = false;
     }
 }
 
@@ -326,6 +380,19 @@ fn option_for_final_setup_token<'a>(
         InitFinalSetupOptionKind::Sync => matches!(token, "sync" | "codebase"),
         InitFinalSetupOptionKind::Ingest => {
             matches!(token, "ingest" | "history" | "commit-history")
+        }
+        InitFinalSetupOptionKind::CodeEmbeddings => {
+            matches!(
+                token,
+                "embeddings" | "code-embeddings" | "code_embeddings" | "code"
+            )
+        }
+        InitFinalSetupOptionKind::Summaries => matches!(token, "summaries" | "summary"),
+        InitFinalSetupOptionKind::SummaryEmbeddings => {
+            matches!(
+                token,
+                "summary-embeddings" | "summary_embeddings" | "summary-embedding"
+            )
         }
         InitFinalSetupOptionKind::Telemetry => matches!(token, "telemetry"),
         InitFinalSetupOptionKind::AutoStartDaemon => matches!(

--- a/bitloops/src/cli/init/final_setup.rs
+++ b/bitloops/src/cli/init/final_setup.rs
@@ -13,9 +13,6 @@ use anyhow::{Context, Result, bail};
 pub(crate) struct InitFinalSetupSelection {
     pub sync: bool,
     pub ingest: bool,
-    pub code_embeddings: bool,
-    pub summaries: bool,
-    pub summary_embeddings: bool,
     pub telemetry: bool,
     pub auto_start_daemon: bool,
 }
@@ -26,13 +23,10 @@ pub(crate) struct InitFinalSetupPromptOptions {
     pub show_auto_start_daemon: bool,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum InitFinalSetupOptionKind {
     Sync,
     Ingest,
-    CodeEmbeddings,
-    Summaries,
-    SummaryEmbeddings,
     Telemetry,
     AutoStartDaemon,
 }
@@ -52,19 +46,14 @@ pub(crate) fn choose_final_setup_options(
     prompt_options: InitFinalSetupPromptOptions,
 ) -> Result<InitFinalSetupSelection> {
     let can_prompt = telemetry_consent::can_prompt_interactively();
-    let code_embeddings_default = sync.unwrap_or(true);
     let defaults = InitFinalSetupSelection {
         sync: sync.unwrap_or(true),
         ingest: ingest.unwrap_or(true),
-        code_embeddings: code_embeddings_default,
-        summaries: false,
-        summary_embeddings: false,
         telemetry: prompt_options.show_telemetry,
         auto_start_daemon: prompt_options.show_auto_start_daemon && can_prompt,
     };
     let requires_prompt = sync.is_none()
         || ingest.is_none()
-        || can_prompt
         || prompt_options.show_telemetry
         || (prompt_options.show_auto_start_daemon && can_prompt);
 
@@ -132,11 +121,6 @@ fn prompt_final_setup_selection_with_picker(
             }
             FollowUpKey::Toggle => {
                 selected[cursor] = !selected[cursor];
-                apply_final_setup_toggle_dependencies(
-                    &options,
-                    &mut selected,
-                    options[cursor].kind,
-                );
             }
             FollowUpKey::Cancel => bail!("cancelled by user"),
             FollowUpKey::Submit => break,
@@ -153,16 +137,12 @@ fn prompt_final_setup_selection_with_picker(
     let mut selection = InitFinalSetupSelection {
         sync: false,
         ingest: false,
-        code_embeddings: false,
-        summaries: false,
-        summary_embeddings: false,
         telemetry: false,
         auto_start_daemon: false,
     };
     for (option, is_selected) in options.iter().zip(selected) {
         set_final_setup_selection_value(&mut selection, option.kind, is_selected);
     }
-    normalize_final_setup_dependencies(&mut selection);
     Ok(selection)
 }
 
@@ -218,18 +198,13 @@ fn prompt_final_setup_selection_with_text_input(
             .context("reading final setup selection for `bitloops init`")?;
         let response = response.trim().to_ascii_lowercase();
         if response.is_empty() {
-            let mut selection = defaults;
-            normalize_final_setup_dependencies(&mut selection);
-            return Ok(selection);
+            return Ok(defaults);
         }
 
         if matches!(response.as_str(), "none" | "skip") {
             return Ok(InitFinalSetupSelection {
                 sync: false,
                 ingest: false,
-                code_embeddings: false,
-                summaries: false,
-                summary_embeddings: false,
                 telemetry: false,
                 auto_start_daemon: false,
             });
@@ -238,9 +213,6 @@ fn prompt_final_setup_selection_with_text_input(
         let mut selection = InitFinalSetupSelection {
             sync: false,
             ingest: false,
-            code_embeddings: false,
-            summaries: false,
-            summary_embeddings: false,
             telemetry: false,
             auto_start_daemon: false,
         };
@@ -271,7 +243,6 @@ fn prompt_final_setup_selection_with_text_input(
         }
 
         if !invalid {
-            normalize_final_setup_dependencies(&mut selection);
             return Ok(selection);
         }
 
@@ -294,21 +265,6 @@ fn final_setup_option_specs(
         InitFinalSetupOptionSpec {
             kind: InitFinalSetupOptionKind::Ingest,
             label: "Import commit history",
-            insert_spacing_before: false,
-        },
-        InitFinalSetupOptionSpec {
-            kind: InitFinalSetupOptionKind::CodeEmbeddings,
-            label: "Code embeddings",
-            insert_spacing_before: false,
-        },
-        InitFinalSetupOptionSpec {
-            kind: InitFinalSetupOptionKind::Summaries,
-            label: "Summaries",
-            insert_spacing_before: false,
-        },
-        InitFinalSetupOptionSpec {
-            kind: InitFinalSetupOptionKind::SummaryEmbeddings,
-            label: "Summary embeddings",
             insert_spacing_before: false,
         },
     ];
@@ -340,9 +296,6 @@ fn final_setup_selection_value(
     match kind {
         InitFinalSetupOptionKind::Sync => selection.sync,
         InitFinalSetupOptionKind::Ingest => selection.ingest,
-        InitFinalSetupOptionKind::CodeEmbeddings => selection.code_embeddings,
-        InitFinalSetupOptionKind::Summaries => selection.summaries,
-        InitFinalSetupOptionKind::SummaryEmbeddings => selection.summary_embeddings,
         InitFinalSetupOptionKind::Telemetry => selection.telemetry,
         InitFinalSetupOptionKind::AutoStartDaemon => selection.auto_start_daemon,
     }
@@ -356,54 +309,8 @@ fn set_final_setup_selection_value(
     match kind {
         InitFinalSetupOptionKind::Sync => selection.sync = value,
         InitFinalSetupOptionKind::Ingest => selection.ingest = value,
-        InitFinalSetupOptionKind::CodeEmbeddings => selection.code_embeddings = value,
-        InitFinalSetupOptionKind::Summaries => selection.summaries = value,
-        InitFinalSetupOptionKind::SummaryEmbeddings => selection.summary_embeddings = value,
         InitFinalSetupOptionKind::Telemetry => selection.telemetry = value,
         InitFinalSetupOptionKind::AutoStartDaemon => selection.auto_start_daemon = value,
-    }
-}
-
-fn normalize_final_setup_dependencies(selection: &mut InitFinalSetupSelection) {
-    if selection.summary_embeddings {
-        selection.summaries = true;
-    }
-    if !selection.summaries {
-        selection.summary_embeddings = false;
-    }
-}
-
-fn apply_final_setup_toggle_dependencies(
-    options: &[InitFinalSetupOptionSpec],
-    selected: &mut [bool],
-    toggled_kind: InitFinalSetupOptionKind,
-) {
-    let find_index = |kind| options.iter().position(|option| option.kind == kind);
-    match toggled_kind {
-        InitFinalSetupOptionKind::SummaryEmbeddings => {
-            let summary_embeddings_selected =
-                find_index(InitFinalSetupOptionKind::SummaryEmbeddings)
-                    .and_then(|index| selected.get(index))
-                    .copied()
-                    .unwrap_or(false);
-            if summary_embeddings_selected {
-                if let Some(index) = find_index(InitFinalSetupOptionKind::Summaries) {
-                    selected[index] = true;
-                }
-            }
-        }
-        InitFinalSetupOptionKind::Summaries => {
-            let summaries_selected = find_index(InitFinalSetupOptionKind::Summaries)
-                .and_then(|index| selected.get(index))
-                .copied()
-                .unwrap_or(false);
-            if !summaries_selected {
-                if let Some(index) = find_index(InitFinalSetupOptionKind::SummaryEmbeddings) {
-                    selected[index] = false;
-                }
-            }
-        }
-        _ => {}
     }
 }
 
@@ -419,19 +326,6 @@ fn option_for_final_setup_token<'a>(
         InitFinalSetupOptionKind::Sync => matches!(token, "sync" | "codebase"),
         InitFinalSetupOptionKind::Ingest => {
             matches!(token, "ingest" | "history" | "commit-history")
-        }
-        InitFinalSetupOptionKind::CodeEmbeddings => {
-            matches!(
-                token,
-                "embeddings" | "code-embeddings" | "code_embeddings" | "code"
-            )
-        }
-        InitFinalSetupOptionKind::Summaries => matches!(token, "summaries" | "summary"),
-        InitFinalSetupOptionKind::SummaryEmbeddings => {
-            matches!(
-                token,
-                "summary-embeddings" | "summary_embeddings" | "summary-embedding"
-            )
         }
         InitFinalSetupOptionKind::Telemetry => matches!(token, "telemetry"),
         InitFinalSetupOptionKind::AutoStartDaemon => matches!(
@@ -618,41 +512,4 @@ fn selected_follow_up_checkbox() -> String {
 fn selected_follow_up_label(label: &str) -> String {
     const SELECTION_WHITE_HEX: &str = "#ffffff";
     color_hex_if_enabled(label, SELECTION_WHITE_HEX)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn picker_toggle_dependencies_keep_summary_choices_consistent() {
-        let options = final_setup_option_specs(InitFinalSetupPromptOptions {
-            show_telemetry: false,
-            show_auto_start_daemon: false,
-        });
-        let mut selected = vec![false; options.len()];
-        let summary_embeddings_index = options
-            .iter()
-            .position(|option| option.kind == InitFinalSetupOptionKind::SummaryEmbeddings)
-            .expect("summary embeddings option");
-        selected[summary_embeddings_index] = true;
-        apply_final_setup_toggle_dependencies(
-            &options,
-            &mut selected,
-            InitFinalSetupOptionKind::SummaryEmbeddings,
-        );
-        let summaries_index = options
-            .iter()
-            .position(|option| option.kind == InitFinalSetupOptionKind::Summaries)
-            .expect("summaries option");
-        assert!(selected[summaries_index]);
-
-        selected[summaries_index] = false;
-        apply_final_setup_toggle_dependencies(
-            &options,
-            &mut selected,
-            InitFinalSetupOptionKind::Summaries,
-        );
-        assert!(!selected[summary_embeddings_index]);
-    }
 }

--- a/bitloops/src/cli/init/final_setup.rs
+++ b/bitloops/src/cli/init/final_setup.rs
@@ -26,7 +26,7 @@ pub(crate) struct InitFinalSetupPromptOptions {
     pub show_auto_start_daemon: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum InitFinalSetupOptionKind {
     Sync,
     Ingest,
@@ -52,7 +52,7 @@ pub(crate) fn choose_final_setup_options(
     prompt_options: InitFinalSetupPromptOptions,
 ) -> Result<InitFinalSetupSelection> {
     let can_prompt = telemetry_consent::can_prompt_interactively();
-    let code_embeddings_default = sync.unwrap_or(true) || ingest.unwrap_or(true);
+    let code_embeddings_default = sync.unwrap_or(true);
     let defaults = InitFinalSetupSelection {
         sync: sync.unwrap_or(true),
         ingest: ingest.unwrap_or(true),
@@ -132,6 +132,11 @@ fn prompt_final_setup_selection_with_picker(
             }
             FollowUpKey::Toggle => {
                 selected[cursor] = !selected[cursor];
+                apply_final_setup_toggle_dependencies(
+                    &options,
+                    &mut selected,
+                    options[cursor].kind,
+                );
             }
             FollowUpKey::Cancel => bail!("cancelled by user"),
             FollowUpKey::Submit => break,
@@ -368,6 +373,40 @@ fn normalize_final_setup_dependencies(selection: &mut InitFinalSetupSelection) {
     }
 }
 
+fn apply_final_setup_toggle_dependencies(
+    options: &[InitFinalSetupOptionSpec],
+    selected: &mut [bool],
+    toggled_kind: InitFinalSetupOptionKind,
+) {
+    let find_index = |kind| options.iter().position(|option| option.kind == kind);
+    match toggled_kind {
+        InitFinalSetupOptionKind::SummaryEmbeddings => {
+            let summary_embeddings_selected =
+                find_index(InitFinalSetupOptionKind::SummaryEmbeddings)
+                    .and_then(|index| selected.get(index))
+                    .copied()
+                    .unwrap_or(false);
+            if summary_embeddings_selected {
+                if let Some(index) = find_index(InitFinalSetupOptionKind::Summaries) {
+                    selected[index] = true;
+                }
+            }
+        }
+        InitFinalSetupOptionKind::Summaries => {
+            let summaries_selected = find_index(InitFinalSetupOptionKind::Summaries)
+                .and_then(|index| selected.get(index))
+                .copied()
+                .unwrap_or(false);
+            if !summaries_selected {
+                if let Some(index) = find_index(InitFinalSetupOptionKind::SummaryEmbeddings) {
+                    selected[index] = false;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 fn option_for_final_setup_token<'a>(
     options: &'a [InitFinalSetupOptionSpec],
     token: &str,
@@ -579,4 +618,41 @@ fn selected_follow_up_checkbox() -> String {
 fn selected_follow_up_label(label: &str) -> String {
     const SELECTION_WHITE_HEX: &str = "#ffffff";
     color_hex_if_enabled(label, SELECTION_WHITE_HEX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picker_toggle_dependencies_keep_summary_choices_consistent() {
+        let options = final_setup_option_specs(InitFinalSetupPromptOptions {
+            show_telemetry: false,
+            show_auto_start_daemon: false,
+        });
+        let mut selected = vec![false; options.len()];
+        let summary_embeddings_index = options
+            .iter()
+            .position(|option| option.kind == InitFinalSetupOptionKind::SummaryEmbeddings)
+            .expect("summary embeddings option");
+        selected[summary_embeddings_index] = true;
+        apply_final_setup_toggle_dependencies(
+            &options,
+            &mut selected,
+            InitFinalSetupOptionKind::SummaryEmbeddings,
+        );
+        let summaries_index = options
+            .iter()
+            .position(|option| option.kind == InitFinalSetupOptionKind::Summaries)
+            .expect("summaries option");
+        assert!(selected[summaries_index]);
+
+        selected[summaries_index] = false;
+        apply_final_setup_toggle_dependencies(
+            &options,
+            &mut selected,
+            InitFinalSetupOptionKind::Summaries,
+        );
+        assert!(!selected[summary_embeddings_index]);
+    }
 }

--- a/bitloops/src/cli/init/summary_setup.rs
+++ b/bitloops/src/cli/init/summary_setup.rs
@@ -7,7 +7,6 @@ use crate::cli::inference::{
     SummarySetupSelection, prompt_summary_setup_selection, summary_generation_configured,
 };
 use crate::cli::telemetry_consent;
-use crate::config::{SemanticSummaryMode, resolve_semantic_clones_config_for_repo};
 
 use super::cloud_login_status::resolve_cloud_logged_in_for_optional_setup;
 
@@ -20,10 +19,6 @@ pub(crate) async fn choose_summary_setup_during_init(
     input: &mut dyn BufRead,
 ) -> Result<SummarySetupSelection> {
     if no_summaries || !repo_selected_summaries {
-        return Ok(SummarySetupSelection::Skip);
-    }
-
-    if resolve_semantic_clones_config_for_repo(repo_root).summary_mode == SemanticSummaryMode::Off {
         return Ok(SummarySetupSelection::Skip);
     }
 

--- a/bitloops/src/cli/init/summary_setup.rs
+++ b/bitloops/src/cli/init/summary_setup.rs
@@ -15,10 +15,11 @@ pub(crate) async fn choose_summary_setup_during_init(
     repo_root: &Path,
     install_default_daemon: bool,
     no_summaries: bool,
+    repo_selected_summaries: bool,
     out: &mut dyn Write,
     input: &mut dyn BufRead,
 ) -> Result<SummarySetupSelection> {
-    if no_summaries {
+    if no_summaries || !repo_selected_summaries {
         return Ok(SummarySetupSelection::Skip);
     }
 

--- a/bitloops/src/cli/init/summary_setup.rs
+++ b/bitloops/src/cli/init/summary_setup.rs
@@ -7,6 +7,8 @@ use crate::cli::inference::{
     SummarySetupSelection, prompt_summary_setup_selection, summary_generation_configured,
 };
 use crate::cli::telemetry_consent;
+use crate::config::SemanticSummaryMode;
+use crate::config::settings::repo_semantic_embedding_policy;
 
 use super::cloud_login_status::resolve_cloud_logged_in_for_optional_setup;
 
@@ -22,7 +24,7 @@ pub(crate) async fn choose_summary_setup_during_init(
         return Ok(SummarySetupSelection::Skip);
     }
 
-    if summary_generation_configured(repo_root) {
+    if repo_summary_generation_configured(repo_root) {
         return Ok(SummarySetupSelection::Skip);
     }
 
@@ -42,4 +44,20 @@ pub(crate) async fn choose_summary_setup_during_init(
         install_default_daemon,
         cloud_logged_in,
     )
+}
+
+fn repo_summary_generation_configured(repo_root: &Path) -> bool {
+    let Ok(policy) = repo_semantic_embedding_policy(repo_root) else {
+        return false;
+    };
+    if policy.summary_mode == Some(SemanticSummaryMode::Off) {
+        return false;
+    }
+    let repo_selected_summary_profile = policy
+        .inference
+        .summary_generation
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|profile| !profile.is_empty());
+    repo_selected_summary_profile && summary_generation_configured(repo_root)
 }

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -909,31 +909,39 @@ fn choose_context_guidance_setup_during_init_skips_noninteractive_without_explic
 }
 
 #[test]
-fn choose_summary_setup_during_init_skips_when_summary_mode_is_off() {
+fn choose_summary_setup_during_init_can_reenable_existing_summary_mode_off() {
     let repo = tempfile::tempdir().expect("tempdir");
-    std::fs::write(
-        repo.path().join(BITLOOPS_CONFIG_RELATIVE_PATH),
+    write_repo_policy(
+        &repo,
+        REPO_POLICY_LOCAL_FILE_NAME,
         "[semantic_clones]\nsummary_mode = \"off\"\n",
-    )
-    .expect("write config");
+    );
     let mut out = Vec::new();
-    let mut input = Cursor::new("");
+    let mut input = Cursor::new("3\n");
 
-    let selection = test_runtime()
-        .block_on(choose_summary_setup_during_init(
-            repo.path(),
-            true,
-            false,
-            true,
-            &mut out,
-            &mut input,
-        ))
-        .expect("choose summary setup");
+    let selection = with_test_tty_override(true, || {
+        with_summary_generation_configured_hook(
+            |_| false,
+            || {
+                test_runtime().block_on(choose_summary_setup_during_init(
+                    repo.path(),
+                    true,
+                    false,
+                    true,
+                    &mut out,
+                    &mut input,
+                ))
+            },
+        )
+    })
+    .expect("choose summary setup");
 
     assert_eq!(
         selection,
-        crate::cli::inference::SummarySetupSelection::Skip
+        crate::cli::inference::SummarySetupSelection::Local
     );
+    let rendered = String::from_utf8(out).expect("utf8 output");
+    assert!(rendered.contains("Configure semantic summaries"));
 }
 
 #[test]
@@ -5582,6 +5590,117 @@ model = "text-embedding-3-small"
                 );
             },
         );
+    });
+}
+
+#[test]
+fn run_init_existing_selection_fills_partial_repo_embedding_policy_from_daemon() {
+    let repo = tempfile::tempdir().unwrap();
+    let app_dirs = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+    let config_path = repo.path().join(BITLOOPS_CONFIG_RELATIVE_PATH);
+    write_repo_policy(
+        &repo,
+        REPO_POLICY_LOCAL_FILE_NAME,
+        &format!(
+            r#"
+[daemon]
+config_path = {:?}
+
+[semantic_clones]
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+code_embeddings = "repo_code_profile"
+"#,
+            config_path.to_string_lossy()
+        ),
+    );
+    std::fs::write(
+        &config_path,
+        r#"
+[runtime]
+local_dev = false
+
+[semantic_clones]
+embedding_mode = "semantic_aware_once"
+summary_mode = "auto"
+
+[semantic_clones.inference]
+code_embeddings = "daemon_code_profile"
+summary_embeddings = "daemon_summary_profile"
+summary_generation = "daemon_summary_generation"
+
+[inference.runtimes.bitloops_inference]
+command = "bitloops-inference"
+
+[inference.profiles.repo_code_profile]
+task = "embeddings"
+driver = "openai"
+model = "text-embedding-3-large"
+
+[inference.profiles.daemon_code_profile]
+task = "embeddings"
+driver = "openai"
+model = "text-embedding-3-large"
+
+[inference.profiles.daemon_summary_profile]
+task = "embeddings"
+driver = "openai"
+model = "text-embedding-3-small"
+
+[inference.profiles.daemon_summary_generation]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "daemon-summary-model"
+"#,
+    )
+    .expect("write daemon config");
+
+    with_temp_app_dirs_and_summary_configured(&app_dirs, true, true, true, || {
+        let mut out = Vec::new();
+        let mut input = Cursor::new("3,4,5\n");
+        let runtime = test_runtime();
+        runtime
+            .block_on(run_with_io_async_for_project_root(
+                InitArgs {
+                    command: None,
+                    install_default_daemon: false,
+                    force: false,
+                    disable_devql_guidance: false,
+                    agent: vec![DEFAULT_AGENT.to_string()],
+                    telemetry: Some(false),
+                    no_telemetry: false,
+                    skip_baseline: false,
+                    sync: Some(false),
+                    ingest: Some(false),
+                    backfill: None,
+                    exclude: Vec::new(),
+                    exclude_from: Vec::new(),
+                    embeddings_runtime: None,
+                    no_embeddings: false,
+                    no_summaries: false,
+                    context_guidance_runtime: None,
+                    no_context_guidance: true,
+                    context_guidance_gateway_url: None,
+                    context_guidance_api_key_env: None,
+                    embeddings_gateway_url: None,
+                    embeddings_api_key_env: "BITLOOPS_PLATFORM_GATEWAY_TOKEN".to_string(),
+                },
+                repo.path(),
+                &mut out,
+                &mut input,
+                None,
+            ))
+            .expect("run init");
+
+        let policy = std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+            .expect("read local policy");
+        assert!(policy.contains("summary_mode = \"auto\""));
+        assert!(policy.contains("summary_generation = \"daemon_summary_generation\""));
+        assert!(policy.contains("code_embeddings = \"repo_code_profile\""));
+        assert!(policy.contains("summary_embeddings = \"daemon_summary_profile\""));
     });
 }
 

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -6550,6 +6550,9 @@ fn choose_final_setup_options_renders_final_setup_prompt() {
             InitFinalSetupSelection {
                 sync: true,
                 ingest: true,
+                code_embeddings: true,
+                summaries: false,
+                summary_embeddings: false,
                 telemetry: false,
                 auto_start_daemon: false,
             }
@@ -6560,6 +6563,97 @@ fn choose_final_setup_options_renders_final_setup_prompt() {
         assert!(rendered.contains("Use space to select, enter to confirm."));
         assert!(rendered.contains("1. Sync codebase (selected)"));
         assert!(rendered.contains("2. Import commit history (selected)"));
+    });
+}
+
+#[test]
+fn choose_final_setup_options_prompts_for_all_repo_local_choices() {
+    with_test_tty_override(true, || {
+        let mut out = Vec::new();
+        let mut input = Cursor::new("1,2,3,4,5\n");
+
+        let selection = choose_final_setup_options(
+            None,
+            &mut out,
+            &mut input,
+            None,
+            InitFinalSetupPromptOptions {
+                show_telemetry: false,
+                show_auto_start_daemon: false,
+            },
+        )
+        .expect("choose setup options");
+
+        assert_eq!(
+            selection,
+            InitFinalSetupSelection {
+                sync: true,
+                ingest: true,
+                code_embeddings: true,
+                summaries: true,
+                summary_embeddings: true,
+                telemetry: false,
+                auto_start_daemon: false,
+            }
+        );
+        let rendered = String::from_utf8(out).expect("utf8 output");
+        assert!(rendered.contains("1. Sync codebase"));
+        assert!(rendered.contains("2. Import commit history"));
+        assert!(rendered.contains("3. Code embeddings"));
+        assert!(rendered.contains("4. Summaries"));
+        assert!(rendered.contains("5. Summary embeddings"));
+    });
+}
+
+#[test]
+fn choose_final_setup_options_enables_summaries_when_summary_embeddings_selected() {
+    with_test_tty_override(true, || {
+        let mut out = Vec::new();
+        let mut input = Cursor::new("5\n");
+
+        let selection = choose_final_setup_options(
+            Some(false),
+            &mut out,
+            &mut input,
+            Some(false),
+            InitFinalSetupPromptOptions {
+                show_telemetry: false,
+                show_auto_start_daemon: false,
+            },
+        )
+        .expect("choose summary embeddings");
+
+        assert!(!selection.sync);
+        assert!(!selection.ingest);
+        assert!(!selection.code_embeddings);
+        assert!(selection.summaries);
+        assert!(selection.summary_embeddings);
+    });
+}
+
+#[test]
+fn choose_final_setup_options_all_selects_all_repo_local_choices() {
+    with_test_tty_override(true, || {
+        let mut out = Vec::new();
+        let mut input = Cursor::new("all\n");
+
+        let selection = choose_final_setup_options(
+            Some(false),
+            &mut out,
+            &mut input,
+            Some(false),
+            InitFinalSetupPromptOptions {
+                show_telemetry: false,
+                show_auto_start_daemon: false,
+            },
+        )
+        .expect("choose all setup options");
+
+        assert!(selection.sync);
+        assert!(selection.ingest);
+        assert!(selection.code_embeddings);
+        assert!(selection.summaries);
+        assert!(selection.summary_embeddings);
     });
 }
 
@@ -6586,6 +6680,9 @@ fn choose_final_setup_options_preselects_telemetry_when_shown() {
             InitFinalSetupSelection {
                 sync: false,
                 ingest: false,
+                code_embeddings: false,
+                summaries: false,
+                summary_embeddings: false,
                 telemetry: true,
                 auto_start_daemon: false,
             }
@@ -6618,6 +6715,9 @@ fn choose_final_setup_options_defaults_auto_start_to_disabled_when_not_interacti
             InitFinalSetupSelection {
                 sync: false,
                 ingest: false,
+                code_embeddings: false,
+                summaries: false,
+                summary_embeddings: false,
                 telemetry: false,
                 auto_start_daemon: false,
             }

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -4297,6 +4297,94 @@ fn run_init_with_install_default_daemon_can_skip_summaries_via_flag() {
 }
 
 #[test]
+fn run_init_no_summaries_persists_repo_summary_mode_off_even_with_daemon_provider() {
+    let repo = tempfile::tempdir().unwrap();
+    let app_dirs = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+
+    with_temp_app_dirs_and_generation_configured(&app_dirs, false, true, true, true, || {
+        let config_path = ensure_daemon_config_exists().expect("create default daemon config");
+        std::fs::write(
+            &config_path,
+            r#"
+[runtime]
+local_dev = false
+
+[semantic_clones]
+summary_mode = "auto"
+
+[semantic_clones.inference]
+summary_generation = "daemon_summary"
+
+[inference.runtimes.bitloops_inference]
+command = "bitloops-inference"
+
+[inference.profiles.daemon_summary]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "daemon-summary-model"
+"#,
+        )
+        .expect("write daemon config");
+
+        with_global_graphql_executor_hook(
+            |_runtime_root, _query, variables| {
+                assert_eq!(variables["telemetry"], serde_json::json!(false));
+                Ok(serde_json::json!({
+                    "updateCliTelemetryConsent": {
+                        "telemetry": false,
+                        "needsPrompt": false
+                    }
+                }))
+            },
+            || {
+                let mut out = Vec::new();
+                let mut input = Cursor::new("");
+                let runtime = test_runtime();
+                runtime
+                    .block_on(run_with_io_async_for_project_root(
+                        InitArgs {
+                            command: None,
+                            install_default_daemon: false,
+                            force: false,
+                            disable_devql_guidance: false,
+                            agent: vec![DEFAULT_AGENT.to_string()],
+                            telemetry: Some(false),
+                            no_telemetry: false,
+                            skip_baseline: false,
+                            sync: Some(false),
+                            ingest: Some(false),
+                            backfill: None,
+                            exclude: Vec::new(),
+                            exclude_from: Vec::new(),
+                            embeddings_runtime: None,
+                            no_embeddings: false,
+                            no_summaries: true,
+                            context_guidance_runtime: None,
+                            no_context_guidance: true,
+                            context_guidance_gateway_url: None,
+                            context_guidance_api_key_env: None,
+                            embeddings_gateway_url: None,
+                            embeddings_api_key_env: "BITLOOPS_PLATFORM_GATEWAY_TOKEN".to_string(),
+                        },
+                        repo.path(),
+                        &mut out,
+                        &mut input,
+                        None,
+                    ))
+                    .expect("run init");
+
+                let policy = std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+                    .expect("read policy");
+                assert!(policy.contains("summary_mode = \"off\""));
+                assert!(!policy.contains("summary_generation = "));
+            },
+        );
+    });
+}
+
+#[test]
 fn run_init_with_install_default_daemon_sends_summary_bootstrap_when_prompt_is_accepted() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -47,6 +47,27 @@ fn assert_repo_embedding_policy(repo: &TempDir, profile_name: &str) {
     assert_repo_embedding_policy_bindings(repo, profile_name, profile_name);
 }
 
+fn assert_repo_code_embedding_policy(repo: &TempDir, profile_name: &str) {
+    let policy = std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+        .expect("read local policy");
+    assert!(
+        policy.contains("embedding_mode = \"semantic_aware_once\""),
+        "expected semantic-aware embedding mode:\n{policy}"
+    );
+    assert!(
+        policy.contains(&format!("code_embeddings = \"{profile_name}\"")),
+        "expected code embedding profile {profile_name}:\n{policy}"
+    );
+    assert!(
+        !policy.contains("summary_embeddings = "),
+        "did not expect summary embedding profile:\n{policy}"
+    );
+    assert!(
+        policy.contains("summary_mode = \"off\""),
+        "expected summaries off:\n{policy}"
+    );
+}
+
 fn assert_repo_embedding_policy_bindings(
     repo: &TempDir,
     code_profile_name: &str,
@@ -54,9 +75,18 @@ fn assert_repo_embedding_policy_bindings(
 ) {
     let policy = std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
         .expect("read local policy");
-    assert!(policy.contains("embedding_mode = \"semantic_aware_once\""));
-    assert!(policy.contains(&format!("code_embeddings = \"{code_profile_name}\"")));
-    assert!(policy.contains(&format!("summary_embeddings = \"{summary_profile_name}\"")));
+    assert!(
+        policy.contains("embedding_mode = \"semantic_aware_once\""),
+        "expected semantic-aware embedding mode:\n{policy}"
+    );
+    assert!(
+        policy.contains(&format!("code_embeddings = \"{code_profile_name}\"")),
+        "expected code embedding profile {code_profile_name}:\n{policy}"
+    );
+    assert!(
+        policy.contains(&format!("summary_embeddings = \"{summary_profile_name}\"")),
+        "expected summary embedding profile {summary_profile_name}:\n{policy}"
+    );
 }
 
 fn strip_ansi_escape_sequences(text: &str) -> String {
@@ -456,6 +486,49 @@ request_timeout_secs = 5
         ),
     )
     .expect("write daemon config");
+}
+
+fn write_daemon_config_with_embeddings_and_summary(config_path: &Path) {
+    std::fs::write(
+        config_path,
+        r#"
+[runtime]
+local_dev = false
+
+[semantic_clones.inference]
+summary_generation = "summary_local"
+code_embeddings = "local_code"
+summary_embeddings = "local_code"
+
+[inference.runtimes.bitloops_local_embeddings]
+command = "bitloops-local-embeddings"
+args = []
+startup_timeout_secs = 5
+request_timeout_secs = 5
+
+[inference.runtimes.bitloops_inference]
+command = "bitloops-inference"
+args = []
+startup_timeout_secs = 60
+request_timeout_secs = 300
+
+[inference.profiles.local_code]
+task = "embeddings"
+driver = "bitloops_embeddings_ipc"
+runtime = "bitloops_local_embeddings"
+model = "bge-m3"
+
+[inference.profiles.summary_local]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "ministral-3:3b"
+base_url = "http://127.0.0.1:11434/api/chat"
+temperature = "0.1"
+max_output_tokens = 200
+"#,
+    )
+    .expect("write daemon config with semantic providers");
 }
 
 fn test_repo_id(repo_root: &Path) -> String {
@@ -1583,8 +1656,18 @@ fn run_init_creates_project_local_policy_and_installs_selected_agents() {
             "expected init --ingest=false to persist ingest_enabled=false:\n{local_policy}"
         );
         assert!(
-            !local_policy.contains("[semantic_clones]"),
-            "plain init should not persist an embeddings policy unless the user makes an embeddings choice:\n{local_policy}"
+            local_policy.contains("summary_mode = \"off\""),
+            "plain init should persist summaries off for the repo-local final setup choice:\n{local_policy}"
+        );
+        assert!(
+            local_policy.contains("embedding_mode = \"off\""),
+            "plain init should persist embeddings off for the repo-local final setup choice:\n{local_policy}"
+        );
+        assert!(
+            !local_policy.contains("code_embeddings = ")
+                && !local_policy.contains("summary_embeddings = ")
+                && !local_policy.contains("summary_generation = "),
+            "plain init should not bind semantic inference profiles:\n{local_policy}"
         );
         assert_eq!(
             crate::cli::enable::initialized_agents(repo.path()),
@@ -3276,7 +3359,7 @@ fn run_init_prompts_for_unresolved_existing_telemetry_consent() {
             },
             || {
                 let mut out = Vec::new();
-                let mut input = Cursor::new("3\n");
+                let mut input = Cursor::new("\n");
                 let select = |_items: &[String], enable_devql_guidance: bool| {
                     Ok(InitAgentSelection {
                         agents: vec!["claude-code".to_string()],
@@ -3834,7 +3917,7 @@ fn run_init_without_install_default_daemon_explicit_local_persists_repo_policy()
                 )
                 .expect("run init");
 
-                assert_repo_embedding_policy(&repo, "local_code");
+                assert_repo_code_embedding_policy(&repo, "local_code");
             },
         );
     });
@@ -3911,7 +3994,138 @@ fn run_init_without_install_default_daemon_explicit_platform_persists_repo_polic
                         )
                         .expect("run init");
 
-                        assert_repo_embedding_policy(&repo, "platform_code");
+                        assert_repo_code_embedding_policy(&repo, "platform_code");
+                    },
+                );
+            },
+        );
+    });
+}
+
+#[test]
+fn second_repo_can_disable_summaries_when_default_daemon_has_summary_provider() {
+    let repo = tempfile::tempdir().unwrap();
+    let app_dirs = tempfile::tempdir().unwrap();
+    let repo_id = test_repo_id(repo.path());
+    let session_id = "init-session-disable-summaries";
+    setup_git_repo(&repo);
+
+    with_temp_app_dirs(&app_dirs, true, true, || {
+        let config_path = ensure_daemon_config_exists().expect("create default daemon config");
+        write_daemon_config_with_embeddings_and_summary(&config_path);
+        crate::config::settings::write_repo_daemon_binding(
+            &repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+            &config_path,
+        )
+        .expect("write repo daemon binding");
+
+        with_global_graphql_executor_hook(
+            |_runtime_root, _query, variables| {
+                assert_eq!(variables["telemetry"], serde_json::json!(false));
+                Ok(serde_json::json!({
+                    "updateCliTelemetryConsent": {
+                        "telemetry": false,
+                        "needsPrompt": false
+                    }
+                }))
+            },
+            || {
+                with_ingest_daemon_bootstrap_hook(
+                    |_repo_root| Ok(()),
+                    || {
+                        with_graphql_executor_hook(
+                            {
+                                let repo_id = repo_id.clone();
+                                move |_repo_root, query, variables| {
+                                    if query.contains("startInit(") {
+                                        assert_eq!(variables["repoId"], repo_id);
+                                        assert_eq!(variables["input"]["runSync"], json!(true));
+                                        assert_eq!(variables["input"]["runIngest"], json!(true));
+                                        assert_eq!(
+                                            variables["input"]["runCodeEmbeddings"],
+                                            json!(false)
+                                        );
+                                        assert_eq!(
+                                            variables["input"]["runSummaries"],
+                                            json!(false)
+                                        );
+                                        assert_eq!(
+                                            variables["input"]["runSummaryEmbeddings"],
+                                            json!(false)
+                                        );
+                                        return Ok(runtime_start_init_result_json(session_id));
+                                    }
+
+                                    if query.contains("runtimeSnapshot(") {
+                                        return Ok(runtime_snapshot_json(
+                                            repo_id.as_str(),
+                                            session_id,
+                                            RuntimeSessionSnapshotFixture {
+                                                status: "COMPLETED",
+                                                run_sync: true,
+                                                run_ingest: true,
+                                                top_lane_status: "COMPLETED",
+                                                ..RuntimeSessionSnapshotFixture::default()
+                                            },
+                                        ));
+                                    }
+
+                                    panic!("unexpected repo-scoped query: {query}");
+                                }
+                            },
+                            || {
+                                let mut out = Vec::new();
+                                let mut input = Cursor::new("1,2\n");
+                                let runtime = test_runtime();
+                                runtime
+                                    .block_on(run_with_io_async_for_project_root(
+                                        InitArgs {
+                                            command: None,
+                                            install_default_daemon: false,
+                                            force: false,
+                                            disable_devql_guidance: false,
+                                            agent: vec![DEFAULT_AGENT.to_string()],
+                                            telemetry: Some(false),
+                                            no_telemetry: false,
+                                            skip_baseline: false,
+                                            sync: None,
+                                            ingest: None,
+                                            backfill: None,
+                                            exclude: Vec::new(),
+                                            exclude_from: Vec::new(),
+                                            embeddings_runtime: None,
+                                            no_embeddings: false,
+                                            no_summaries: false,
+                                            context_guidance_runtime: None,
+                                            no_context_guidance: false,
+                                            context_guidance_gateway_url: None,
+                                            context_guidance_api_key_env: None,
+                                            embeddings_gateway_url: None,
+                                            embeddings_api_key_env:
+                                                "BITLOOPS_PLATFORM_GATEWAY_TOKEN".to_string(),
+                                        },
+                                        repo.path(),
+                                        &mut out,
+                                        &mut input,
+                                        None,
+                                    ))
+                                    .expect("run init");
+
+                                let rendered =
+                                    strip_ansi_escape_sequences(&String::from_utf8(out).unwrap());
+                                assert!(rendered.contains("3. Code embeddings"));
+                                assert!(rendered.contains("4. Summaries"));
+                                assert!(rendered.contains("5. Summary embeddings"));
+
+                                let policy = std::fs::read_to_string(
+                                    repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+                                )
+                                .expect("read local policy");
+                                assert!(policy.contains("summary_mode = \"off\""));
+                                assert!(!policy.contains("summary_generation = "));
+                                assert!(!policy.contains("summary_embeddings = "));
+                            },
+                        )
                     },
                 );
             },
@@ -5059,7 +5273,7 @@ model = "bge-m3"
 }
 
 #[test]
-fn run_init_existing_selection_preserves_distinct_repo_embedding_bindings() {
+fn run_init_existing_repo_embedding_bindings_are_disabled_without_resolvable_runtime() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
@@ -5088,114 +5302,26 @@ summary_embeddings = "summary_profile"
 [runtime]
 local_dev = false
 
+[semantic_clones.inference]
+code_embeddings = "code_profile"
+summary_embeddings = "summary_profile"
+
+[inference.runtimes.bitloops_local_embeddings]
+command = "bitloops-local-embeddings"
+args = []
+startup_timeout_secs = 5
+request_timeout_secs = 5
+
 [inference.profiles.code_profile]
 task = "embeddings"
-driver = "openai"
+driver = "bitloops_embeddings_ipc"
+runtime = "bitloops_local_embeddings"
 model = "text-embedding-3-large"
 
 [inference.profiles.summary_profile]
 task = "embeddings"
-driver = "openai"
-model = "text-embedding-3-small"
-"#,
-                )
-                .expect("write daemon config");
-                Ok(())
-            },
-            || {
-                with_global_graphql_executor_hook(
-                    |_runtime_root, _query, variables| {
-                        assert_eq!(variables["telemetry"], serde_json::json!(false));
-                        Ok(serde_json::json!({
-                            "updateCliTelemetryConsent": {
-                                "telemetry": false,
-                                "needsPrompt": false
-                            }
-                        }))
-                    },
-                    || {
-                        let mut out = Vec::new();
-                        let mut input = Cursor::new("");
-                        let runtime = test_runtime();
-                        runtime
-                            .block_on(run_with_io_async_for_project_root(
-                                InitArgs {
-                                    command: None,
-                                    install_default_daemon: true,
-                                    force: false,
-                                    disable_devql_guidance: false,
-                                    agent: vec![DEFAULT_AGENT.to_string()],
-                                    telemetry: Some(false),
-                                    no_telemetry: false,
-                                    skip_baseline: false,
-                                    sync: Some(false),
-                                    ingest: Some(false),
-                                    backfill: None,
-                                    exclude: Vec::new(),
-                                    exclude_from: Vec::new(),
-                                    embeddings_runtime: None,
-                                    no_embeddings: false,
-                                    no_summaries: false,
-                                    context_guidance_runtime: None,
-                                    no_context_guidance: false,
-                                    context_guidance_gateway_url: None,
-                                    context_guidance_api_key_env: None,
-                                    embeddings_gateway_url: None,
-                                    embeddings_api_key_env: "BITLOOPS_PLATFORM_GATEWAY_TOKEN"
-                                        .to_string(),
-                                },
-                                repo.path(),
-                                &mut out,
-                                &mut input,
-                                None,
-                            ))
-                            .expect("run init");
-
-                        assert_repo_embedding_policy_bindings(
-                            &repo,
-                            "code_profile",
-                            "summary_profile",
-                        );
-                    },
-                );
-            },
-        );
-    });
-}
-
-#[test]
-fn run_init_existing_selection_preserves_distinct_legacy_daemon_embedding_bindings() {
-    let repo = tempfile::tempdir().unwrap();
-    let app_dirs = tempfile::tempdir().unwrap();
-    setup_git_repo(&repo);
-
-    with_temp_app_dirs_and_summary_configured(&app_dirs, false, true, true, || {
-        with_install_default_daemon_hook(
-            move |install_default_daemon| {
-                assert!(install_default_daemon);
-                let config_path =
-                    ensure_daemon_config_exists().expect("create default daemon config");
-                std::fs::write(
-                    &config_path,
-                    r#"
-[runtime]
-local_dev = false
-
-[semantic_clones]
-embedding_mode = "refresh_on_upgrade"
-
-[semantic_clones.inference]
-code_embeddings = "daemon_code_profile"
-summary_embeddings = "daemon_summary_profile"
-
-[inference.profiles.daemon_code_profile]
-task = "embeddings"
-driver = "openai"
-model = "text-embedding-3-large"
-
-[inference.profiles.daemon_summary_profile]
-task = "embeddings"
-driver = "openai"
+driver = "bitloops_embeddings_ipc"
+runtime = "bitloops_local_embeddings"
 model = "text-embedding-3-small"
 "#,
                 )
@@ -5254,9 +5380,116 @@ model = "text-embedding-3-small"
                         let policy =
                             std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
                                 .expect("read local policy");
-                        assert!(policy.contains("embedding_mode = \"refresh_on_upgrade\""));
+                        assert!(
+                            policy.contains("embedding_mode = \"off\""),
+                            "unresolvable existing embeddings should be disabled:\n{policy}"
+                        );
+                        assert!(
+                            !policy.contains("code_embeddings = ")
+                                && !policy.contains("summary_embeddings = "),
+                            "unresolvable existing embeddings should not persist profile bindings:\n{policy}"
+                        );
+                    },
+                );
+            },
+        );
+    });
+}
+
+#[test]
+fn run_init_existing_selection_preserves_distinct_legacy_daemon_embedding_bindings() {
+    let repo = tempfile::tempdir().unwrap();
+    let app_dirs = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+
+    with_temp_app_dirs_and_summary_configured(&app_dirs, true, true, true, || {
+        with_install_default_daemon_hook(
+            move |install_default_daemon| {
+                assert!(install_default_daemon);
+                let config_path =
+                    ensure_daemon_config_exists().expect("create default daemon config");
+                std::fs::write(
+                    &config_path,
+                    r#"
+[runtime]
+local_dev = false
+
+[semantic_clones]
+embedding_mode = "refresh_on_upgrade"
+
+[semantic_clones.inference]
+code_embeddings = "daemon_code_profile"
+summary_embeddings = "daemon_summary_profile"
+
+[inference.profiles.daemon_code_profile]
+task = "embeddings"
+driver = "openai"
+model = "text-embedding-3-large"
+
+[inference.profiles.daemon_summary_profile]
+task = "embeddings"
+driver = "openai"
+model = "text-embedding-3-small"
+"#,
+                )
+                .expect("write daemon config");
+                Ok(())
+            },
+            || {
+                with_global_graphql_executor_hook(
+                    |_runtime_root, _query, variables| {
+                        assert_eq!(variables["telemetry"], serde_json::json!(false));
+                        Ok(serde_json::json!({
+                            "updateCliTelemetryConsent": {
+                                "telemetry": false,
+                                "needsPrompt": false
+                            }
+                        }))
+                    },
+                    || {
+                        let mut out = Vec::new();
+                        let mut input = Cursor::new("3,4,5\n");
+                        let runtime = test_runtime();
+                        runtime
+                            .block_on(run_with_io_async_for_project_root(
+                                InitArgs {
+                                    command: None,
+                                    install_default_daemon: true,
+                                    force: false,
+                                    disable_devql_guidance: false,
+                                    agent: vec![DEFAULT_AGENT.to_string()],
+                                    telemetry: Some(false),
+                                    no_telemetry: false,
+                                    skip_baseline: false,
+                                    sync: Some(false),
+                                    ingest: Some(false),
+                                    backfill: None,
+                                    exclude: Vec::new(),
+                                    exclude_from: Vec::new(),
+                                    embeddings_runtime: None,
+                                    no_embeddings: false,
+                                    no_summaries: false,
+                                    context_guidance_runtime: None,
+                                    no_context_guidance: false,
+                                    context_guidance_gateway_url: None,
+                                    context_guidance_api_key_env: None,
+                                    embeddings_gateway_url: None,
+                                    embeddings_api_key_env: "BITLOOPS_PLATFORM_GATEWAY_TOKEN"
+                                        .to_string(),
+                                },
+                                repo.path(),
+                                &mut out,
+                                &mut input,
+                                None,
+                            ))
+                            .expect("run init");
+
+                        let policy =
+                            std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
+                                .expect("read local policy");
+                        assert!(policy.contains("embedding_mode = \"semantic_aware_once\""));
                         assert!(policy.contains("code_embeddings = \"daemon_code_profile\""));
-                        assert!(policy.contains("summary_embeddings = \"daemon_summary_profile\""));
+                        assert!(policy.contains("summary_embeddings = \"daemon_code_profile\""));
                     },
                 );
             },
@@ -6377,7 +6610,7 @@ fn run_init_with_install_default_daemon_renders_separate_summaries_lane() {
         |_| false,
         || {
             with_test_platform_dir_overrides(app_dir_overrides(&app_dirs), || {
-                with_test_tty_override(false, || {
+                with_test_tty_override(true, || {
                     with_test_assume_daemon_running(true, || {
                         with_install_default_daemon_hook(
                             move |install_default_daemon| {
@@ -6407,7 +6640,11 @@ fn run_init_with_install_default_daemon_renders_separate_summaries_lane() {
                                     },
                                     || {
                                         with_ollama_probe_hook(
-                                            || Ok(OllamaAvailability::MissingCli),
+                                            || {
+                                                Ok(OllamaAvailability::Running {
+                                                    models: vec!["ministral-3:3b".to_string()],
+                                                })
+                                            },
                                             || {
                                                 with_ingest_daemon_bootstrap_hook(
                                                     |_repo_root| Ok(()),
@@ -6427,7 +6664,11 @@ fn run_init_with_install_default_daemon_renders_separate_summaries_lane() {
                                                                         assert_eq!(variables["input"]["runIngest"], json!(false));
                                                                         assert_eq!(
                                                                             variables["input"]["summariesBootstrap"]["action"],
-                                                                            json!("INSTALL_RUNTIME_ONLY")
+                                                                            json!("CONFIGURE_LOCAL")
+                                                                        );
+                                                                        assert_eq!(
+                                                                            variables["input"]["summariesBootstrap"]["modelName"],
+                                                                            json!("ministral-3:3b")
                                                                         );
                                                                         return Ok(runtime_start_init_result_json(session_id));
                                                                     }
@@ -6459,7 +6700,8 @@ fn run_init_with_install_default_daemon_renders_separate_summaries_lane() {
                                                             },
                                                             || {
                                                                 let mut out = Vec::new();
-                                                                let mut input = Cursor::new("");
+                                                                let mut input =
+                                                                    Cursor::new("1,3,4,5\n3\n");
                                                                 let runtime = test_runtime();
                                                                 runtime
                                                                     .block_on(run_with_io_async_for_project_root(
@@ -6468,7 +6710,10 @@ fn run_init_with_install_default_daemon_renders_separate_summaries_lane() {
                                                                             install_default_daemon: true,
                                                                             force: false,
                                                                             disable_devql_guidance: false,
-                                                                            agent: Vec::new(),
+                                                                            agent: vec![
+                                                                                DEFAULT_AGENT
+                                                                                    .to_string(),
+                                                                            ],
                                                                             telemetry: Some(false),
                                                                             no_telemetry: false,
                                                                             skip_baseline: false,
@@ -6668,6 +6913,142 @@ fn choose_final_setup_options_prompts_for_all_repo_local_choices() {
         assert!(rendered.contains("4. Summaries"));
         assert!(rendered.contains("5. Summary embeddings"));
     });
+}
+
+#[test]
+fn init_runtime_lanes_follow_repo_setup_selection() {
+    let saw_start_init = std::rc::Rc::new(std::cell::RefCell::new(false));
+    let repo = tempfile::tempdir().unwrap();
+    let app_dirs = tempfile::tempdir().unwrap();
+    let repo_id = test_repo_id(repo.path());
+    let session_id = "init-session-repo-selected-lanes";
+    setup_git_repo(&repo);
+
+    with_temp_app_dirs(&app_dirs, true, true, || {
+        let config_path = ensure_daemon_config_exists().expect("create default daemon config");
+        write_daemon_config_with_embeddings_and_summary(&config_path);
+        crate::config::settings::write_repo_daemon_binding(
+            &repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+            &config_path,
+        )
+        .expect("write repo daemon binding");
+
+        with_global_graphql_executor_hook(
+            |_runtime_root, _query, variables| {
+                assert_eq!(variables["telemetry"], serde_json::json!(false));
+                Ok(serde_json::json!({
+                    "updateCliTelemetryConsent": {
+                        "telemetry": false,
+                        "needsPrompt": false
+                    }
+                }))
+            },
+            || {
+                with_ingest_daemon_bootstrap_hook(
+                    |_repo_root| Ok(()),
+                    || {
+                        with_graphql_executor_hook(
+                            {
+                                let saw_start_init = std::rc::Rc::clone(&saw_start_init);
+                                let repo_id = repo_id.clone();
+                                move |_repo_root, query, variables| {
+                                    if query.contains("startInit(") {
+                                        *saw_start_init.borrow_mut() = true;
+                                        assert_eq!(variables["repoId"], repo_id);
+                                        assert_eq!(variables["input"]["runSync"], json!(true));
+                                        assert_eq!(variables["input"]["runIngest"], json!(true));
+                                        assert_eq!(
+                                            variables["input"]["runCodeEmbeddings"],
+                                            json!(true)
+                                        );
+                                        assert_eq!(variables["input"]["runSummaries"], json!(true));
+                                        assert_eq!(
+                                            variables["input"]["runSummaryEmbeddings"],
+                                            json!(true)
+                                        );
+                                        assert_eq!(
+                                            variables["input"]["embeddingsBootstrap"],
+                                            serde_json::Value::Null
+                                        );
+                                        assert_eq!(
+                                            variables["input"]["summariesBootstrap"],
+                                            serde_json::Value::Null
+                                        );
+                                        return Ok(runtime_start_init_result_json(session_id));
+                                    }
+
+                                    if query.contains("runtimeSnapshot(") {
+                                        return Ok(runtime_snapshot_json(
+                                            repo_id.as_str(),
+                                            session_id,
+                                            RuntimeSessionSnapshotFixture {
+                                                status: "COMPLETED",
+                                                run_sync: true,
+                                                run_ingest: true,
+                                                embeddings_selected: true,
+                                                summaries_selected: true,
+                                                summary_embeddings_selected: true,
+                                                top_lane_status: "COMPLETED",
+                                                embeddings_lane_status: "COMPLETED",
+                                                summaries_lane_status: "COMPLETED",
+                                                summary_embeddings_lane_status: Some("COMPLETED"),
+                                                ..RuntimeSessionSnapshotFixture::default()
+                                            },
+                                        ));
+                                    }
+
+                                    panic!("unexpected repo-scoped query: {query}");
+                                }
+                            },
+                            || {
+                                let mut out = Vec::new();
+                                let mut input = Cursor::new("all\n");
+                                let runtime = test_runtime();
+                                runtime
+                                    .block_on(run_with_io_async_for_project_root(
+                                        InitArgs {
+                                            command: None,
+                                            install_default_daemon: false,
+                                            force: false,
+                                            disable_devql_guidance: false,
+                                            agent: vec![DEFAULT_AGENT.to_string()],
+                                            telemetry: Some(false),
+                                            no_telemetry: false,
+                                            skip_baseline: false,
+                                            sync: None,
+                                            ingest: None,
+                                            backfill: None,
+                                            exclude: Vec::new(),
+                                            exclude_from: Vec::new(),
+                                            embeddings_runtime: None,
+                                            no_embeddings: false,
+                                            no_summaries: false,
+                                            context_guidance_runtime: None,
+                                            no_context_guidance: false,
+                                            context_guidance_gateway_url: None,
+                                            context_guidance_api_key_env: None,
+                                            embeddings_gateway_url: None,
+                                            embeddings_api_key_env:
+                                                "BITLOOPS_PLATFORM_GATEWAY_TOKEN".to_string(),
+                                        },
+                                        repo.path(),
+                                        &mut out,
+                                        &mut input,
+                                        None,
+                                    ))
+                                    .expect("run init");
+                            },
+                        )
+                    },
+                );
+            },
+        );
+    });
+
+    assert!(
+        *saw_start_init.borrow(),
+        "init should invoke runtime startInit"
+    );
 }
 
 #[test]

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -945,6 +945,42 @@ fn choose_summary_setup_during_init_can_reenable_existing_summary_mode_off() {
 }
 
 #[test]
+fn choose_summary_setup_during_init_prompts_when_only_daemon_summary_provider_exists() {
+    let repo = tempfile::tempdir().expect("tempdir");
+    let config_path = repo.path().join(BITLOOPS_CONFIG_RELATIVE_PATH);
+    write_daemon_config_with_embeddings_and_summary(&config_path);
+    crate::config::settings::write_repo_daemon_binding(
+        &repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+        &config_path,
+    )
+    .expect("write daemon binding");
+    let mut out = Vec::new();
+    let mut input = Cursor::new("\n");
+
+    let selection = with_test_tty_override(true, || {
+        test_runtime().block_on(choose_summary_setup_during_init(
+            repo.path(),
+            true,
+            false,
+            true,
+            &mut out,
+            &mut input,
+        ))
+    })
+    .expect("choose summary setup");
+
+    assert_eq!(
+        selection,
+        crate::cli::inference::SummarySetupSelection::Skip
+    );
+    let rendered = String::from_utf8(out).expect("utf8 output");
+    assert!(
+        rendered.contains("Configure semantic summaries"),
+        "summary setup should remain repo-local even when daemon has providers:\n{rendered}"
+    );
+}
+
+#[test]
 fn summary_setup_skips_when_repo_did_not_select_summaries() {
     let repo = tempfile::tempdir().expect("tempdir");
     let mut out = Vec::new();
@@ -4089,7 +4125,7 @@ fn run_init_without_install_default_daemon_explicit_platform_persists_repo_polic
 }
 
 #[test]
-fn second_repo_uses_existing_daemon_providers_without_expanding_final_setup_prompt() {
+fn second_repo_can_skip_summaries_even_when_daemon_provider_exists() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     let repo_id = test_repo_id(repo.path());
@@ -4131,10 +4167,13 @@ fn second_repo_uses_existing_daemon_providers_without_expanding_final_setup_prom
                                             variables["input"]["runCodeEmbeddings"],
                                             json!(true)
                                         );
-                                        assert_eq!(variables["input"]["runSummaries"], json!(true));
+                                        assert_eq!(
+                                            variables["input"]["runSummaries"],
+                                            json!(false)
+                                        );
                                         assert_eq!(
                                             variables["input"]["runSummaryEmbeddings"],
-                                            json!(true)
+                                            json!(false)
                                         );
                                         return Ok(runtime_start_init_result_json(session_id));
                                     }
@@ -4148,12 +4187,10 @@ fn second_repo_uses_existing_daemon_providers_without_expanding_final_setup_prom
                                                 run_sync: true,
                                                 run_ingest: true,
                                                 embeddings_selected: true,
-                                                summaries_selected: true,
-                                                summary_embeddings_selected: true,
+                                                summaries_selected: false,
+                                                summary_embeddings_selected: false,
                                                 top_lane_status: "COMPLETED",
                                                 embeddings_lane_status: "COMPLETED",
-                                                summaries_lane_status: "COMPLETED",
-                                                summary_embeddings_lane_status: Some("COMPLETED"),
                                                 ..RuntimeSessionSnapshotFixture::default()
                                             },
                                         ));
@@ -4164,7 +4201,7 @@ fn second_repo_uses_existing_daemon_providers_without_expanding_final_setup_prom
                             },
                             || {
                                 let mut out = Vec::new();
-                                let mut input = Cursor::new("1,2\n");
+                                let mut input = Cursor::new("\n1,2\n");
                                 let runtime = test_runtime();
                                 runtime
                                     .block_on(run_with_io_async_for_project_root(
@@ -4202,6 +4239,7 @@ fn second_repo_uses_existing_daemon_providers_without_expanding_final_setup_prom
 
                                 let rendered =
                                     strip_ansi_escape_sequences(&String::from_utf8(out).unwrap());
+                                assert!(rendered.contains("Configure semantic summaries"));
                                 assert!(!rendered.contains("3. Code embeddings"));
                                 assert!(!rendered.contains("4. Summaries"));
                                 assert!(!rendered.contains("5. Summary embeddings"));
@@ -4210,9 +4248,9 @@ fn second_repo_uses_existing_daemon_providers_without_expanding_final_setup_prom
                                     repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
                                 )
                                 .expect("read local policy");
-                                assert!(policy.contains("summary_mode = \"auto\""));
-                                assert!(policy.contains("summary_generation = \"summary_local\""));
-                                assert!(policy.contains("summary_embeddings = \"local_code\""));
+                                assert!(policy.contains("summary_mode = \"off\""));
+                                assert!(!policy.contains("summary_generation = "));
+                                assert!(!policy.contains("summary_embeddings = "));
                             },
                         )
                     },
@@ -5574,7 +5612,7 @@ model = "text-embedding-3-small"
 }
 
 #[test]
-fn run_init_existing_selection_preserves_distinct_legacy_daemon_embedding_bindings() {
+fn run_init_existing_selection_uses_daemon_code_embeddings_without_enabling_summaries() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
@@ -5633,7 +5671,7 @@ model = "daemon-summary-model"
                     },
                     || {
                         let mut out = Vec::new();
-                        let mut input = Cursor::new("3,4,5\n");
+                        let mut input = Cursor::new("\n");
                         let runtime = test_runtime();
                         runtime
                             .block_on(run_with_io_async_for_project_root(
@@ -5673,12 +5711,10 @@ model = "daemon-summary-model"
                             std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
                                 .expect("read local policy");
                         assert!(policy.contains("embedding_mode = \"semantic_aware_once\""));
-                        assert!(policy.contains("summary_mode = \"auto\""));
+                        assert!(policy.contains("summary_mode = \"off\""));
                         assert!(policy.contains("code_embeddings = \"daemon_code_profile\""));
-                        assert!(policy.contains("summary_embeddings = \"daemon_summary_profile\""));
-                        assert!(
-                            policy.contains("summary_generation = \"daemon_summary_generation\"")
-                        );
+                        assert!(!policy.contains("summary_embeddings = "));
+                        assert!(!policy.contains("summary_generation = "));
                     },
                 );
             },
@@ -5702,9 +5738,11 @@ config_path = {:?}
 
 [semantic_clones]
 embedding_mode = "semantic_aware_once"
+summary_mode = "auto"
 
 [semantic_clones.inference]
 code_embeddings = "repo_code_profile"
+summary_generation = "daemon_summary_generation"
 "#,
             config_path.to_string_lossy()
         ),

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -43,10 +43,6 @@ fn write_repo_policy(dir: &TempDir, file_name: &str, content: &str) {
     std::fs::write(dir.path().join(file_name), content).expect("write repo policy");
 }
 
-fn assert_repo_embedding_policy(repo: &TempDir, profile_name: &str) {
-    assert_repo_embedding_policy_bindings(repo, profile_name, profile_name);
-}
-
 fn assert_repo_code_embedding_policy(repo: &TempDir, profile_name: &str) {
     let policy = std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
         .expect("read local policy");
@@ -65,27 +61,6 @@ fn assert_repo_code_embedding_policy(repo: &TempDir, profile_name: &str) {
     assert!(
         policy.contains("summary_mode = \"off\""),
         "expected summaries off:\n{policy}"
-    );
-}
-
-fn assert_repo_embedding_policy_bindings(
-    repo: &TempDir,
-    code_profile_name: &str,
-    summary_profile_name: &str,
-) {
-    let policy = std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
-        .expect("read local policy");
-    assert!(
-        policy.contains("embedding_mode = \"semantic_aware_once\""),
-        "expected semantic-aware embedding mode:\n{policy}"
-    );
-    assert!(
-        policy.contains(&format!("code_embeddings = \"{code_profile_name}\"")),
-        "expected code embedding profile {code_profile_name}:\n{policy}"
-    );
-    assert!(
-        policy.contains(&format!("summary_embeddings = \"{summary_profile_name}\"")),
-        "expected summary embedding profile {summary_profile_name}:\n{policy}"
     );
 }
 
@@ -316,7 +291,7 @@ fn render_install_default_daemon_handoff_with_mkcert(
                                         exclude_from: Vec::new(),
                                         embeddings_runtime: None,
                                         no_embeddings: true,
-                                        no_summaries: false,
+                                        no_summaries: true,
                                         context_guidance_runtime: None,
                                         no_context_guidance: false,
                                         context_guidance_gateway_url: None,
@@ -494,11 +469,6 @@ fn write_daemon_config_with_embeddings_and_summary(config_path: &Path) {
         r#"
 [runtime]
 local_dev = false
-
-[semantic_clones.inference]
-summary_generation = "summary_local"
-code_embeddings = "local_code"
-summary_embeddings = "local_code"
 
 [inference.runtimes.bitloops_local_embeddings]
 command = "bitloops-local-embeddings"
@@ -3428,8 +3398,8 @@ fn run_init_prompts_for_unresolved_existing_telemetry_consent() {
                             exclude: Vec::new(),
                             exclude_from: Vec::new(),
                             embeddings_runtime: None,
-                            no_embeddings: false,
-                            no_summaries: false,
+                            no_embeddings: true,
+                            no_summaries: true,
                             context_guidance_runtime: None,
                             no_context_guidance: false,
                             context_guidance_gateway_url: None,
@@ -3717,7 +3687,7 @@ fn run_init_with_install_default_daemon_shows_shell_escaped_config_path() {
                                                                 exclude_from: Vec::new(),
                                                                 embeddings_runtime: None,
                                                                 no_embeddings: true,
-                                                                no_summaries: false,
+                                                                no_summaries: true,
                                                                 context_guidance_runtime: None,
                                                                 no_context_guidance: false,
                                                                 context_guidance_gateway_url: None,
@@ -3835,7 +3805,7 @@ fn run_init_without_install_default_daemon_prompts_for_skippable_embeddings_setu
             },
             || {
                 let mut out = Vec::new();
-                let mut input = Cursor::new("3\n3\n");
+                let mut input = Cursor::new("3\n1\n");
                 let runtime = test_runtime();
                 runtime
                     .block_on(run_with_io_async_for_project_root(
@@ -4165,7 +4135,7 @@ fn second_repo_can_skip_summaries_even_when_daemon_provider_exists() {
                                         assert_eq!(variables["input"]["runIngest"], json!(true));
                                         assert_eq!(
                                             variables["input"]["runCodeEmbeddings"],
-                                            json!(true)
+                                            json!(false)
                                         );
                                         assert_eq!(
                                             variables["input"]["runSummaries"],
@@ -4186,11 +4156,10 @@ fn second_repo_can_skip_summaries_even_when_daemon_provider_exists() {
                                                 status: "COMPLETED",
                                                 run_sync: true,
                                                 run_ingest: true,
-                                                embeddings_selected: true,
+                                                embeddings_selected: false,
                                                 summaries_selected: false,
                                                 summary_embeddings_selected: false,
                                                 top_lane_status: "COMPLETED",
-                                                embeddings_lane_status: "COMPLETED",
                                                 ..RuntimeSessionSnapshotFixture::default()
                                             },
                                         ));
@@ -4201,7 +4170,7 @@ fn second_repo_can_skip_summaries_even_when_daemon_provider_exists() {
                             },
                             || {
                                 let mut out = Vec::new();
-                                let mut input = Cursor::new("\n1,2\n");
+                                let mut input = Cursor::new("3\n\n1,2\n");
                                 let runtime = test_runtime();
                                 runtime
                                     .block_on(run_with_io_async_for_project_root(
@@ -4836,7 +4805,7 @@ fn run_init_with_install_default_daemon_auto_installs_embeddings() {
                                                 crate::cli::embeddings::EmbeddingsRuntime::Local,
                                             ),
                                             no_embeddings: false,
-                                            no_summaries: false,
+                                            no_summaries: true,
                                             context_guidance_runtime: None,
                                             no_context_guidance: false,
                                             context_guidance_gateway_url: None,
@@ -4944,7 +4913,7 @@ fn run_init_with_install_default_daemon_leaves_embeddings_unchanged_when_noninte
                                     exclude_from: Vec::new(),
                                     embeddings_runtime: None,
                                     no_embeddings: false,
-                                    no_summaries: false,
+                                    no_summaries: true,
                                     context_guidance_runtime: None,
                                     no_context_guidance: false,
                                     context_guidance_gateway_url: None,
@@ -5022,7 +4991,7 @@ fn run_init_with_install_default_daemon_can_skip_embeddings_via_flag() {
                                 exclude_from: Vec::new(),
                                 embeddings_runtime: None,
                                 no_embeddings: true,
-                                no_summaries: false,
+                                no_summaries: true,
                                 context_guidance_runtime: None,
                                 no_context_guidance: false,
                                 context_guidance_gateway_url: None,
@@ -5316,7 +5285,7 @@ fn run_init_no_embeddings_persists_repo_embedding_policy_off() {
                                     exclude_from: Vec::new(),
                                     embeddings_runtime: None,
                                     no_embeddings: true,
-                                    no_summaries: false,
+                                    no_summaries: true,
                                     context_guidance_runtime: None,
                                     no_context_guidance: false,
                                     context_guidance_gateway_url: None,
@@ -5447,7 +5416,7 @@ model = "bge-m3"
                                                 crate::cli::embeddings::EmbeddingsRuntime::Local,
                                             ),
                                             no_embeddings: false,
-                                            no_summaries: false,
+                                            no_summaries: true,
                                             context_guidance_runtime: None,
                                             no_context_guidance: false,
                                             context_guidance_gateway_url: None,
@@ -5530,7 +5499,7 @@ request_timeout_secs = 5
 [inference.profiles.code_profile]
 task = "embeddings"
 driver = "bitloops_embeddings_ipc"
-runtime = "bitloops_local_embeddings"
+runtime = "missing_embeddings_runtime"
 model = "text-embedding-3-large"
 
 [inference.profiles.summary_profile]
@@ -5576,7 +5545,7 @@ model = "text-embedding-3-small"
                                     exclude_from: Vec::new(),
                                     embeddings_runtime: None,
                                     no_embeddings: false,
-                                    no_summaries: false,
+                                    no_summaries: true,
                                     context_guidance_runtime: None,
                                     no_context_guidance: false,
                                     context_guidance_gateway_url: None,
@@ -5612,7 +5581,7 @@ model = "text-embedding-3-small"
 }
 
 #[test]
-fn run_init_existing_selection_uses_daemon_code_embeddings_without_enabling_summaries() {
+fn run_init_ignores_daemon_semantic_bindings_without_repo_selection() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
@@ -5671,7 +5640,7 @@ model = "daemon-summary-model"
                     },
                     || {
                         let mut out = Vec::new();
-                        let mut input = Cursor::new("\n");
+                        let mut input = Cursor::new("3\n");
                         let runtime = test_runtime();
                         runtime
                             .block_on(run_with_io_async_for_project_root(
@@ -5691,7 +5660,7 @@ model = "daemon-summary-model"
                                     exclude_from: Vec::new(),
                                     embeddings_runtime: None,
                                     no_embeddings: false,
-                                    no_summaries: false,
+                                    no_summaries: true,
                                     context_guidance_runtime: None,
                                     no_context_guidance: false,
                                     context_guidance_gateway_url: None,
@@ -5710,9 +5679,9 @@ model = "daemon-summary-model"
                         let policy =
                             std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
                                 .expect("read local policy");
-                        assert!(policy.contains("embedding_mode = \"semantic_aware_once\""));
+                        assert!(policy.contains("embedding_mode = \"off\""));
                         assert!(policy.contains("summary_mode = \"off\""));
-                        assert!(policy.contains("code_embeddings = \"daemon_code_profile\""));
+                        assert!(!policy.contains("code_embeddings = "));
                         assert!(!policy.contains("summary_embeddings = "));
                         assert!(!policy.contains("summary_generation = "));
                     },
@@ -5988,7 +5957,7 @@ fn run_init_with_install_default_daemon_can_configure_cloud_embeddings_from_gate
                                                     },
                                                     || {
                                                         let mut out = Vec::new();
-                                                        let mut input = Cursor::new("3\n1\n");
+                                                        let mut input = Cursor::new("1\n1\n");
                                                         let runtime = test_runtime();
                                                         runtime
                                                             .block_on(run_with_io_async_for_project_root(
@@ -6043,7 +6012,7 @@ fn run_init_with_install_default_daemon_can_configure_cloud_embeddings_from_gate
                                                         assert!(!rendered.contains(
                                                             "Installed managed standalone `bitloops-platform-embeddings` runtime"
                                                         ));
-                                                        assert_repo_embedding_policy(
+                                                        assert_repo_code_embedding_policy(
                                                             &repo,
                                                             "platform_code",
                                                         );
@@ -6190,7 +6159,7 @@ fn run_init_with_install_default_daemon_can_configure_cloud_embeddings_without_g
                                                 },
                                                 || {
                                                     let mut out = Vec::new();
-                                                    let mut input = Cursor::new("3\n1\n");
+                                                    let mut input = Cursor::new("1\n1\n");
                                                     let runtime = test_runtime();
                                                     runtime
                                                         .block_on(run_with_io_async_for_project_root(
@@ -6731,7 +6700,7 @@ fn run_init_with_install_default_daemon_renders_follow_up_sync_waiting_state() {
                                                     embeddings_runtime:
                                                         Some(crate::cli::embeddings::EmbeddingsRuntime::Local),
                                                     no_embeddings: false,
-                                                    no_summaries: false,
+                                                    no_summaries: true,
                                                     context_guidance_runtime: None,
                                                     no_context_guidance: false,
                                                     context_guidance_gateway_url: None,
@@ -6775,6 +6744,17 @@ fn run_init_with_install_default_daemon_does_not_mark_summaries_complete_while_w
     let repo_id = test_repo_id(repo.path());
     let session_id = "init-session-summary-follow-up-wait";
     setup_git_repo(&repo);
+    write_repo_policy(
+        &repo,
+        REPO_POLICY_LOCAL_FILE_NAME,
+        r#"
+[semantic_clones]
+summary_mode = "auto"
+
+[semantic_clones.inference]
+summary_generation = "summary_local"
+"#,
+    );
 
     with_temp_app_dirs(&app_dirs, false, true, || {
         with_install_default_daemon_hook(
@@ -7253,6 +7233,20 @@ fn init_runtime_lanes_follow_repo_setup_selection() {
             &config_path,
         )
         .expect("write repo daemon binding");
+        crate::config::set_repo_semantic_embedding_policy(
+            &repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+            &crate::config::RepoSemanticEmbeddingPolicy {
+                present: true,
+                summary_mode: Some(crate::config::SemanticSummaryMode::Auto),
+                embedding_mode: Some(crate::config::SemanticCloneEmbeddingMode::SemanticAwareOnce),
+                inference: crate::config::SemanticClonesInferenceBindings {
+                    summary_generation: Some("summary_local".to_string()),
+                    code_embeddings: Some("local_code".to_string()),
+                    summary_embeddings: Some("local_code".to_string()),
+                },
+            },
+        )
+        .expect("write repo semantic policy");
 
         with_global_graphql_executor_hook(
             |_runtime_root, _query, variables| {
@@ -7645,7 +7639,7 @@ fn run_init_with_install_default_daemon_can_skip_auto_start() {
                             },
                             || {
                                 let mut out = Vec::new();
-                                let mut input = Cursor::new("none\n");
+                                let mut input = Cursor::new("\nnone\n");
                                 let select = |_items: &[String], enable_devql_guidance: bool| {
                                     Ok(InitAgentSelection {
                                         agents: vec!["claude-code".to_string()],

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -5723,7 +5723,7 @@ model = "daemon-summary-model"
 }
 
 #[test]
-fn run_init_existing_selection_fills_partial_repo_embedding_policy_from_daemon() {
+fn run_init_existing_selection_does_not_fill_summary_embeddings_from_daemon() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     setup_git_repo(&repo);
@@ -5831,7 +5831,7 @@ model = "daemon-summary-model"
         assert!(policy.contains("summary_mode = \"auto\""));
         assert!(policy.contains("summary_generation = \"daemon_summary_generation\""));
         assert!(policy.contains("code_embeddings = \"repo_code_profile\""));
-        assert!(policy.contains("summary_embeddings = \"daemon_summary_profile\""));
+        assert!(!policy.contains("summary_embeddings = "));
     });
 }
 
@@ -6560,7 +6560,7 @@ fn run_init_with_install_default_daemon_starts_runtime_session_for_sync_ingest_a
                                                     exclude_from: Vec::new(),
                                                 embeddings_runtime: Some(crate::cli::embeddings::EmbeddingsRuntime::Local),
                                                 no_embeddings: false,
-                                                no_summaries: false,
+                                                no_summaries: true,
                                                 context_guidance_runtime: None,
                                                 no_context_guidance: false,
                                                 context_guidance_gateway_url: None,

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -851,6 +851,7 @@ fn choose_summary_setup_during_init_skips_when_summary_mode_is_off() {
             repo.path(),
             true,
             false,
+            true,
             &mut out,
             &mut input,
         ))
@@ -860,6 +861,30 @@ fn choose_summary_setup_during_init_skips_when_summary_mode_is_off() {
         selection,
         crate::cli::inference::SummarySetupSelection::Skip
     );
+}
+
+#[test]
+fn summary_setup_skips_when_repo_did_not_select_summaries() {
+    let repo = tempfile::tempdir().expect("tempdir");
+    let mut out = Vec::new();
+    let mut input = Cursor::new("2\n");
+
+    let selection = test_runtime()
+        .block_on(choose_summary_setup_during_init(
+            repo.path(),
+            true,
+            false,
+            false,
+            &mut out,
+            &mut input,
+        ))
+        .expect("choose summary setup");
+
+    assert_eq!(
+        selection,
+        crate::cli::inference::SummarySetupSelection::Skip
+    );
+    assert!(String::from_utf8(out).expect("utf8 output").is_empty());
 }
 
 #[test]
@@ -879,6 +904,7 @@ fn choose_summary_setup_interactive_does_not_resolve_cloud_login_status() {
                             repo.path(),
                             false,
                             false,
+                            true,
                             &mut out,
                             &mut input,
                         ))
@@ -914,6 +940,7 @@ fn choose_summary_setup_noninteractive_treats_login_error_as_not_logged_in() {
                             repo.path(),
                             false,
                             false,
+                            true,
                             &mut out,
                             &mut input,
                         ))
@@ -1433,6 +1460,24 @@ fn init_embeddings_prompt_reprompts_after_invalid_input() {
     assert_eq!(selection, InitEmbeddingsSetupSelection::Skip);
     let rendered = String::from_utf8(out).expect("utf8 output");
     assert!(rendered.contains("Please choose 1, 2, or 3."));
+}
+
+#[test]
+fn embeddings_setup_skips_when_repo_did_not_select_embedding_lanes() {
+    let repo = tempfile::tempdir().expect("tempdir");
+    let parsed = Cli::try_parse_from(["bitloops", "init"]).expect("parse init");
+    let Some(Commands::Init(args)) = parsed.command else {
+        panic!("expected init command");
+    };
+    let mut out = Vec::new();
+    let mut input = Cursor::new("1\n");
+
+    let selection =
+        should_install_embeddings_during_init(repo.path(), &args, false, &mut out, &mut input)
+            .expect("choose embeddings setup");
+
+    assert_eq!(selection, InitEmbeddingsSetupSelection::Skip);
+    assert!(String::from_utf8(out).expect("utf8 output").is_empty());
 }
 
 #[test]
@@ -3566,7 +3611,7 @@ fn run_init_without_install_default_daemon_prompts_for_skippable_embeddings_setu
             },
             || {
                 let mut out = Vec::new();
-                let mut input = Cursor::new("3\n\n");
+                let mut input = Cursor::new("3\n3\n");
                 let runtime = test_runtime();
                 runtime
                     .block_on(run_with_io_async_for_project_root(
@@ -3640,7 +3685,7 @@ fn run_init_interactive_without_install_default_daemon_uses_full_setup_prompt_pa
                     |_repo_root| panic!("plain init should not install embeddings"),
                     || {
                         let mut out = Vec::new();
-                        let mut input = Cursor::new("3\n\n\n\n");
+                        let mut input = Cursor::new("3,4\n3\n\n\n");
                         let select = |_items: &[String], enable_devql_guidance: bool| {
                             Ok(InitAgentSelection {
                                 agents: vec!["claude-code".to_string()],
@@ -4133,7 +4178,7 @@ fn run_init_with_install_default_daemon_sends_summary_bootstrap_when_prompt_is_a
                                                             || {
                                                                 let mut out = Vec::new();
                                                                 let mut input =
-                                                                    Cursor::new("3\n\n");
+                                                                    Cursor::new("3,4\n3\n");
                                                                 let select = |_items: &[String],
                                                                               enable_devql_guidance: bool| {
                                                                     Ok(InitAgentSelection {
@@ -4766,6 +4811,7 @@ model = "bge-m3"
             embeddings_gateway_url: None,
             embeddings_api_key_env: "BITLOOPS_PLATFORM_GATEWAY_TOKEN".to_string(),
         },
+        true,
         &mut out,
         &mut input,
     )
@@ -5352,7 +5398,7 @@ fn run_init_with_install_default_daemon_can_configure_cloud_embeddings_from_gate
                                                     },
                                                     || {
                                                         let mut out = Vec::new();
-                                                        let mut input = Cursor::new("1\n1\n");
+                                                        let mut input = Cursor::new("3\n1\n");
                                                         let runtime = test_runtime();
                                                         runtime
                                                             .block_on(run_with_io_async_for_project_root(
@@ -5554,7 +5600,7 @@ fn run_init_with_install_default_daemon_can_configure_cloud_embeddings_without_g
                                                 },
                                                 || {
                                                     let mut out = Vec::new();
-                                                    let mut input = Cursor::new("1\n1\n");
+                                                    let mut input = Cursor::new("3\n1\n");
                                                     let runtime = test_runtime();
                                                     runtime
                                                         .block_on(run_with_io_async_for_project_root(
@@ -5745,7 +5791,7 @@ fn run_init_with_install_default_daemon_logs_in_once_for_cloud_embeddings_and_su
                                                     },
                                                     || {
                                                         let mut out = Vec::new();
-                                                        let mut input = Cursor::new("1\n2\n");
+                                                        let mut input = Cursor::new("3,4\n1\n2\n");
                                                         let runtime = test_runtime();
                                                         runtime
                                                             .block_on(run_with_io_async_for_project_root(

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -5249,7 +5249,7 @@ model = "bge-m3"
                                     .expect("run init");
                                 std::mem::forget(runtime);
 
-                                assert_repo_embedding_policy(&repo, "local_code");
+                                assert_repo_code_embedding_policy(&repo, "local_code");
                                 let config_path =
                                     default_daemon_config_path().expect("default daemon config");
                                 let daemon_config = std::fs::read_to_string(config_path)
@@ -6159,11 +6159,11 @@ fn run_init_with_install_default_daemon_starts_runtime_session_for_sync_ingest_a
                                                 );
                                                 assert_eq!(
                                                     variables["input"]["runSummaries"],
-                                                    json!(true)
+                                                    json!(false)
                                                 );
                                                 assert_eq!(
                                                     variables["input"]["runSummaryEmbeddings"],
-                                                    json!(true)
+                                                    json!(false)
                                                 );
                                                 assert_eq!(
                                                     variables["input"]["ingestBackfill"],
@@ -6188,14 +6188,10 @@ fn run_init_with_install_default_daemon_starts_runtime_session_for_sync_ingest_a
                                                         run_sync: true,
                                                         run_ingest: true,
                                                         embeddings_selected: true,
-                                                        summaries_selected: true,
-                                                        summary_embeddings_selected: true,
+                                                        summaries_selected: false,
+                                                        summary_embeddings_selected: false,
                                                         top_lane_status: "COMPLETED",
                                                         embeddings_lane_status: "COMPLETED",
-                                                        summaries_lane_status: "COMPLETED",
-                                                        summary_embeddings_lane_status: Some(
-                                                            "COMPLETED",
-                                                        ),
                                                         ..RuntimeSessionSnapshotFixture::default()
                                                     },
                                                 ));
@@ -6260,7 +6256,7 @@ fn run_init_with_install_default_daemon_starts_runtime_session_for_sync_ingest_a
                                             !rendered.contains("Starting initial DevQL sync...")
                                         );
                                         assert!(rendered.contains("Embeddings"));
-                                        assert_repo_embedding_policy(&repo, "local_code");
+                                        assert_repo_code_embedding_policy(&repo, "local_code");
                                     },
                                 )
                             },

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -6606,6 +6606,35 @@ fn choose_final_setup_options_prompts_for_all_repo_local_choices() {
 }
 
 #[test]
+fn choose_final_setup_options_does_not_preselect_code_embeddings_when_sync_disabled() {
+    with_test_tty_override(true, || {
+        let mut out = Vec::new();
+        let mut input = Cursor::new("\n");
+
+        let selection = choose_final_setup_options(
+            Some(false),
+            &mut out,
+            &mut input,
+            Some(true),
+            InitFinalSetupPromptOptions {
+                show_telemetry: false,
+                show_auto_start_daemon: false,
+            },
+        )
+        .expect("choose setup options");
+
+        assert!(!selection.sync);
+        assert!(selection.ingest);
+        assert!(!selection.code_embeddings);
+        assert!(!selection.summaries);
+        assert!(!selection.summary_embeddings);
+
+        let rendered = String::from_utf8(out).expect("utf8 output");
+        assert!(!rendered.contains("3. Code embeddings (selected)"));
+    });
+}
+
+#[test]
 fn choose_final_setup_options_enables_summaries_when_summary_embeddings_selected() {
     with_test_tty_override(true, || {
         let mut out = Vec::new();

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -3418,6 +3418,84 @@ fn run_init_prompts_for_unresolved_existing_telemetry_consent() {
 }
 
 #[test]
+fn run_init_prompts_for_semantic_setup_before_final_setup() {
+    let repo = tempfile::tempdir().unwrap();
+    let app_dirs = tempfile::tempdir().unwrap();
+    setup_git_repo(&repo);
+
+    with_temp_app_dirs_and_generation_configured(&app_dirs, true, true, false, false, || {
+        let mut out = Vec::new();
+        let mut input = Cursor::new("skip\nskip\nskip\nskip\n");
+        let select = |_items: &[String], enable_devql_guidance: bool| {
+            Ok(InitAgentSelection {
+                agents: vec!["claude-code".to_string()],
+                enable_devql_guidance,
+            })
+        };
+        let runtime = test_runtime();
+        runtime
+            .block_on(run_with_io_async_for_project_root(
+                InitArgs {
+                    command: None,
+                    install_default_daemon: false,
+                    force: false,
+                    disable_devql_guidance: false,
+                    agent: Vec::new(),
+                    telemetry: None,
+                    no_telemetry: false,
+                    skip_baseline: false,
+                    sync: None,
+                    ingest: None,
+                    backfill: None,
+                    exclude: Vec::new(),
+                    exclude_from: Vec::new(),
+                    embeddings_runtime: None,
+                    no_embeddings: false,
+                    no_summaries: false,
+                    context_guidance_runtime: None,
+                    no_context_guidance: false,
+                    context_guidance_gateway_url: None,
+                    context_guidance_api_key_env: None,
+                    embeddings_gateway_url: None,
+                    embeddings_api_key_env: "BITLOOPS_PLATFORM_GATEWAY_TOKEN".to_string(),
+                },
+                repo.path(),
+                &mut out,
+                &mut input,
+                Some(&select),
+            ))
+            .expect("run init");
+
+        let rendered = String::from_utf8(out).expect("utf8 output");
+        let embeddings = rendered
+            .find("Configure embeddings")
+            .expect("embeddings prompt");
+        let summaries = rendered
+            .find("Configure semantic summaries")
+            .expect("summary prompt");
+        let context_guidance = rendered
+            .find("Configure context guidance")
+            .expect("context guidance prompt");
+        let final_setup = rendered
+            .find("And we made it to the last setup options")
+            .expect("final setup prompt");
+
+        assert!(
+            embeddings < final_setup,
+            "expected embeddings setup before final setup:\n{rendered}"
+        );
+        assert!(
+            summaries < final_setup,
+            "expected summary setup before final setup:\n{rendered}"
+        );
+        assert!(
+            context_guidance < final_setup,
+            "expected context guidance setup before final setup:\n{rendered}"
+        );
+    });
+}
+
+#[test]
 fn run_init_noninteractive_existing_telemetry_requires_explicit_flag() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -1481,6 +1481,25 @@ fn embeddings_setup_skips_when_repo_did_not_select_embedding_lanes() {
 }
 
 #[test]
+fn embeddings_setup_honors_explicit_runtime_even_without_repo_embedding_lanes() {
+    let repo = tempfile::tempdir().expect("tempdir");
+    let parsed = Cli::try_parse_from(["bitloops", "init", "--embeddings-runtime", "local"])
+        .expect("parse init");
+    let Some(Commands::Init(args)) = parsed.command else {
+        panic!("expected init command");
+    };
+    let mut out = Vec::new();
+    let mut input = Cursor::new("1\n");
+
+    let selection =
+        should_install_embeddings_during_init(repo.path(), &args, false, &mut out, &mut input)
+            .expect("choose embeddings setup");
+
+    assert_eq!(selection, InitEmbeddingsSetupSelection::Local);
+    assert!(String::from_utf8(out).expect("utf8 output").is_empty());
+}
+
+#[test]
 fn init_args_reject_zero_backfill() {
     let err = Cli::try_parse_from(["bitloops", "init", "--backfill=0"])
         .err()

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -5489,7 +5489,7 @@ model = "text-embedding-3-small"
                                 .expect("read local policy");
                         assert!(policy.contains("embedding_mode = \"semantic_aware_once\""));
                         assert!(policy.contains("code_embeddings = \"daemon_code_profile\""));
-                        assert!(policy.contains("summary_embeddings = \"daemon_code_profile\""));
+                        assert!(policy.contains("summary_embeddings = \"daemon_summary_profile\""));
                     },
                 );
             },

--- a/bitloops/src/cli/init/tests.rs
+++ b/bitloops/src/cli/init/tests.rs
@@ -4011,7 +4011,7 @@ fn run_init_without_install_default_daemon_explicit_platform_persists_repo_polic
 }
 
 #[test]
-fn second_repo_can_disable_summaries_when_default_daemon_has_summary_provider() {
+fn second_repo_uses_existing_daemon_providers_without_expanding_final_setup_prompt() {
     let repo = tempfile::tempdir().unwrap();
     let app_dirs = tempfile::tempdir().unwrap();
     let repo_id = test_repo_id(repo.path());
@@ -4051,15 +4051,12 @@ fn second_repo_can_disable_summaries_when_default_daemon_has_summary_provider() 
                                         assert_eq!(variables["input"]["runIngest"], json!(true));
                                         assert_eq!(
                                             variables["input"]["runCodeEmbeddings"],
-                                            json!(false)
+                                            json!(true)
                                         );
-                                        assert_eq!(
-                                            variables["input"]["runSummaries"],
-                                            json!(false)
-                                        );
+                                        assert_eq!(variables["input"]["runSummaries"], json!(true));
                                         assert_eq!(
                                             variables["input"]["runSummaryEmbeddings"],
-                                            json!(false)
+                                            json!(true)
                                         );
                                         return Ok(runtime_start_init_result_json(session_id));
                                     }
@@ -4072,7 +4069,13 @@ fn second_repo_can_disable_summaries_when_default_daemon_has_summary_provider() 
                                                 status: "COMPLETED",
                                                 run_sync: true,
                                                 run_ingest: true,
+                                                embeddings_selected: true,
+                                                summaries_selected: true,
+                                                summary_embeddings_selected: true,
                                                 top_lane_status: "COMPLETED",
+                                                embeddings_lane_status: "COMPLETED",
+                                                summaries_lane_status: "COMPLETED",
+                                                summary_embeddings_lane_status: Some("COMPLETED"),
                                                 ..RuntimeSessionSnapshotFixture::default()
                                             },
                                         ));
@@ -4121,17 +4124,17 @@ fn second_repo_can_disable_summaries_when_default_daemon_has_summary_provider() 
 
                                 let rendered =
                                     strip_ansi_escape_sequences(&String::from_utf8(out).unwrap());
-                                assert!(rendered.contains("3. Code embeddings"));
-                                assert!(rendered.contains("4. Summaries"));
-                                assert!(rendered.contains("5. Summary embeddings"));
+                                assert!(!rendered.contains("3. Code embeddings"));
+                                assert!(!rendered.contains("4. Summaries"));
+                                assert!(!rendered.contains("5. Summary embeddings"));
 
                                 let policy = std::fs::read_to_string(
                                     repo.path().join(REPO_POLICY_LOCAL_FILE_NAME),
                                 )
                                 .expect("read local policy");
-                                assert!(policy.contains("summary_mode = \"off\""));
-                                assert!(!policy.contains("summary_generation = "));
-                                assert!(!policy.contains("summary_embeddings = "));
+                                assert!(policy.contains("summary_mode = \"auto\""));
+                                assert!(policy.contains("summary_generation = \"summary_local\""));
+                                assert!(policy.contains("summary_embeddings = \"local_code\""));
                             },
                         )
                     },
@@ -5512,10 +5515,12 @@ local_dev = false
 
 [semantic_clones]
 embedding_mode = "refresh_on_upgrade"
+summary_mode = "auto"
 
 [semantic_clones.inference]
 code_embeddings = "daemon_code_profile"
 summary_embeddings = "daemon_summary_profile"
+summary_generation = "daemon_summary_generation"
 
 [inference.profiles.daemon_code_profile]
 task = "embeddings"
@@ -5526,6 +5531,12 @@ model = "text-embedding-3-large"
 task = "embeddings"
 driver = "openai"
 model = "text-embedding-3-small"
+
+[inference.profiles.daemon_summary_generation]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "daemon-summary-model"
 "#,
                 )
                 .expect("write daemon config");
@@ -5584,8 +5595,12 @@ model = "text-embedding-3-small"
                             std::fs::read_to_string(repo.path().join(REPO_POLICY_LOCAL_FILE_NAME))
                                 .expect("read local policy");
                         assert!(policy.contains("embedding_mode = \"semantic_aware_once\""));
+                        assert!(policy.contains("summary_mode = \"auto\""));
                         assert!(policy.contains("code_embeddings = \"daemon_code_profile\""));
                         assert!(policy.contains("summary_embeddings = \"daemon_summary_profile\""));
+                        assert!(
+                            policy.contains("summary_generation = \"daemon_summary_generation\"")
+                        );
                     },
                 );
             },
@@ -7058,32 +7073,27 @@ fn choose_final_setup_options_renders_final_setup_prompt() {
         )
         .expect("render prompt");
 
-        assert_eq!(
-            selection,
-            InitFinalSetupSelection {
-                sync: true,
-                ingest: true,
-                code_embeddings: true,
-                summaries: false,
-                summary_embeddings: false,
-                telemetry: false,
-                auto_start_daemon: false,
-            }
-        );
+        assert!(selection.sync);
+        assert!(selection.ingest);
+        assert!(!selection.telemetry);
+        assert!(!selection.auto_start_daemon);
         let rendered = String::from_utf8(out).expect("utf8 output");
         assert!(rendered.contains("\nFinal setup\n"));
         assert!(rendered.contains("And we made it to the last setup options 🎉"));
         assert!(rendered.contains("Use space to select, enter to confirm."));
         assert!(rendered.contains("1. Sync codebase (selected)"));
         assert!(rendered.contains("2. Import commit history (selected)"));
+        assert!(!rendered.contains("Code embeddings"));
+        assert!(!rendered.contains("Summaries"));
+        assert!(!rendered.contains("Summary embeddings"));
     });
 }
 
 #[test]
-fn choose_final_setup_options_prompts_for_all_repo_local_choices() {
+fn choose_final_setup_options_does_not_render_semantic_repo_choices() {
     with_test_tty_override(true, || {
         let mut out = Vec::new();
-        let mut input = Cursor::new("1,2,3,4,5\n");
+        let mut input = Cursor::new("1,2\n");
 
         let selection = choose_final_setup_options(
             None,
@@ -7097,24 +7107,16 @@ fn choose_final_setup_options_prompts_for_all_repo_local_choices() {
         )
         .expect("choose setup options");
 
-        assert_eq!(
-            selection,
-            InitFinalSetupSelection {
-                sync: true,
-                ingest: true,
-                code_embeddings: true,
-                summaries: true,
-                summary_embeddings: true,
-                telemetry: false,
-                auto_start_daemon: false,
-            }
-        );
+        assert!(selection.sync);
+        assert!(selection.ingest);
+        assert!(!selection.telemetry);
+        assert!(!selection.auto_start_daemon);
         let rendered = String::from_utf8(out).expect("utf8 output");
         assert!(rendered.contains("1. Sync codebase"));
         assert!(rendered.contains("2. Import commit history"));
-        assert!(rendered.contains("3. Code embeddings"));
-        assert!(rendered.contains("4. Summaries"));
-        assert!(rendered.contains("5. Summary embeddings"));
+        assert!(!rendered.contains("Code embeddings"));
+        assert!(!rendered.contains("Summaries"));
+        assert!(!rendered.contains("Summary embeddings"));
     });
 }
 
@@ -7274,52 +7276,50 @@ fn choose_final_setup_options_does_not_preselect_code_embeddings_when_sync_disab
 
         assert!(!selection.sync);
         assert!(selection.ingest);
-        assert!(!selection.code_embeddings);
-        assert!(!selection.summaries);
-        assert!(!selection.summary_embeddings);
 
         let rendered = String::from_utf8(out).expect("utf8 output");
-        assert!(!rendered.contains("3. Code embeddings (selected)"));
+        assert!(!rendered.contains("Code embeddings"));
+        assert!(!rendered.contains("Summaries"));
+        assert!(!rendered.contains("Summary embeddings"));
     });
 }
 
 #[test]
-fn choose_final_setup_options_enables_summaries_when_summary_embeddings_selected() {
+fn choose_final_setup_options_rejects_removed_semantic_option_numbers() {
     with_test_tty_override(true, || {
         let mut out = Vec::new();
-        let mut input = Cursor::new("5\n");
+        let mut input = Cursor::new("5\n\n");
 
         let selection = choose_final_setup_options(
-            Some(false),
+            None,
             &mut out,
             &mut input,
-            Some(false),
+            None,
             InitFinalSetupPromptOptions {
                 show_telemetry: false,
                 show_auto_start_daemon: false,
             },
         )
-        .expect("choose summary embeddings");
+        .expect("choose setup options");
 
-        assert!(!selection.sync);
-        assert!(!selection.ingest);
-        assert!(!selection.code_embeddings);
-        assert!(selection.summaries);
-        assert!(selection.summary_embeddings);
+        assert!(selection.sync);
+        assert!(selection.ingest);
+        let rendered = String::from_utf8(out).expect("utf8 output");
+        assert!(rendered.contains("Please choose option numbers"));
     });
 }
 
 #[test]
-fn choose_final_setup_options_all_selects_all_repo_local_choices() {
+fn choose_final_setup_options_all_selects_visible_choices_only() {
     with_test_tty_override(true, || {
         let mut out = Vec::new();
         let mut input = Cursor::new("all\n");
 
         let selection = choose_final_setup_options(
-            Some(false),
+            None,
             &mut out,
             &mut input,
-            Some(false),
+            None,
             InitFinalSetupPromptOptions {
                 show_telemetry: false,
                 show_auto_start_daemon: false,
@@ -7329,9 +7329,10 @@ fn choose_final_setup_options_all_selects_all_repo_local_choices() {
 
         assert!(selection.sync);
         assert!(selection.ingest);
-        assert!(selection.code_embeddings);
-        assert!(selection.summaries);
-        assert!(selection.summary_embeddings);
+        let rendered = String::from_utf8(out).expect("utf8 output");
+        assert!(!rendered.contains("Code embeddings"));
+        assert!(!rendered.contains("Summaries"));
+        assert!(!rendered.contains("Summary embeddings"));
     });
 }
 
@@ -7353,18 +7354,10 @@ fn choose_final_setup_options_preselects_telemetry_when_shown() {
         )
         .expect("render telemetry prompt");
 
-        assert_eq!(
-            selection,
-            InitFinalSetupSelection {
-                sync: false,
-                ingest: false,
-                code_embeddings: false,
-                summaries: false,
-                summary_embeddings: false,
-                telemetry: true,
-                auto_start_daemon: false,
-            }
-        );
+        assert!(!selection.sync);
+        assert!(!selection.ingest);
+        assert!(selection.telemetry);
+        assert!(!selection.auto_start_daemon);
         let rendered = String::from_utf8(out).expect("utf8 output");
         assert!(rendered.contains("Enable anonymous telemetry (selected)"));
     });
@@ -7388,18 +7381,10 @@ fn choose_final_setup_options_defaults_auto_start_to_disabled_when_not_interacti
         )
         .expect("default auto-start selection");
 
-        assert_eq!(
-            selection,
-            InitFinalSetupSelection {
-                sync: false,
-                ingest: false,
-                code_embeddings: false,
-                summaries: false,
-                summary_embeddings: false,
-                telemetry: false,
-                auto_start_daemon: false,
-            }
-        );
+        assert!(!selection.sync);
+        assert!(!selection.ingest);
+        assert!(!selection.telemetry);
+        assert!(!selection.auto_start_daemon);
         assert!(
             out.is_empty(),
             "non-interactive auto-start should not prompt"

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -272,7 +272,8 @@ pub(crate) async fn run_for_project_root(
     let mut embeddings_bootstrap = None;
     let mut embeddings_bootstrap_rollback_plan = None;
     let mut prepared_summary_setup = None;
-    let mut selected_embedding_profile_name: Option<String> = None;
+    let mut selected_code_embedding_profile_name: Option<String> = None;
+    let mut selected_summary_embedding_profile_name: Option<String> = None;
     let mut selected_summary_generation_profile_name: Option<String> = None;
     let mut login_required = false;
     let embeddings_selection = should_install_embeddings_during_init(
@@ -285,10 +286,17 @@ pub(crate) async fn run_for_project_root(
     match embeddings_selection {
         InitEmbeddingsSetupSelection::Unchanged => {}
         InitEmbeddingsSetupSelection::Existing => {
-            selected_embedding_profile_name =
-                embedding_profile_name_from_policy(&previous_embeddings_policy)
-                    .map(str::to_string)
-                    .or(existing_init_embedding_profile_name(project_root)?);
+            let profile_names = {
+                let previous_profile_names =
+                    embedding_profile_names_from_policy(&previous_embeddings_policy);
+                if previous_profile_names.has_any() {
+                    previous_profile_names
+                } else {
+                    existing_init_embedding_profile_names(project_root)?
+                }
+            };
+            selected_code_embedding_profile_name = profile_names.code_embeddings;
+            selected_summary_embedding_profile_name = profile_names.summary_embeddings;
         }
         InitEmbeddingsSetupSelection::Cloud => {
             login_required = true;
@@ -301,7 +309,9 @@ pub(crate) async fn run_for_project_root(
                     gateway_url.as_deref(),
                     Some(args.embeddings_api_key_env.as_str()),
                 )?;
-                selected_embedding_profile_name =
+                selected_code_embedding_profile_name =
+                    Some(prepared_bootstrap.request.profile_name.clone());
+                selected_summary_embedding_profile_name =
                     Some(prepared_bootstrap.request.profile_name.clone());
                 embeddings_bootstrap_rollback_plan = prepared_bootstrap.rollback_plan;
                 embeddings_bootstrap = Some(prepared_bootstrap.request);
@@ -313,8 +323,9 @@ pub(crate) async fn run_for_project_root(
                 )? {
                     writeln!(out, "{line}")?;
                 }
-                selected_embedding_profile_name =
-                    existing_init_embedding_profile_name(project_root)?;
+                let profile_names = existing_init_embedding_profile_names(project_root)?;
+                selected_code_embedding_profile_name = profile_names.code_embeddings;
+                selected_summary_embedding_profile_name = profile_names.summary_embeddings;
             }
         }
         InitEmbeddingsSetupSelection::Local => {
@@ -325,14 +336,17 @@ pub(crate) async fn run_for_project_root(
                     None,
                     None,
                 )?;
-                selected_embedding_profile_name =
+                selected_code_embedding_profile_name =
+                    Some(prepared_bootstrap.request.profile_name.clone());
+                selected_summary_embedding_profile_name =
                     Some(prepared_bootstrap.request.profile_name.clone());
                 embeddings_bootstrap_rollback_plan = prepared_bootstrap.rollback_plan;
                 embeddings_bootstrap = Some(prepared_bootstrap.request);
             } else {
                 install_embeddings_during_init(project_root, out)?;
-                selected_embedding_profile_name =
-                    existing_init_embedding_profile_name(project_root)?;
+                let profile_names = existing_init_embedding_profile_names(project_root)?;
+                selected_code_embedding_profile_name = profile_names.code_embeddings;
+                selected_summary_embedding_profile_name = profile_names.summary_embeddings;
             }
         }
         InitEmbeddingsSetupSelection::Skip => {}
@@ -459,7 +473,8 @@ pub(crate) async fn run_for_project_root(
     persist_init_semantic_policy(
         &local_policy_path,
         &final_setup_selection,
-        selected_embedding_profile_name.as_deref(),
+        selected_code_embedding_profile_name.as_deref(),
+        selected_summary_embedding_profile_name.as_deref(),
         selected_summary_generation_profile_name.as_deref(),
     )?;
     let summaries_selected =
@@ -707,13 +722,15 @@ model = "local-model"
 fn persist_init_semantic_policy(
     local_policy_path: &Path,
     selection: &super::final_setup::InitFinalSetupSelection,
-    embedding_profile_name: Option<&str>,
+    code_embedding_profile_name: Option<&str>,
+    summary_embedding_profile_name: Option<&str>,
     summary_generation_profile_name: Option<&str>,
 ) -> Result<()> {
     let summaries = selection.summaries && summary_generation_profile_name.is_some();
-    let code_embeddings = selection.code_embeddings && embedding_profile_name.is_some();
-    let summary_embeddings =
-        selection.summary_embeddings && selection.summaries && embedding_profile_name.is_some();
+    let code_embeddings = selection.code_embeddings && code_embedding_profile_name.is_some();
+    let summary_embeddings = selection.summary_embeddings
+        && selection.summaries
+        && summary_embedding_profile_name.is_some();
     let embedding_mode = if code_embeddings || summary_embeddings {
         Some(SemanticCloneEmbeddingMode::SemanticAwareOnce)
     } else {
@@ -737,13 +754,13 @@ fn persist_init_semantic_policy(
                         .to_string()
                 }),
                 code_embeddings: code_embeddings.then(|| {
-                    embedding_profile_name
-                        .expect("embedding profile checked above")
+                    code_embedding_profile_name
+                        .expect("code embedding profile checked above")
                         .to_string()
                 }),
                 summary_embeddings: summary_embeddings.then(|| {
-                    embedding_profile_name
-                        .expect("embedding profile checked above")
+                    summary_embedding_profile_name
+                        .expect("summary embedding profile checked above")
                         .to_string()
                 }),
             },
@@ -751,33 +768,69 @@ fn persist_init_semantic_policy(
     )
 }
 
-fn existing_init_embedding_profile_name(repo_root: &Path) -> Result<Option<String>> {
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct InitEmbeddingProfileNames {
+    code_embeddings: Option<String>,
+    summary_embeddings: Option<String>,
+}
+
+impl InitEmbeddingProfileNames {
+    fn has_any(&self) -> bool {
+        self.code_embeddings.is_some() || self.summary_embeddings.is_some()
+    }
+}
+
+fn existing_init_embedding_profile_names(repo_root: &Path) -> Result<InitEmbeddingProfileNames> {
     let existing_policy = repo_semantic_embedding_policy(repo_root)?;
-    if let Some(profile_name) = embedding_profile_name_from_policy(&existing_policy) {
-        return Ok(Some(profile_name.to_string()));
+    let policy_profile_names = embedding_profile_names_from_policy(&existing_policy);
+    if policy_profile_names.has_any() {
+        return Ok(policy_profile_names);
     }
 
     let config_path = crate::config::resolve_bound_daemon_config_path_for_repo(repo_root)
         .or_else(|_| crate::config::resolve_daemon_config_path_for_repo(repo_root))?;
     let capability = crate::cli::embeddings::embedding_capability_for_config_path(&config_path)?;
-    Ok(crate::cli::embeddings::selected_inference_profile_name(&capability).map(str::to_string))
-}
-
-fn embedding_profile_name_from_policy(policy: &RepoSemanticEmbeddingPolicy) -> Option<&str> {
-    policy
-        .inference
-        .code_embeddings
-        .as_deref()
-        .map(str::trim)
-        .filter(|profile| !profile.is_empty())
-        .or_else(|| {
-            policy
+    let mut profile_names = InitEmbeddingProfileNames {
+        code_embeddings: trimmed_profile_name(
+            capability
+                .semantic_clones
+                .inference
+                .code_embeddings
+                .as_deref(),
+        ),
+        summary_embeddings: trimmed_profile_name(
+            capability
+                .semantic_clones
                 .inference
                 .summary_embeddings
-                .as_deref()
-                .map(str::trim)
-                .filter(|profile| !profile.is_empty())
-        })
+                .as_deref(),
+        ),
+    };
+    if !profile_names.has_any()
+        && let Some(profile_name) =
+            crate::cli::embeddings::selected_inference_profile_name(&capability)
+    {
+        let profile_name = profile_name.to_string();
+        profile_names.code_embeddings = Some(profile_name.clone());
+        profile_names.summary_embeddings = Some(profile_name);
+    }
+    Ok(profile_names)
+}
+
+fn embedding_profile_names_from_policy(
+    policy: &RepoSemanticEmbeddingPolicy,
+) -> InitEmbeddingProfileNames {
+    InitEmbeddingProfileNames {
+        code_embeddings: trimmed_profile_name(policy.inference.code_embeddings.as_deref()),
+        summary_embeddings: trimmed_profile_name(policy.inference.summary_embeddings.as_deref()),
+    }
+}
+
+fn trimmed_profile_name(profile_name: Option<&str>) -> Option<String> {
+    profile_name
+        .map(str::trim)
+        .filter(|profile| !profile.is_empty())
+        .map(str::to_string)
 }
 
 fn existing_init_summary_generation_profile_name(repo_root: &Path) -> Option<String> {

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -245,12 +245,29 @@ pub(crate) async fn run_for_project_root(
         out.write_all(&surface_updates)?;
         out.flush()?;
     }
+    let final_setup_selection = choose_final_setup_options(
+        args.sync,
+        out,
+        input,
+        effective_ingest,
+        InitFinalSetupPromptOptions {
+            show_telemetry: should_prompt_for_telemetry,
+            show_auto_start_daemon: args.install_default_daemon && !daemon_already_always_on,
+        },
+    )?;
+    let repo_selected_embedding_lanes =
+        final_setup_selection.code_embeddings || final_setup_selection.summary_embeddings;
     let mut embeddings_bootstrap = None;
     let mut embeddings_bootstrap_rollback_plan = None;
     let mut prepared_summary_setup = None;
     let mut login_required = false;
-    let embeddings_selection =
-        should_install_embeddings_during_init(project_root, &args, out, input)?;
+    let embeddings_selection = should_install_embeddings_during_init(
+        project_root,
+        &args,
+        repo_selected_embedding_lanes,
+        out,
+        input,
+    )?;
     match embeddings_selection {
         InitEmbeddingsSetupSelection::Unchanged => {}
         InitEmbeddingsSetupSelection::Existing => {
@@ -323,6 +340,7 @@ pub(crate) async fn run_for_project_root(
         project_root,
         args.install_default_daemon,
         args.no_summaries,
+        final_setup_selection.summaries,
         out,
         input,
     )
@@ -429,16 +447,6 @@ pub(crate) async fn run_for_project_root(
     }
     let summaries_selected =
         prepared_summary_setup.is_some() || summary_generation_configured(project_root);
-    let final_setup_selection = choose_final_setup_options(
-        args.sync,
-        out,
-        input,
-        effective_ingest,
-        InitFinalSetupPromptOptions {
-            show_telemetry: should_prompt_for_telemetry,
-            show_auto_start_daemon: args.install_default_daemon && !daemon_already_always_on,
-        },
-    )?;
     if args.install_default_daemon {
         maybe_enable_default_daemon_service(
             final_setup_selection.auto_start_daemon,

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -42,8 +42,8 @@ use crate::config::settings::{
 use crate::config::{
     DaemonEmbeddingsInstallPlan, InferenceProfileConfig, InferenceTask,
     REPO_POLICY_LOCAL_FILE_NAME, RepoSemanticEmbeddingPolicy, SemanticCloneEmbeddingMode,
-    default_daemon_config_exists, prepare_daemon_local_embeddings_profile_install,
-    resolve_semantic_clones_config_for_repo,
+    SemanticSummaryMode, default_daemon_config_exists,
+    prepare_daemon_local_embeddings_profile_install, resolve_semantic_clones_config_for_repo,
 };
 
 struct PreparedEmbeddingsBootstrapRequest {
@@ -334,7 +334,7 @@ pub(crate) async fn run_for_project_root(
     }
     if !args.no_summaries {
         selected_summary_generation_profile_name =
-            existing_init_summary_generation_profile_name(project_root);
+            existing_repo_init_summary_generation_profile_name(project_root);
     }
     let context_guidance_selection =
         choose_context_guidance_setup_during_init(project_root, &args, out, input).await?;
@@ -367,7 +367,7 @@ pub(crate) async fn run_for_project_root(
                 })?;
                 writeln!(out, "{message}")?;
                 selected_summary_generation_profile_name =
-                    existing_init_summary_generation_profile_name(project_root);
+                    existing_effective_init_summary_generation_profile_name(project_root);
             }
         }
         SummarySetupSelection::Local => {
@@ -398,7 +398,7 @@ pub(crate) async fn run_for_project_root(
                     )
                 })?;
                 selected_summary_generation_profile_name =
-                    existing_init_summary_generation_profile_name(project_root);
+                    existing_effective_init_summary_generation_profile_name(project_root);
             }
         }
         SummarySetupSelection::Skip => {}
@@ -605,6 +605,7 @@ struct InitRepoSemanticSelection {
     summary_embeddings: bool,
 }
 
+#[cfg(test)]
 fn init_repo_selected_embedding_lanes(selection: InitRepoSemanticSelection) -> bool {
     selection.code_embeddings || selection.summary_embeddings
 }
@@ -885,7 +886,7 @@ fn trimmed_profile_name(profile_name: Option<&str>) -> Option<String> {
         .map(str::to_string)
 }
 
-fn existing_init_summary_generation_profile_name(repo_root: &Path) -> Option<String> {
+fn existing_effective_init_summary_generation_profile_name(repo_root: &Path) -> Option<String> {
     let capability = crate::config::resolve_inference_capability_config_for_repo(repo_root);
     capability
         .semantic_clones
@@ -895,6 +896,14 @@ fn existing_init_summary_generation_profile_name(repo_root: &Path) -> Option<Str
         .map(str::trim)
         .filter(|profile| !profile.is_empty())
         .map(str::to_string)
+}
+
+fn existing_repo_init_summary_generation_profile_name(repo_root: &Path) -> Option<String> {
+    let policy = repo_semantic_embedding_policy(repo_root).ok()?;
+    if policy.summary_mode == Some(SemanticSummaryMode::Off) {
+        return None;
+    }
+    trimmed_profile_name(policy.inference.summary_generation.as_deref())
 }
 
 #[derive(Clone, Copy)]

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -608,6 +608,7 @@ fn persist_init_embeddings_policy(
             if code_profile.is_some() || summary_profile.is_some() {
                 RepoSemanticEmbeddingPolicy {
                     present: true,
+                    summary_mode: None,
                     embedding_mode: existing_policy
                         .embedding_mode
                         .or(Some(SemanticCloneEmbeddingMode::SemanticAwareOnce)),
@@ -652,6 +653,7 @@ fn legacy_daemon_semantic_embedding_policy(
     if code_profile.is_some() || summary_profile.is_some() {
         return Some(RepoSemanticEmbeddingPolicy {
             present: true,
+            summary_mode: None,
             embedding_mode: Some(capability.semantic_clones.embedding_mode),
             inference: crate::config::SemanticClonesInferenceBindings {
                 summary_generation: capability.semantic_clones.inference.summary_generation,

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -812,59 +812,9 @@ struct InitEmbeddingProfileNames {
     summary_embeddings: Option<String>,
 }
 
-impl InitEmbeddingProfileNames {
-    fn has_any(&self) -> bool {
-        self.code_embeddings.is_some() || self.summary_embeddings.is_some()
-    }
-}
-
 fn existing_init_embedding_profile_names(repo_root: &Path) -> Result<InitEmbeddingProfileNames> {
-    let existing_policy = repo_semantic_embedding_policy(repo_root)?;
-    let mut profile_names = embedding_profile_names_from_policy(&existing_policy);
-    if profile_names.code_embeddings.is_some() {
-        return Ok(profile_names);
-    }
-
-    let daemon_profile_names = match daemon_init_embedding_profile_names(repo_root) {
-        Ok(profile_names) => profile_names,
-        Err(_) if profile_names.has_any() => return Ok(profile_names),
-        Err(err) => return Err(err),
-    };
-    if profile_names.code_embeddings.is_none() {
-        profile_names.code_embeddings = daemon_profile_names.code_embeddings;
-    }
-    Ok(profile_names)
-}
-
-fn daemon_init_embedding_profile_names(repo_root: &Path) -> Result<InitEmbeddingProfileNames> {
-    let config_path = crate::config::resolve_bound_daemon_config_path_for_repo(repo_root)
-        .or_else(|_| crate::config::resolve_daemon_config_path_for_repo(repo_root))?;
-    let capability = crate::cli::embeddings::embedding_capability_for_config_path(&config_path)?;
-    let mut profile_names = InitEmbeddingProfileNames {
-        code_embeddings: trimmed_profile_name(
-            capability
-                .semantic_clones
-                .inference
-                .code_embeddings
-                .as_deref(),
-        ),
-        summary_embeddings: trimmed_profile_name(
-            capability
-                .semantic_clones
-                .inference
-                .summary_embeddings
-                .as_deref(),
-        ),
-    };
-    if !profile_names.has_any()
-        && let Some(profile_name) =
-            crate::cli::embeddings::selected_inference_profile_name(&capability)
-    {
-        let profile_name = profile_name.to_string();
-        profile_names.code_embeddings = Some(profile_name.clone());
-        profile_names.summary_embeddings = Some(profile_name);
-    }
-    Ok(profile_names)
+    repo_semantic_embedding_policy(repo_root)
+        .map(|policy| embedding_profile_names_from_policy(&policy))
 }
 
 fn embedding_profile_names_from_policy(
@@ -884,15 +834,7 @@ fn trimmed_profile_name(profile_name: Option<&str>) -> Option<String> {
 }
 
 fn existing_effective_init_summary_generation_profile_name(repo_root: &Path) -> Option<String> {
-    let capability = crate::config::resolve_inference_capability_config_for_repo(repo_root);
-    capability
-        .semantic_clones
-        .inference
-        .summary_generation
-        .as_deref()
-        .map(str::trim)
-        .filter(|profile| !profile.is_empty())
-        .map(str::to_string)
+    existing_repo_init_summary_generation_profile_name(repo_root)
 }
 
 fn existing_repo_init_summary_generation_profile_name(repo_root: &Path) -> Option<String> {

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -246,7 +246,7 @@ pub(crate) async fn run_for_project_root(
         out.write_all(&surface_updates)?;
         out.flush()?;
     }
-    let mut final_setup_selection = choose_final_setup_options(
+    let final_setup_selection = choose_final_setup_options(
         args.sync,
         out,
         input,
@@ -256,19 +256,6 @@ pub(crate) async fn run_for_project_root(
             show_auto_start_daemon: args.install_default_daemon && !daemon_already_always_on,
         },
     )?;
-    if args.no_embeddings {
-        final_setup_selection.code_embeddings = false;
-        final_setup_selection.summary_embeddings = false;
-    }
-    if args.no_summaries {
-        final_setup_selection.summaries = false;
-        final_setup_selection.summary_embeddings = false;
-    }
-    if args.embeddings_runtime.is_some() && !args.no_embeddings {
-        final_setup_selection.code_embeddings = true;
-    }
-    let repo_selected_embedding_lanes =
-        init_repo_selected_embedding_lanes(final_setup_selection, args.no_summaries);
     let mut embeddings_bootstrap = None;
     let mut embeddings_bootstrap_rollback_plan = None;
     let mut prepared_summary_setup = None;
@@ -279,7 +266,7 @@ pub(crate) async fn run_for_project_root(
     let embeddings_selection = should_install_embeddings_during_init(
         project_root,
         &args,
-        repo_selected_embedding_lanes,
+        !args.no_embeddings,
         out,
         input,
     )?;
@@ -347,7 +334,7 @@ pub(crate) async fn run_for_project_root(
         project_root,
         args.install_default_daemon,
         args.no_summaries,
-        final_setup_selection.summaries,
+        !args.no_summaries,
         out,
         input,
     )
@@ -355,7 +342,7 @@ pub(crate) async fn run_for_project_root(
     if matches!(summary_selection, SummarySetupSelection::Cloud) {
         login_required = true;
     }
-    if final_setup_selection.summaries {
+    if !args.no_summaries {
         selected_summary_generation_profile_name =
             existing_init_summary_generation_profile_name(project_root);
     }
@@ -462,15 +449,22 @@ pub(crate) async fn run_for_project_root(
         }
         ContextGuidanceSetupSelection::Skip => {}
     }
+    let semantic_selection = InitRepoSemanticSelection {
+        code_embeddings: !args.no_embeddings && selected_code_embedding_profile_name.is_some(),
+        summaries: !args.no_summaries && selected_summary_generation_profile_name.is_some(),
+        summary_embeddings: !args.no_embeddings
+            && !args.no_summaries
+            && selected_summary_generation_profile_name.is_some()
+            && selected_summary_embedding_profile_name.is_some(),
+    };
     persist_init_semantic_policy(
         &local_policy_path,
-        &final_setup_selection,
+        semantic_selection,
         selected_code_embedding_profile_name.as_deref(),
         selected_summary_embedding_profile_name.as_deref(),
         selected_summary_generation_profile_name.as_deref(),
     )?;
-    let summaries_selected =
-        final_setup_selection.summaries && selected_summary_generation_profile_name.is_some();
+    let summaries_selected = semantic_selection.summaries;
     if args.install_default_daemon {
         maybe_enable_default_daemon_service(
             final_setup_selection.auto_start_daemon,
@@ -497,15 +491,14 @@ pub(crate) async fn run_for_project_root(
     let should_ingest = final_setup_selection.ingest;
     set_devql_producer_settings(&local_policy_path, should_sync, should_ingest)?;
     let semantic_policy = resolve_semantic_clones_config_for_repo(project_root);
-    let code_embeddings_selected = final_setup_selection.code_embeddings
+    let code_embeddings_selected = semantic_selection.code_embeddings
         && semantic_policy.embedding_mode != SemanticCloneEmbeddingMode::Off
         && semantic_policy
             .inference
             .code_embeddings
             .as_deref()
             .is_some_and(|profile| !profile.trim().is_empty());
-    let summary_embeddings_selected = final_setup_selection.summary_embeddings
-        && final_setup_selection.summaries
+    let summary_embeddings_selected = semantic_selection.summary_embeddings
         && semantic_policy.embedding_mode != SemanticCloneEmbeddingMode::Off
         && semantic_policy
             .inference
@@ -605,13 +598,15 @@ pub(crate) async fn run_for_project_root(
     Ok(())
 }
 
-fn init_repo_selected_embedding_lanes(
-    selection: super::final_setup::InitFinalSetupSelection,
-    no_summaries: bool,
-) -> bool {
-    let summary_embedding_lane =
-        selection.summaries && selection.summary_embeddings && !no_summaries;
-    selection.code_embeddings || summary_embedding_lane
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct InitRepoSemanticSelection {
+    code_embeddings: bool,
+    summaries: bool,
+    summary_embeddings: bool,
+}
+
+fn init_repo_selected_embedding_lanes(selection: InitRepoSemanticSelection) -> bool {
+    selection.code_embeddings || selection.summary_embeddings
 }
 
 #[cfg(test)]
@@ -632,31 +627,27 @@ mod tests {
         .expect("write daemon binding");
     }
 
-    fn final_setup_selection(
+    fn semantic_selection(
         code_embeddings: bool,
         summaries: bool,
         summary_embeddings: bool,
-    ) -> super::super::final_setup::InitFinalSetupSelection {
-        super::super::final_setup::InitFinalSetupSelection {
-            sync: false,
-            ingest: false,
+    ) -> InitRepoSemanticSelection {
+        InitRepoSemanticSelection {
             code_embeddings,
             summaries,
             summary_embeddings,
-            telemetry: false,
-            auto_start_daemon: false,
         }
     }
 
     #[test]
-    fn repo_selected_embedding_lanes_ignores_summary_embeddings_when_summaries_disabled() {
-        let summary_only = final_setup_selection(false, true, true);
+    fn repo_selected_embedding_lanes_tracks_semantic_embedding_choices() {
+        let summary_only = semantic_selection(false, true, true);
 
-        assert!(!init_repo_selected_embedding_lanes(summary_only, true));
+        assert!(init_repo_selected_embedding_lanes(summary_only));
 
-        let code_embeddings = final_setup_selection(true, false, false);
+        let code_embeddings = semantic_selection(true, false, false);
 
-        assert!(init_repo_selected_embedding_lanes(code_embeddings, true));
+        assert!(init_repo_selected_embedding_lanes(code_embeddings));
     }
 
     #[test]
@@ -767,7 +758,7 @@ code_embeddings = "repo_code"
 
 fn persist_init_semantic_policy(
     local_policy_path: &Path,
-    selection: &super::final_setup::InitFinalSetupSelection,
+    selection: InitRepoSemanticSelection,
     code_embedding_profile_name: Option<&str>,
     summary_embedding_profile_name: Option<&str>,
     summary_generation_profile_name: Option<&str>,

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -286,15 +286,7 @@ pub(crate) async fn run_for_project_root(
     match embeddings_selection {
         InitEmbeddingsSetupSelection::Unchanged => {}
         InitEmbeddingsSetupSelection::Existing => {
-            let profile_names = {
-                let previous_profile_names =
-                    embedding_profile_names_from_policy(&previous_embeddings_policy);
-                if previous_profile_names.has_any() {
-                    previous_profile_names
-                } else {
-                    existing_init_embedding_profile_names(project_root)?
-                }
-            };
+            let profile_names = existing_init_embedding_profile_names(project_root)?;
             selected_code_embedding_profile_name = profile_names.code_embeddings;
             selected_summary_embedding_profile_name = profile_names.summary_embeddings;
         }
@@ -717,6 +709,60 @@ model = "local-model"
             Some("summary_llm_1".to_string())
         );
     }
+
+    #[test]
+    fn existing_init_embedding_profile_names_fills_missing_slots_from_daemon_config() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        write_bound_daemon_config(
+            repo.path(),
+            r#"
+[semantic_clones]
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+code_embeddings = "daemon_code"
+summary_embeddings = "daemon_summary"
+
+[inference.profiles.daemon_code]
+task = "embeddings"
+driver = "openai"
+model = "text-embedding-3-large"
+
+[inference.profiles.daemon_summary]
+task = "embeddings"
+driver = "openai"
+model = "text-embedding-3-small"
+"#,
+        );
+        let local_policy_path = repo.path().join(crate::config::REPO_POLICY_LOCAL_FILE_NAME);
+        let mut local_policy = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&local_policy_path)
+            .expect("open local policy");
+        write!(
+            local_policy,
+            r#"
+
+[semantic_clones]
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+code_embeddings = "repo_code"
+"#
+        )
+        .expect("write local semantic policy");
+
+        let names =
+            existing_init_embedding_profile_names(repo.path()).expect("resolve profile names");
+
+        assert_eq!(
+            names,
+            InitEmbeddingProfileNames {
+                code_embeddings: Some("repo_code".to_string()),
+                summary_embeddings: Some("daemon_summary".to_string()),
+            }
+        );
+    }
 }
 
 fn persist_init_semantic_policy(
@@ -782,11 +828,26 @@ impl InitEmbeddingProfileNames {
 
 fn existing_init_embedding_profile_names(repo_root: &Path) -> Result<InitEmbeddingProfileNames> {
     let existing_policy = repo_semantic_embedding_policy(repo_root)?;
-    let policy_profile_names = embedding_profile_names_from_policy(&existing_policy);
-    if policy_profile_names.has_any() {
-        return Ok(policy_profile_names);
+    let mut profile_names = embedding_profile_names_from_policy(&existing_policy);
+    if profile_names.code_embeddings.is_some() && profile_names.summary_embeddings.is_some() {
+        return Ok(profile_names);
     }
 
+    let daemon_profile_names = match daemon_init_embedding_profile_names(repo_root) {
+        Ok(profile_names) => profile_names,
+        Err(_) if profile_names.has_any() => return Ok(profile_names),
+        Err(err) => return Err(err),
+    };
+    if profile_names.code_embeddings.is_none() {
+        profile_names.code_embeddings = daemon_profile_names.code_embeddings;
+    }
+    if profile_names.summary_embeddings.is_none() {
+        profile_names.summary_embeddings = daemon_profile_names.summary_embeddings;
+    }
+    Ok(profile_names)
+}
+
+fn daemon_init_embedding_profile_names(repo_root: &Path) -> Result<InitEmbeddingProfileNames> {
     let config_path = crate::config::resolve_bound_daemon_config_path_for_repo(repo_root)
         .or_else(|_| crate::config::resolve_daemon_config_path_for_repo(repo_root))?;
     let capability = crate::cli::embeddings::embedding_capability_for_config_path(&config_path)?;

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -40,9 +40,10 @@ use crate::config::settings::{
     write_project_bootstrap_settings_with_daemon_binding_and_devql_guidance,
 };
 use crate::config::{
-    DaemonEmbeddingsInstallPlan, REPO_POLICY_LOCAL_FILE_NAME, RepoSemanticEmbeddingPolicy,
-    SemanticCloneEmbeddingMode, default_daemon_config_exists,
-    prepare_daemon_local_embeddings_profile_install, resolve_semantic_clones_config_for_repo,
+    DaemonEmbeddingsInstallPlan, InferenceProfileConfig, InferenceTask,
+    REPO_POLICY_LOCAL_FILE_NAME, RepoSemanticEmbeddingPolicy, SemanticCloneEmbeddingMode,
+    default_daemon_config_exists, prepare_daemon_local_embeddings_profile_install,
+    resolve_semantic_clones_config_for_repo,
 };
 
 struct PreparedEmbeddingsBootstrapRequest {
@@ -369,7 +370,7 @@ pub(crate) async fn run_for_project_root(
             if args.install_default_daemon {
                 let plan = prepare_cloud_summary_generation_plan(gateway_url_override.as_deref());
                 selected_summary_generation_profile_name =
-                    prepared_summary_generation_profile_name(&plan).map(str::to_string);
+                    prepared_summary_generation_profile_name(project_root, &plan);
                 prepared_summary_setup = Some(plan);
             } else {
                 let message = configure_cloud_summary_generation(
@@ -399,7 +400,7 @@ pub(crate) async fn run_for_project_root(
                     )
                 })?;
                 selected_summary_generation_profile_name =
-                    prepared_summary_generation_profile_name(&plan).map(str::to_string);
+                    prepared_summary_generation_profile_name(project_root, &plan);
                 prepared_summary_setup = Some(plan);
             } else {
                 configure_local_summary_generation(
@@ -610,6 +611,20 @@ fn init_repo_selected_embedding_lanes(
 mod tests {
     use super::*;
 
+    fn write_bound_daemon_config(repo_root: &Path, contents: &str) {
+        let config_path = repo_root
+            .join("daemon")
+            .join(crate::config::BITLOOPS_CONFIG_RELATIVE_PATH);
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(&config_path, contents).expect("write daemon config");
+        crate::config::settings::write_repo_daemon_binding(
+            &repo_root.join(crate::config::REPO_POLICY_LOCAL_FILE_NAME),
+            &config_path,
+        )
+        .expect("write daemon binding");
+    }
+
     fn final_setup_selection(
         code_embeddings: bool,
         summaries: bool,
@@ -635,6 +650,57 @@ mod tests {
         let code_embeddings = final_setup_selection(true, false, false);
 
         assert!(init_repo_selected_embedding_lanes(code_embeddings, true));
+    }
+
+    #[test]
+    fn prepared_local_summary_profile_name_uses_suffix_when_default_is_not_managed() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        write_bound_daemon_config(
+            repo.path(),
+            r#"
+[inference.profiles.summary_local]
+task = "embeddings"
+driver = "custom_driver"
+runtime = "custom_runtime"
+model = "custom-model"
+"#,
+        );
+        let plan = crate::cli::inference::PreparedSummarySetupPlan::new(
+            PreparedSummarySetupAction::ConfigureLocal {
+                model_name: "model".to_string(),
+            },
+        );
+
+        assert_eq!(
+            prepared_summary_generation_profile_name(repo.path(), &plan),
+            Some("summary_local_1".to_string())
+        );
+    }
+
+    #[test]
+    fn prepared_platform_summary_profile_name_uses_suffix_when_default_is_not_managed() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        write_bound_daemon_config(
+            repo.path(),
+            r#"
+[inference.profiles.summary_llm]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "local-model"
+"#,
+        );
+        let plan = crate::cli::inference::PreparedSummarySetupPlan::new(
+            PreparedSummarySetupAction::ConfigureCloud {
+                gateway_url_override: None,
+                api_key_env: None,
+            },
+        );
+
+        assert_eq!(
+            prepared_summary_generation_profile_name(repo.path(), &plan),
+            Some("summary_llm_1".to_string())
+        );
     }
 }
 
@@ -726,15 +792,91 @@ fn existing_init_summary_generation_profile_name(repo_root: &Path) -> Option<Str
         .map(str::to_string)
 }
 
+#[derive(Clone, Copy)]
+enum PreparedSummaryProfileKind {
+    Local,
+    Platform,
+}
+
 fn prepared_summary_generation_profile_name(
+    repo_root: &Path,
     plan: &crate::cli::inference::PreparedSummarySetupPlan,
-) -> Option<&'static str> {
+) -> Option<String> {
     match plan.action() {
-        PreparedSummarySetupAction::ConfigureCloud { .. } => Some("summary_llm"),
-        PreparedSummarySetupAction::ConfigureLocal { .. } => Some("summary_local"),
+        PreparedSummarySetupAction::ConfigureCloud { .. } => Some(planned_summary_profile_name(
+            repo_root,
+            "summary_llm",
+            PreparedSummaryProfileKind::Platform,
+        )),
+        PreparedSummarySetupAction::ConfigureLocal { .. } => Some(planned_summary_profile_name(
+            repo_root,
+            "summary_local",
+            PreparedSummaryProfileKind::Local,
+        )),
         PreparedSummarySetupAction::InstallRuntimeOnly { .. }
         | PreparedSummarySetupAction::InstallRuntimeOnlyPendingProbe { .. } => None,
     }
+}
+
+fn planned_summary_profile_name(
+    repo_root: &Path,
+    default_name: &str,
+    kind: PreparedSummaryProfileKind,
+) -> String {
+    let capability = crate::config::resolve_inference_capability_config_for_repo(repo_root);
+    let profiles = &capability.inference.profiles;
+
+    match profiles.get(default_name) {
+        None => default_name.to_string(),
+        Some(profile) if is_managed_prepared_summary_profile(profile, kind) => {
+            default_name.to_string()
+        }
+        Some(_) => next_available_summary_profile_name(profiles, default_name),
+    }
+}
+
+fn next_available_summary_profile_name(
+    profiles: &std::collections::BTreeMap<String, InferenceProfileConfig>,
+    prefix: &str,
+) -> String {
+    let mut suffix = 1usize;
+    loop {
+        let candidate = format!("{prefix}_{suffix}");
+        if !profiles.contains_key(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+fn is_managed_prepared_summary_profile(
+    profile: &InferenceProfileConfig,
+    kind: PreparedSummaryProfileKind,
+) -> bool {
+    match kind {
+        PreparedSummaryProfileKind::Local => is_managed_local_summary_profile(profile),
+        PreparedSummaryProfileKind::Platform => is_managed_platform_summary_profile(profile),
+    }
+}
+
+fn is_managed_local_summary_profile(profile: &InferenceProfileConfig) -> bool {
+    profile.task == InferenceTask::TextGeneration
+        && profile.runtime.as_deref().map(str::trim) == Some("bitloops_inference")
+        && profile.driver.trim() == "ollama_chat"
+}
+
+fn is_managed_platform_summary_profile(profile: &InferenceProfileConfig) -> bool {
+    profile.task == InferenceTask::TextGeneration
+        && profile.runtime.as_deref().map(str::trim) == Some("bitloops_inference")
+        && matches!(
+            profile.driver.trim(),
+            "bitloops_platform_chat" | "openai_chat_completions"
+        )
+        && profile
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(|api_key| api_key == "${BITLOOPS_PLATFORM_GATEWAY_TOKEN}")
 }
 
 async fn bound_running_daemon_config_path() -> Result<std::path::PathBuf> {

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -246,16 +246,6 @@ pub(crate) async fn run_for_project_root(
         out.write_all(&surface_updates)?;
         out.flush()?;
     }
-    let final_setup_selection = choose_final_setup_options(
-        args.sync,
-        out,
-        input,
-        effective_ingest,
-        InitFinalSetupPromptOptions {
-            show_telemetry: should_prompt_for_telemetry,
-            show_auto_start_daemon: args.install_default_daemon && !daemon_already_always_on,
-        },
-    )?;
     let mut embeddings_bootstrap = None;
     let mut embeddings_bootstrap_rollback_plan = None;
     let mut prepared_summary_setup = None;
@@ -465,6 +455,16 @@ pub(crate) async fn run_for_project_root(
         selected_summary_generation_profile_name.as_deref(),
     )?;
     let summaries_selected = semantic_selection.summaries;
+    let final_setup_selection = choose_final_setup_options(
+        args.sync,
+        out,
+        input,
+        effective_ingest,
+        InitFinalSetupPromptOptions {
+            show_telemetry: should_prompt_for_telemetry,
+            show_auto_start_daemon: args.install_default_daemon && !daemon_already_always_on,
+        },
+    )?;
     if args.install_default_daemon {
         maybe_enable_default_daemon_service(
             final_setup_selection.auto_start_daemon,

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -30,7 +30,7 @@ use crate::cli::inference::{
     configure_cloud_summary_generation, configure_local_context_guidance_generation,
     configure_local_summary_generation, platform_context_guidance_gateway_url_override,
     platform_summary_gateway_url_override, prepare_cloud_summary_generation_plan,
-    prepare_local_summary_generation_plan, summary_generation_configured,
+    prepare_local_summary_generation_plan,
 };
 use crate::cli::telemetry_consent;
 use crate::config::settings::{
@@ -245,7 +245,7 @@ pub(crate) async fn run_for_project_root(
         out.write_all(&surface_updates)?;
         out.flush()?;
     }
-    let final_setup_selection = choose_final_setup_options(
+    let mut final_setup_selection = choose_final_setup_options(
         args.sync,
         out,
         input,
@@ -255,11 +255,24 @@ pub(crate) async fn run_for_project_root(
             show_auto_start_daemon: args.install_default_daemon && !daemon_already_always_on,
         },
     )?;
+    if args.no_embeddings {
+        final_setup_selection.code_embeddings = false;
+        final_setup_selection.summary_embeddings = false;
+    }
+    if args.no_summaries {
+        final_setup_selection.summaries = false;
+        final_setup_selection.summary_embeddings = false;
+    }
+    if args.embeddings_runtime.is_some() && !args.no_embeddings {
+        final_setup_selection.code_embeddings = true;
+    }
     let repo_selected_embedding_lanes =
         init_repo_selected_embedding_lanes(final_setup_selection, args.no_summaries);
     let mut embeddings_bootstrap = None;
     let mut embeddings_bootstrap_rollback_plan = None;
     let mut prepared_summary_setup = None;
+    let mut selected_embedding_profile_name: Option<String> = None;
+    let mut selected_summary_generation_profile_name: Option<String> = None;
     let mut login_required = false;
     let embeddings_selection = should_install_embeddings_during_init(
         project_root,
@@ -271,12 +284,10 @@ pub(crate) async fn run_for_project_root(
     match embeddings_selection {
         InitEmbeddingsSetupSelection::Unchanged => {}
         InitEmbeddingsSetupSelection::Existing => {
-            persist_init_embeddings_policy(
-                project_root,
-                &local_policy_path,
-                InitEmbeddingsSetupSelection::Existing,
-                None,
-            )?;
+            selected_embedding_profile_name =
+                embedding_profile_name_from_policy(&previous_embeddings_policy)
+                    .map(str::to_string)
+                    .or(existing_init_embedding_profile_name(project_root)?);
         }
         InitEmbeddingsSetupSelection::Cloud => {
             login_required = true;
@@ -289,12 +300,8 @@ pub(crate) async fn run_for_project_root(
                     gateway_url.as_deref(),
                     Some(args.embeddings_api_key_env.as_str()),
                 )?;
-                persist_init_embeddings_policy(
-                    project_root,
-                    &local_policy_path,
-                    InitEmbeddingsSetupSelection::Cloud,
-                    Some(&prepared_bootstrap.request.profile_name),
-                )?;
+                selected_embedding_profile_name =
+                    Some(prepared_bootstrap.request.profile_name.clone());
                 embeddings_bootstrap_rollback_plan = prepared_bootstrap.rollback_plan;
                 embeddings_bootstrap = Some(prepared_bootstrap.request);
             } else {
@@ -305,6 +312,8 @@ pub(crate) async fn run_for_project_root(
                 )? {
                     writeln!(out, "{line}")?;
                 }
+                selected_embedding_profile_name =
+                    existing_init_embedding_profile_name(project_root)?;
             }
         }
         InitEmbeddingsSetupSelection::Local => {
@@ -315,26 +324,17 @@ pub(crate) async fn run_for_project_root(
                     None,
                     None,
                 )?;
-                persist_init_embeddings_policy(
-                    project_root,
-                    &local_policy_path,
-                    InitEmbeddingsSetupSelection::Local,
-                    Some(&prepared_bootstrap.request.profile_name),
-                )?;
+                selected_embedding_profile_name =
+                    Some(prepared_bootstrap.request.profile_name.clone());
                 embeddings_bootstrap_rollback_plan = prepared_bootstrap.rollback_plan;
                 embeddings_bootstrap = Some(prepared_bootstrap.request);
             } else {
                 install_embeddings_during_init(project_root, out)?;
+                selected_embedding_profile_name =
+                    existing_init_embedding_profile_name(project_root)?;
             }
         }
-        InitEmbeddingsSetupSelection::Skip => {
-            persist_init_embeddings_policy(
-                project_root,
-                &local_policy_path,
-                InitEmbeddingsSetupSelection::Skip,
-                None,
-            )?;
-        }
+        InitEmbeddingsSetupSelection::Skip => {}
     }
     let summary_selection = choose_summary_setup_during_init(
         project_root,
@@ -347,6 +347,10 @@ pub(crate) async fn run_for_project_root(
     .await?;
     if matches!(summary_selection, SummarySetupSelection::Cloud) {
         login_required = true;
+    }
+    if final_setup_selection.summaries {
+        selected_summary_generation_profile_name =
+            existing_init_summary_generation_profile_name(project_root);
     }
     let context_guidance_selection =
         choose_context_guidance_setup_during_init(project_root, &args, out, input).await?;
@@ -363,9 +367,10 @@ pub(crate) async fn run_for_project_root(
         SummarySetupSelection::Cloud => {
             let gateway_url_override = platform_summary_gateway_url_override();
             if args.install_default_daemon {
-                prepared_summary_setup = Some(prepare_cloud_summary_generation_plan(
-                    gateway_url_override.as_deref(),
-                ));
+                let plan = prepare_cloud_summary_generation_plan(gateway_url_override.as_deref());
+                selected_summary_generation_profile_name =
+                    prepared_summary_generation_profile_name(&plan).map(str::to_string);
+                prepared_summary_setup = Some(plan);
             } else {
                 let message = configure_cloud_summary_generation(
                     project_root,
@@ -377,22 +382,25 @@ pub(crate) async fn run_for_project_root(
                     )
                 })?;
                 writeln!(out, "{message}")?;
+                selected_summary_generation_profile_name =
+                    existing_init_summary_generation_profile_name(project_root);
             }
         }
         SummarySetupSelection::Local => {
             if args.install_default_daemon {
-                prepared_summary_setup = Some(
-                    prepare_local_summary_generation_plan(
-                        out,
-                        input,
-                        telemetry_consent::can_prompt_interactively(),
+                let plan = prepare_local_summary_generation_plan(
+                    out,
+                    input,
+                    telemetry_consent::can_prompt_interactively(),
+                )
+                .map_err(|err| {
+                    anyhow::anyhow!(
+                        "Bitloops init completed, but semantic summary setup failed: {err:#}"
                     )
-                    .map_err(|err| {
-                        anyhow::anyhow!(
-                            "Bitloops init completed, but semantic summary setup failed: {err:#}"
-                        )
-                    })?,
-                );
+                })?;
+                selected_summary_generation_profile_name =
+                    prepared_summary_generation_profile_name(&plan).map(str::to_string);
+                prepared_summary_setup = Some(plan);
             } else {
                 configure_local_summary_generation(
                     project_root,
@@ -405,6 +413,8 @@ pub(crate) async fn run_for_project_root(
                         "Bitloops init completed, but semantic summary setup failed: {err:#}"
                     )
                 })?;
+                selected_summary_generation_profile_name =
+                    existing_init_summary_generation_profile_name(project_root);
             }
         }
         SummarySetupSelection::Skip => {}
@@ -445,8 +455,14 @@ pub(crate) async fn run_for_project_root(
         }
         ContextGuidanceSetupSelection::Skip => {}
     }
+    persist_init_semantic_policy(
+        &local_policy_path,
+        &final_setup_selection,
+        selected_embedding_profile_name.as_deref(),
+        selected_summary_generation_profile_name.as_deref(),
+    )?;
     let summaries_selected =
-        prepared_summary_setup.is_some() || summary_generation_configured(project_root);
+        final_setup_selection.summaries && selected_summary_generation_profile_name.is_some();
     if args.install_default_daemon {
         maybe_enable_default_daemon_service(
             final_setup_selection.auto_start_daemon,
@@ -473,15 +489,16 @@ pub(crate) async fn run_for_project_root(
     let should_ingest = final_setup_selection.ingest;
     set_devql_producer_settings(&local_policy_path, should_sync, should_ingest)?;
     let semantic_policy = resolve_semantic_clones_config_for_repo(project_root);
-    let code_embeddings_selected = semantic_policy.embedding_mode
-        != SemanticCloneEmbeddingMode::Off
+    let code_embeddings_selected = final_setup_selection.code_embeddings
+        && semantic_policy.embedding_mode != SemanticCloneEmbeddingMode::Off
         && semantic_policy
             .inference
             .code_embeddings
             .as_deref()
             .is_some_and(|profile| !profile.trim().is_empty());
-    let summary_embeddings_selected = semantic_policy.embedding_mode
-        != SemanticCloneEmbeddingMode::Off
+    let summary_embeddings_selected = final_setup_selection.summary_embeddings
+        && final_setup_selection.summaries
+        && semantic_policy.embedding_mode != SemanticCloneEmbeddingMode::Off
         && semantic_policy
             .inference
             .summary_embeddings
@@ -621,106 +638,103 @@ mod tests {
     }
 }
 
-fn persist_init_embeddings_policy(
-    repo_root: &Path,
+fn persist_init_semantic_policy(
     local_policy_path: &Path,
-    selection: InitEmbeddingsSetupSelection,
-    selected_profile_name: Option<&str>,
+    selection: &super::final_setup::InitFinalSetupSelection,
+    embedding_profile_name: Option<&str>,
+    summary_generation_profile_name: Option<&str>,
 ) -> Result<()> {
-    let policy = match selection {
-        InitEmbeddingsSetupSelection::Unchanged => return Ok(()),
-        InitEmbeddingsSetupSelection::Skip => RepoSemanticEmbeddingPolicy::disabled(),
-        InitEmbeddingsSetupSelection::Cloud | InitEmbeddingsSetupSelection::Local => {
-            RepoSemanticEmbeddingPolicy::enabled_with_profile(selected_profile_name.unwrap_or(
-                match selection {
-                    InitEmbeddingsSetupSelection::Cloud => "platform_code",
-                    _ => "local_code",
-                },
-            ))
-        }
-        InitEmbeddingsSetupSelection::Existing => {
-            let existing_policy = repo_semantic_embedding_policy(repo_root)?;
-            let code_profile = existing_policy
-                .inference
-                .code_embeddings
-                .as_deref()
-                .map(str::trim)
-                .filter(|profile| !profile.is_empty())
-                .map(str::to_string);
-            let summary_profile = existing_policy
+    let summaries = selection.summaries && summary_generation_profile_name.is_some();
+    let code_embeddings = selection.code_embeddings && embedding_profile_name.is_some();
+    let summary_embeddings =
+        selection.summary_embeddings && selection.summaries && embedding_profile_name.is_some();
+    let embedding_mode = if code_embeddings || summary_embeddings {
+        Some(SemanticCloneEmbeddingMode::SemanticAwareOnce)
+    } else {
+        Some(SemanticCloneEmbeddingMode::Off)
+    };
+
+    set_repo_semantic_embedding_policy(
+        local_policy_path,
+        &RepoSemanticEmbeddingPolicy {
+            present: true,
+            summary_mode: Some(if summaries {
+                crate::config::SemanticSummaryMode::Auto
+            } else {
+                crate::config::SemanticSummaryMode::Off
+            }),
+            embedding_mode,
+            inference: crate::config::SemanticClonesInferenceBindings {
+                summary_generation: summaries.then(|| {
+                    summary_generation_profile_name
+                        .expect("summary profile checked above")
+                        .to_string()
+                }),
+                code_embeddings: code_embeddings.then(|| {
+                    embedding_profile_name
+                        .expect("embedding profile checked above")
+                        .to_string()
+                }),
+                summary_embeddings: summary_embeddings.then(|| {
+                    embedding_profile_name
+                        .expect("embedding profile checked above")
+                        .to_string()
+                }),
+            },
+        },
+    )
+}
+
+fn existing_init_embedding_profile_name(repo_root: &Path) -> Result<Option<String>> {
+    let existing_policy = repo_semantic_embedding_policy(repo_root)?;
+    if let Some(profile_name) = embedding_profile_name_from_policy(&existing_policy) {
+        return Ok(Some(profile_name.to_string()));
+    }
+
+    let config_path = crate::config::resolve_bound_daemon_config_path_for_repo(repo_root)
+        .or_else(|_| crate::config::resolve_daemon_config_path_for_repo(repo_root))?;
+    let capability = crate::cli::embeddings::embedding_capability_for_config_path(&config_path)?;
+    Ok(crate::cli::embeddings::selected_inference_profile_name(&capability).map(str::to_string))
+}
+
+fn embedding_profile_name_from_policy(policy: &RepoSemanticEmbeddingPolicy) -> Option<&str> {
+    policy
+        .inference
+        .code_embeddings
+        .as_deref()
+        .map(str::trim)
+        .filter(|profile| !profile.is_empty())
+        .or_else(|| {
+            policy
                 .inference
                 .summary_embeddings
                 .as_deref()
                 .map(str::trim)
                 .filter(|profile| !profile.is_empty())
-                .map(str::to_string);
-            if code_profile.is_some() || summary_profile.is_some() {
-                RepoSemanticEmbeddingPolicy {
-                    present: true,
-                    summary_mode: None,
-                    embedding_mode: existing_policy
-                        .embedding_mode
-                        .or(Some(SemanticCloneEmbeddingMode::SemanticAwareOnce)),
-                    inference: crate::config::SemanticClonesInferenceBindings {
-                        summary_generation: existing_policy.inference.summary_generation,
-                        code_embeddings: code_profile,
-                        summary_embeddings: summary_profile,
-                    },
-                }
-            } else {
-                legacy_daemon_semantic_embedding_policy(repo_root).unwrap_or_else(|| {
-                    RepoSemanticEmbeddingPolicy::enabled_with_profile("local_code")
-                })
-            }
-        }
-    };
-    set_repo_semantic_embedding_policy(local_policy_path, &policy)
+        })
 }
 
-fn legacy_daemon_semantic_embedding_policy(
-    repo_root: &Path,
-) -> Option<RepoSemanticEmbeddingPolicy> {
-    let config_path = crate::config::resolve_bound_daemon_config_path_for_repo(repo_root)
-        .or_else(|_| crate::config::resolve_daemon_config_path_for_repo(repo_root))
-        .ok()?;
-    let capability =
-        crate::cli::embeddings::embedding_capability_for_config_path(&config_path).ok()?;
-    let code_profile = non_empty_profile_name(
-        capability
-            .semantic_clones
-            .inference
-            .code_embeddings
-            .as_deref(),
-    );
-    let summary_profile = non_empty_profile_name(
-        capability
-            .semantic_clones
-            .inference
-            .summary_embeddings
-            .as_deref(),
-    );
-    if code_profile.is_some() || summary_profile.is_some() {
-        return Some(RepoSemanticEmbeddingPolicy {
-            present: true,
-            summary_mode: None,
-            embedding_mode: Some(capability.semantic_clones.embedding_mode),
-            inference: crate::config::SemanticClonesInferenceBindings {
-                summary_generation: capability.semantic_clones.inference.summary_generation,
-                code_embeddings: code_profile,
-                summary_embeddings: summary_profile,
-            },
-        });
-    }
-
-    crate::cli::embeddings::selected_inference_profile_name(&capability)
-        .map(RepoSemanticEmbeddingPolicy::enabled_with_profile)
-}
-
-fn non_empty_profile_name(value: Option<&str>) -> Option<String> {
-    value
+fn existing_init_summary_generation_profile_name(repo_root: &Path) -> Option<String> {
+    let capability = crate::config::resolve_inference_capability_config_for_repo(repo_root);
+    capability
+        .semantic_clones
+        .inference
+        .summary_generation
+        .as_deref()
         .map(str::trim)
         .filter(|profile| !profile.is_empty())
         .map(str::to_string)
+}
+
+fn prepared_summary_generation_profile_name(
+    plan: &crate::cli::inference::PreparedSummarySetupPlan,
+) -> Option<&'static str> {
+    match plan.action() {
+        PreparedSummarySetupAction::ConfigureCloud { .. } => Some("summary_llm"),
+        PreparedSummarySetupAction::ConfigureLocal { .. } => Some("summary_local"),
+        PreparedSummarySetupAction::InstallRuntimeOnly { .. }
+        | PreparedSummarySetupAction::InstallRuntimeOnlyPendingProbe { .. } => None,
+    }
 }
 
 async fn bound_running_daemon_config_path() -> Result<std::path::PathBuf> {

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -256,7 +256,7 @@ pub(crate) async fn run_for_project_root(
         },
     )?;
     let repo_selected_embedding_lanes =
-        final_setup_selection.code_embeddings || final_setup_selection.summary_embeddings;
+        init_repo_selected_embedding_lanes(final_setup_selection, args.no_summaries);
     let mut embeddings_bootstrap = None;
     let mut embeddings_bootstrap_rollback_plan = None;
     let mut prepared_summary_setup = None;
@@ -578,6 +578,47 @@ pub(crate) async fn run_for_project_root(
         }
     }
     Ok(())
+}
+
+fn init_repo_selected_embedding_lanes(
+    selection: super::final_setup::InitFinalSetupSelection,
+    no_summaries: bool,
+) -> bool {
+    let summary_embedding_lane =
+        selection.summaries && selection.summary_embeddings && !no_summaries;
+    selection.code_embeddings || summary_embedding_lane
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn final_setup_selection(
+        code_embeddings: bool,
+        summaries: bool,
+        summary_embeddings: bool,
+    ) -> super::super::final_setup::InitFinalSetupSelection {
+        super::super::final_setup::InitFinalSetupSelection {
+            sync: false,
+            ingest: false,
+            code_embeddings,
+            summaries,
+            summary_embeddings,
+            telemetry: false,
+            auto_start_daemon: false,
+        }
+    }
+
+    #[test]
+    fn repo_selected_embedding_lanes_ignores_summary_embeddings_when_summaries_disabled() {
+        let summary_only = final_setup_selection(false, true, true);
+
+        assert!(!init_repo_selected_embedding_lanes(summary_only, true));
+
+        let code_embeddings = final_setup_selection(true, false, false);
+
+        assert!(init_repo_selected_embedding_lanes(code_embeddings, true));
+    }
 }
 
 fn persist_init_embeddings_policy(

--- a/bitloops/src/cli/init/workflow.rs
+++ b/bitloops/src/cli/init/workflow.rs
@@ -703,7 +703,7 @@ model = "local-model"
     }
 
     #[test]
-    fn existing_init_embedding_profile_names_fills_missing_slots_from_daemon_config() {
+    fn existing_init_embedding_profile_names_does_not_fill_summary_embeddings_from_daemon_config() {
         let repo = tempfile::tempdir().expect("tempdir");
         write_bound_daemon_config(
             repo.path(),
@@ -751,7 +751,7 @@ code_embeddings = "repo_code"
             names,
             InitEmbeddingProfileNames {
                 code_embeddings: Some("repo_code".to_string()),
-                summary_embeddings: Some("daemon_summary".to_string()),
+                summary_embeddings: None,
             }
         );
     }
@@ -821,7 +821,7 @@ impl InitEmbeddingProfileNames {
 fn existing_init_embedding_profile_names(repo_root: &Path) -> Result<InitEmbeddingProfileNames> {
     let existing_policy = repo_semantic_embedding_policy(repo_root)?;
     let mut profile_names = embedding_profile_names_from_policy(&existing_policy);
-    if profile_names.code_embeddings.is_some() && profile_names.summary_embeddings.is_some() {
+    if profile_names.code_embeddings.is_some() {
         return Ok(profile_names);
     }
 
@@ -832,9 +832,6 @@ fn existing_init_embedding_profile_names(repo_root: &Path) -> Result<InitEmbeddi
     };
     if profile_names.code_embeddings.is_none() {
         profile_names.code_embeddings = daemon_profile_names.code_embeddings;
-    }
-    if profile_names.summary_embeddings.is_none() {
-        profile_names.summary_embeddings = daemon_profile_names.summary_embeddings;
     }
     Ok(profile_names)
 }

--- a/bitloops/src/config.rs
+++ b/bitloops/src/config.rs
@@ -21,10 +21,10 @@ pub use daemon_config::{
     persist_daemon_cli_settings, persist_dashboard_tls_hint, update_daemon_telemetry_consent,
 };
 pub(crate) use daemon_config::{
-    DaemonEmbeddingsInstallMode, DaemonEmbeddingsInstallPlan,
-    persist_daemon_store_backend_selection, prepare_daemon_embeddings_install,
-    prepare_daemon_inference_install, prepare_daemon_local_embeddings_profile_install,
-    prepare_daemon_platform_embeddings_install, validate_daemon_config_text,
+    DaemonEmbeddingsInstallPlan, persist_daemon_store_backend_selection,
+    prepare_daemon_embeddings_install, prepare_daemon_inference_install,
+    prepare_daemon_local_embeddings_profile_install, prepare_daemon_platform_embeddings_install,
+    validate_daemon_config_text,
 };
 pub(crate) use repo_policy::validate_repo_policy_text;
 pub use repo_policy::{

--- a/bitloops/src/config/daemon_config.rs
+++ b/bitloops/src/config/daemon_config.rs
@@ -23,4 +23,4 @@ pub(crate) use install::{
     prepare_daemon_embeddings_install, prepare_daemon_inference_install,
     prepare_daemon_local_embeddings_profile_install, prepare_daemon_platform_embeddings_install,
 };
-pub(crate) use plans::{DaemonEmbeddingsInstallMode, DaemonEmbeddingsInstallPlan};
+pub(crate) use plans::DaemonEmbeddingsInstallPlan;

--- a/bitloops/src/config/daemon_config/install.rs
+++ b/bitloops/src/config/daemon_config/install.rs
@@ -10,29 +10,26 @@ use crate::host::inference::{
 };
 use crate::utils::platform_dirs::ensure_parent_dir;
 
-use super::plans::{
-    DaemonEmbeddingsInstallMode, DaemonEmbeddingsInstallPlan, DaemonInferenceInstallPlan,
-};
+use super::plans::{DaemonEmbeddingsInstallPlan, DaemonInferenceInstallPlan};
 use super::toml::{
     ensure_child_table, ensure_table, inference_driver_for_profile, inference_runtime_for_profile,
-    selected_inference_profile_name,
+    strip_semantic_enablement,
 };
 
 pub(crate) fn prepare_daemon_embeddings_install(
     config_path: &Path,
 ) -> Result<DaemonEmbeddingsInstallPlan> {
-    prepare_daemon_embeddings_install_with_mode(config_path, true)
+    prepare_daemon_embeddings_install_with_mode(config_path)
 }
 
 pub(crate) fn prepare_daemon_local_embeddings_profile_install(
     config_path: &Path,
 ) -> Result<DaemonEmbeddingsInstallPlan> {
-    prepare_daemon_embeddings_install_with_mode(config_path, false)
+    prepare_daemon_embeddings_install_with_mode(config_path)
 }
 
 fn prepare_daemon_embeddings_install_with_mode(
     config_path: &Path,
-    respect_selected_profile: bool,
 ) -> Result<DaemonEmbeddingsInstallPlan> {
     const DEFAULT_LOCAL_PROFILE: &str = "local_code";
     const DEFAULT_LOCAL_MODEL: &str = "bge-m3";
@@ -56,28 +53,6 @@ fn prepare_daemon_embeddings_install_with_mode(
         None => DocumentMut::new(),
     };
 
-    if respect_selected_profile && let Some(profile_name) = selected_inference_profile_name(&doc) {
-        let profile_driver = inference_driver_for_profile(&doc, &profile_name);
-        let profile_runtime = inference_runtime_for_profile(&doc, &profile_name);
-        let mode = if profile_driver.as_deref() == Some(BITLOOPS_EMBEDDINGS_IPC_DRIVER)
-            && profile_runtime.as_deref() == Some(BITLOOPS_LOCAL_EMBEDDINGS_RUNTIME_ID)
-        {
-            DaemonEmbeddingsInstallMode::WarmExisting
-        } else {
-            DaemonEmbeddingsInstallMode::SkipHosted
-        };
-        return Ok(DaemonEmbeddingsInstallPlan {
-            config_path: config_path.to_path_buf(),
-            profile_name,
-            runtime_name: BITLOOPS_LOCAL_EMBEDDINGS_RUNTIME_ID.to_string(),
-            profile_driver,
-            mode,
-            config_modified: false,
-            original_contents,
-            prepared_contents: None,
-        });
-    }
-
     if let Some(kind) = inference_driver_for_profile(&doc, DEFAULT_LOCAL_PROFILE)
         && kind != BITLOOPS_EMBEDDINGS_IPC_DRIVER
     {
@@ -93,7 +68,7 @@ fn prepare_daemon_embeddings_install_with_mode(
         );
     }
 
-    let mut modified = false;
+    let mut modified = strip_semantic_enablement(&mut doc);
     {
         let inference = ensure_table(&mut doc, "inference");
 
@@ -198,8 +173,6 @@ fn prepare_daemon_embeddings_install_with_mode(
         config_path: config_path.to_path_buf(),
         profile_name: DEFAULT_LOCAL_PROFILE.to_string(),
         runtime_name: BITLOOPS_LOCAL_EMBEDDINGS_RUNTIME_ID.to_string(),
-        profile_driver: Some(BITLOOPS_EMBEDDINGS_IPC_DRIVER.to_string()),
-        mode: DaemonEmbeddingsInstallMode::Bootstrap,
         config_modified: modified,
         original_contents,
         prepared_contents,
@@ -232,6 +205,7 @@ pub(crate) fn prepare_daemon_platform_embeddings_install(
             .with_context(|| format!("parsing Bitloops daemon config {}", config_path.display()))?,
         None => DocumentMut::new(),
     };
+    strip_semantic_enablement(&mut doc);
 
     {
         let inference = ensure_table(&mut doc, "inference");
@@ -267,8 +241,6 @@ pub(crate) fn prepare_daemon_platform_embeddings_install(
         config_path: config_path.to_path_buf(),
         profile_name: DEFAULT_PLATFORM_PROFILE.to_string(),
         runtime_name: BITLOOPS_PLATFORM_EMBEDDINGS_RUNTIME_ID.to_string(),
-        profile_driver: Some(BITLOOPS_EMBEDDINGS_IPC_DRIVER.to_string()),
-        mode: DaemonEmbeddingsInstallMode::Bootstrap,
         config_modified,
         original_contents,
         prepared_contents: config_modified.then_some(prepared_contents),
@@ -297,7 +269,7 @@ pub(crate) fn prepare_daemon_inference_install(
         None => DocumentMut::new(),
     };
 
-    let mut modified = false;
+    let mut modified = strip_semantic_enablement(&mut doc);
     let inference = ensure_table(&mut doc, "inference");
     let runtimes = ensure_child_table(inference, "runtimes");
     let runtime = ensure_child_table(runtimes, BITLOOPS_INFERENCE_RUNTIME_ID);

--- a/bitloops/src/config/daemon_config/plans.rs
+++ b/bitloops/src/config/daemon_config/plans.rs
@@ -4,22 +4,13 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use toml_edit::{DocumentMut, Item};
 
-use super::toml::{ensure_child_table, ensure_table};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DaemonEmbeddingsInstallMode {
-    Bootstrap,
-    WarmExisting,
-    SkipHosted,
-}
+use super::toml::{ensure_child_table, ensure_table, strip_semantic_enablement};
 
 #[derive(Debug, Clone)]
 pub(crate) struct DaemonEmbeddingsInstallPlan {
     pub config_path: PathBuf,
     pub profile_name: String,
     pub runtime_name: String,
-    pub profile_driver: Option<String>,
-    pub mode: DaemonEmbeddingsInstallMode,
     pub config_modified: bool,
     pub(crate) original_contents: Option<String>,
     pub(crate) prepared_contents: Option<String>,
@@ -111,6 +102,7 @@ impl DaemonEmbeddingsInstallPlan {
             let profiles = ensure_child_table(inference, "profiles");
             profiles[&self.profile_name] = desired_profile;
         }
+        strip_semantic_enablement(&mut current_doc);
 
         let updated_contents = current_doc.to_string();
         if current_contents == updated_contents {

--- a/bitloops/src/config/daemon_config/tests.rs
+++ b/bitloops/src/config/daemon_config/tests.rs
@@ -258,7 +258,6 @@ request_timeout_secs = 300
 
     let plan =
         prepare_daemon_embeddings_install(config.path()).expect("prepare embeddings install");
-    assert_eq!(plan.mode, DaemonEmbeddingsInstallMode::Bootstrap);
     plan.apply().expect("apply staged embeddings config");
 
     let rendered = fs::read_to_string(config.path()).expect("read updated config");
@@ -312,7 +311,6 @@ request_timeout_secs = 300
 
     let plan =
         prepare_daemon_embeddings_install(config.path()).expect("prepare embeddings install");
-    assert_eq!(plan.mode, DaemonEmbeddingsInstallMode::Bootstrap);
 
     fs::write(
         config.path(),
@@ -346,8 +344,8 @@ max_output_tokens = 200
 
     let rendered = fs::read_to_string(config.path()).expect("read updated config");
     assert!(
-        rendered.contains("summary_generation = \"summary_local\""),
-        "expected embeddings apply to preserve summary binding:\n{rendered}"
+        !rendered.contains("summary_generation = \"summary_local\""),
+        "expected embeddings apply to remove daemon semantic binding:\n{rendered}"
     );
     assert!(
         rendered.contains("[inference.profiles.summary_local]"),
@@ -382,7 +380,6 @@ local_dev = false
         "BITLOOPS_PLATFORM_GATEWAY_TOKEN",
     )
     .expect("prepare platform embeddings install");
-    assert_eq!(plan.mode, DaemonEmbeddingsInstallMode::Bootstrap);
     plan.apply()
         .expect("apply staged platform embeddings config");
 
@@ -427,7 +424,7 @@ local_dev = false
 }
 
 #[test]
-fn prepare_daemon_embeddings_install_skips_existing_platform_ipc_profile() {
+fn prepare_daemon_embeddings_install_ignores_daemon_platform_semantic_binding() {
     let config = NamedTempFile::new().expect("create temp config");
     fs::write(
         config.path(),
@@ -457,13 +454,12 @@ model = "bge-m3"
     let plan =
         prepare_daemon_embeddings_install(config.path()).expect("prepare embeddings install");
 
-    assert_eq!(plan.profile_name, "platform_code");
-    assert_eq!(plan.mode, DaemonEmbeddingsInstallMode::SkipHosted);
-    assert!(!plan.config_modified);
+    assert_eq!(plan.profile_name, "local_code");
+    assert!(plan.config_modified);
 }
 
 #[test]
-fn prepare_daemon_embeddings_install_warms_legacy_daemon_bound_profile() {
+fn prepare_daemon_embeddings_install_ignores_daemon_local_semantic_binding() {
     let config = NamedTempFile::new().expect("create temp config");
     fs::write(
         config.path(),
@@ -494,8 +490,7 @@ model = "bge-m3"
         prepare_daemon_embeddings_install(config.path()).expect("prepare embeddings install");
 
     assert_eq!(plan.profile_name, "local_code");
-    assert_eq!(plan.mode, DaemonEmbeddingsInstallMode::WarmExisting);
-    assert!(!plan.config_modified);
+    assert!(plan.config_modified);
 }
 
 #[test]

--- a/bitloops/src/config/daemon_config/toml.rs
+++ b/bitloops/src/config/daemon_config/toml.rs
@@ -19,38 +19,42 @@ pub(super) fn ensure_child_table<'a>(table: &'a mut Table, key: &str) -> &'a mut
         .expect("TOML item should be a table after initialisation")
 }
 
-/// Reads legacy daemon-global semantic embedding bindings for migration and
-/// warm-existing installer behavior.
-pub(super) fn selected_inference_profile_name(doc: &DocumentMut) -> Option<String> {
-    let inference = doc
-        .as_table()
-        .get("semantic_clones")?
-        .as_table()?
-        .get("inference")?
-        .as_table()?;
+pub(super) fn strip_semantic_enablement(doc: &mut DocumentMut) -> bool {
+    let Some(semantic_item) = doc.as_table_mut().get_mut("semantic_clones") else {
+        return false;
+    };
+    let Some(semantic) = semantic_item.as_table_mut() else {
+        return false;
+    };
 
-    for key in ["code_embeddings", "summary_embeddings"] {
-        let Some(value) = inference
-            .get(key)
-            .and_then(Item::as_value)
-            .and_then(|value| value.as_str())
-            .map(str::trim)
-        else {
-            continue;
-        };
-        if value.is_empty() {
-            continue;
-        }
-        if matches!(
-            value.to_ascii_lowercase().as_str(),
-            "none" | "disabled" | "off"
-        ) {
-            continue;
-        }
-        return Some(value.to_string());
+    let mut modified = false;
+    for key in ["summary_mode", "embedding_mode"] {
+        modified |= semantic.remove(key).is_some();
     }
 
-    None
+    if let Some(inference) = semantic.get_mut("inference").and_then(Item::as_table_mut) {
+        for key in [
+            "summary_generation",
+            "code_embeddings",
+            "summary_embeddings",
+        ] {
+            modified |= inference.remove(key).is_some();
+        }
+    }
+    if semantic
+        .get("inference")
+        .and_then(Item::as_table)
+        .is_some_and(Table::is_empty)
+    {
+        semantic.remove("inference");
+        modified = true;
+    }
+    if semantic.is_empty() {
+        doc.as_table_mut().remove("semantic_clones");
+        modified = true;
+    }
+
+    modified
 }
 
 pub(super) fn inference_driver_for_profile(

--- a/bitloops/src/config/resolve.rs
+++ b/bitloops/src/config/resolve.rs
@@ -348,6 +348,7 @@ fn preferred_daemon_settings_with_repo_semantic_policy(
     if semantic_policy.present {
         settings.semantic_clones = Some(apply_repo_semantic_embedding_policy(
             settings.semantic_clones.take(),
+            semantic_policy.summary_mode,
             semantic_policy.embedding_mode,
             semantic_policy.inference,
         ));
@@ -358,12 +359,18 @@ fn preferred_daemon_settings_with_repo_semantic_policy(
 
 fn apply_repo_semantic_embedding_policy(
     daemon_semantic_clones: Option<Value>,
+    summary_mode: Option<SemanticSummaryMode>,
     embedding_mode: Option<SemanticCloneEmbeddingMode>,
     repo_inference: SemanticClonesInferenceBindings,
 ) -> Value {
     let mut root = daemon_semantic_clones
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
+    if let Some(mode) = summary_mode {
+        root.remove("summary_mode");
+        root.insert("summary_mode".to_string(), Value::String(mode.to_string()));
+    }
+
     let repo_supplied_embedding_bindings = repo_inference.code_embeddings.as_ref().is_some()
         || repo_inference.summary_embeddings.as_ref().is_some();
     let daemon_embedding_mode = root
@@ -387,6 +394,17 @@ fn apply_repo_semantic_embedding_policy(
         .remove("inference")
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
+    let repo_controls_summaries =
+        summary_mode.is_some() || repo_inference.summary_generation.as_ref().is_some();
+    if repo_controls_summaries {
+        inference.remove("summary_generation");
+        if summary_mode != Some(SemanticSummaryMode::Off) {
+            if let Some(profile) = repo_inference.summary_generation {
+                inference.insert("summary_generation".to_string(), Value::String(profile));
+            }
+        }
+    }
+
     inference.remove("code_embeddings");
     inference.remove("summary_embeddings");
     if effective_embedding_mode != SemanticCloneEmbeddingMode::Off {
@@ -405,7 +423,9 @@ fn repo_effective_semantic_env(key: &str, repo_policy_present: bool) -> Option<S
     if repo_policy_present
         && matches!(
             key,
-            "BITLOOPS_SEMANTIC_CLONES_EMBEDDING_MODE" | "BITLOOPS_SEMANTIC_CLONES_CODE_EMBEDDINGS"
+            "BITLOOPS_SEMANTIC_CLONES_SUMMARY_MODE"
+                | "BITLOOPS_SEMANTIC_CLONES_EMBEDDING_MODE"
+                | "BITLOOPS_SEMANTIC_CLONES_CODE_EMBEDDINGS"
         )
     {
         return None;

--- a/bitloops/src/config/resolve.rs
+++ b/bitloops/src/config/resolve.rs
@@ -343,6 +343,7 @@ fn preferred_daemon_settings_with_repo_semantic_policy(
     repo_root: &Path,
 ) -> Result<(PathBuf, UnifiedSettings, RepoSemanticEnvPolicy)> {
     let (config_root, mut settings) = preferred_daemon_settings_for_repo(repo_root)?;
+    strip_repo_local_semantic_choices_from_daemon(&mut settings.semantic_clones);
     let repo_policy = discover_repo_policy_optional(repo_root)?;
     let semantic_policy = match repo_semantic_embedding_policy_from_policy(&repo_policy) {
         Ok(policy) => policy,
@@ -359,6 +360,30 @@ fn preferred_daemon_settings_with_repo_semantic_policy(
     }
 
     Ok((config_root, settings, repo_env_policy))
+}
+
+fn strip_repo_local_semantic_choices_from_daemon(semantic_clones: &mut Option<Value>) {
+    let Some(root) = semantic_clones.as_mut().and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    root.remove("summary_mode");
+    root.remove("embedding_mode");
+    if let Some(inference) = root.get_mut("inference").and_then(Value::as_object_mut) {
+        inference.remove("summary_generation");
+        inference.remove("code_embeddings");
+        inference.remove("summary_embeddings");
+    }
+    if root
+        .get("inference")
+        .and_then(Value::as_object)
+        .is_some_and(serde_json::Map::is_empty)
+    {
+        root.remove("inference");
+    }
+    if root.is_empty() {
+        *semantic_clones = None;
+    }
 }
 
 fn apply_repo_semantic_embedding_policy(
@@ -405,6 +430,10 @@ fn apply_repo_semantic_embedding_policy(
                 repo_supplied_embedding_bindings
                     .then_some(daemon_embedding_mode)
                     .flatten()
+            })
+            .or_else(|| {
+                repo_supplied_embedding_bindings
+                    .then_some(SemanticCloneEmbeddingMode::SemanticAwareOnce)
             })
             .unwrap_or(SemanticCloneEmbeddingMode::Off);
 

--- a/bitloops/src/config/resolve.rs
+++ b/bitloops/src/config/resolve.rs
@@ -12,7 +12,7 @@ use super::daemon_config::{
 };
 pub(crate) use super::inference_resolve::resolve_inference_from_unified_with;
 use super::repo_policy::{REPO_POLICY_LOCAL_FILE_NAME, discover_repo_policy_optional};
-use super::settings::repo_semantic_embedding_policy_from_policy;
+use super::settings::{RepoSemanticEmbeddingPolicy, repo_semantic_embedding_policy_from_policy};
 use super::store_config_utils::{
     current_repo_root_or_cwd, current_repo_root_or_cwd_result, normalize_blob_path,
     normalize_sqlite_path, read_any_string, read_any_u64, read_non_empty_env,
@@ -330,21 +330,25 @@ pub fn resolve_provider_config_for_repo(repo_root: &Path) -> Result<ProviderConf
     resolve_provider_from_unified(&settings, |key| env::var(key).ok())
 }
 pub fn resolve_semantic_clones_config_for_repo(repo_root: &Path) -> SemanticClonesConfig {
-    let (settings, repo_policy_present) =
+    let (settings, repo_env_policy) =
         preferred_daemon_settings_with_repo_semantic_policy(repo_root)
-            .map(|(_, settings, repo_policy_present)| (settings, repo_policy_present))
+            .map(|(_, settings, repo_env_policy)| (settings, repo_env_policy))
             .unwrap_or_default();
     resolve_semantic_clones_from_unified(&settings, |key| {
-        repo_effective_semantic_env(key, repo_policy_present)
+        repo_effective_semantic_env(key, repo_env_policy)
     })
 }
 
 fn preferred_daemon_settings_with_repo_semantic_policy(
     repo_root: &Path,
-) -> Result<(PathBuf, UnifiedSettings, bool)> {
+) -> Result<(PathBuf, UnifiedSettings, RepoSemanticEnvPolicy)> {
     let (config_root, mut settings) = preferred_daemon_settings_for_repo(repo_root)?;
     let repo_policy = discover_repo_policy_optional(repo_root)?;
-    let semantic_policy = repo_semantic_embedding_policy_from_policy(&repo_policy)?;
+    let semantic_policy = match repo_semantic_embedding_policy_from_policy(&repo_policy) {
+        Ok(policy) => policy,
+        Err(_) => return Ok((config_root, settings, RepoSemanticEnvPolicy::default())),
+    };
+    let repo_env_policy = RepoSemanticEnvPolicy::from_policy(&semantic_policy);
     if semantic_policy.present {
         settings.semantic_clones = Some(apply_repo_semantic_embedding_policy(
             settings.semantic_clones.take(),
@@ -354,7 +358,7 @@ fn preferred_daemon_settings_with_repo_semantic_policy(
         ));
     }
 
-    Ok((config_root, settings, semantic_policy.present))
+    Ok((config_root, settings, repo_env_policy))
 }
 
 fn apply_repo_semantic_embedding_policy(
@@ -371,25 +375,6 @@ fn apply_repo_semantic_embedding_policy(
         root.insert("summary_mode".to_string(), Value::String(mode.to_string()));
     }
 
-    let repo_supplied_embedding_bindings = repo_inference.code_embeddings.as_ref().is_some()
-        || repo_inference.summary_embeddings.as_ref().is_some();
-    let daemon_embedding_mode = root
-        .get("embedding_mode")
-        .and_then(|value| value.as_str())
-        .map(parse_embedding_mode);
-    let effective_embedding_mode = embedding_mode
-        .or_else(|| {
-            repo_supplied_embedding_bindings
-                .then_some(daemon_embedding_mode)
-                .flatten()
-        })
-        .unwrap_or(SemanticCloneEmbeddingMode::Off);
-    root.remove("embedding_mode");
-    root.insert(
-        "embedding_mode".to_string(),
-        Value::String(effective_embedding_mode.to_string()),
-    );
-
     let mut inference = root
         .remove("inference")
         .and_then(|value| value.as_object().cloned())
@@ -405,30 +390,70 @@ fn apply_repo_semantic_embedding_policy(
         }
     }
 
-    inference.remove("code_embeddings");
-    inference.remove("summary_embeddings");
-    if effective_embedding_mode != SemanticCloneEmbeddingMode::Off {
-        if let Some(profile) = repo_inference.code_embeddings {
-            inference.insert("code_embeddings".to_string(), Value::String(profile));
-        }
-        if let Some(profile) = repo_inference.summary_embeddings {
-            inference.insert("summary_embeddings".to_string(), Value::String(profile));
+    let repo_controls_embeddings = embedding_mode.is_some()
+        || repo_inference.code_embeddings.is_some()
+        || repo_inference.summary_embeddings.is_some();
+    if repo_controls_embeddings {
+        let repo_supplied_embedding_bindings = repo_inference.code_embeddings.as_ref().is_some()
+            || repo_inference.summary_embeddings.as_ref().is_some();
+        let daemon_embedding_mode = root
+            .get("embedding_mode")
+            .and_then(|value| value.as_str())
+            .map(parse_embedding_mode);
+        let effective_embedding_mode = embedding_mode
+            .or_else(|| {
+                repo_supplied_embedding_bindings
+                    .then_some(daemon_embedding_mode)
+                    .flatten()
+            })
+            .unwrap_or(SemanticCloneEmbeddingMode::Off);
+
+        root.remove("embedding_mode");
+        root.insert(
+            "embedding_mode".to_string(),
+            Value::String(effective_embedding_mode.to_string()),
+        );
+        inference.remove("code_embeddings");
+        inference.remove("summary_embeddings");
+        if effective_embedding_mode != SemanticCloneEmbeddingMode::Off {
+            if let Some(profile) = repo_inference.code_embeddings {
+                inference.insert("code_embeddings".to_string(), Value::String(profile));
+            }
+            if let Some(profile) = repo_inference.summary_embeddings {
+                inference.insert("summary_embeddings".to_string(), Value::String(profile));
+            }
         }
     }
     root.insert("inference".to_string(), Value::Object(inference));
     Value::Object(root)
 }
 
-fn repo_effective_semantic_env(key: &str, repo_policy_present: bool) -> Option<String> {
-    if repo_policy_present
-        && matches!(
-            key,
-            "BITLOOPS_SEMANTIC_CLONES_SUMMARY_MODE"
-                | "BITLOOPS_SEMANTIC_CLONES_EMBEDDING_MODE"
-                | "BITLOOPS_SEMANTIC_CLONES_CODE_EMBEDDINGS"
-        )
-    {
-        return None;
+#[derive(Debug, Clone, Copy, Default)]
+struct RepoSemanticEnvPolicy {
+    summary_mode: bool,
+    embedding_mode: bool,
+    code_embeddings: bool,
+}
+
+impl RepoSemanticEnvPolicy {
+    fn from_policy(policy: &RepoSemanticEmbeddingPolicy) -> Self {
+        Self {
+            summary_mode: policy.summary_mode.is_some()
+                || policy.inference.summary_generation.is_some(),
+            embedding_mode: policy.embedding_mode.is_some()
+                || policy.inference.code_embeddings.is_some()
+                || policy.inference.summary_embeddings.is_some(),
+            code_embeddings: policy.inference.code_embeddings.is_some(),
+        }
+    }
+}
+
+fn repo_effective_semantic_env(key: &str, policy: RepoSemanticEnvPolicy) -> Option<String> {
+    match key {
+        "BITLOOPS_SEMANTIC_CLONES_SUMMARY_MODE" if policy.summary_mode => return None,
+        "BITLOOPS_SEMANTIC_CLONES_EMBEDDING_MODE" if policy.embedding_mode => return None,
+        "BITLOOPS_SEMANTIC_CLONES_CODE_EMBEDDINGS" if policy.code_embeddings => return None,
+        _ => {}
     }
 
     env::var(key).ok()
@@ -453,10 +478,10 @@ pub fn resolve_embeddings_config_for_repo(repo_root: &Path) -> EmbeddingsConfig 
 }
 
 pub fn resolve_inference_capability_config_for_repo(repo_root: &Path) -> InferenceCapabilityConfig {
-    let (config_root, settings, repo_policy_present) =
+    let (config_root, settings, repo_env_policy) =
         preferred_daemon_settings_with_repo_semantic_policy(repo_root).unwrap_or_default();
     resolve_inference_capability_from_unified(&settings, &config_root, |key| {
-        repo_effective_semantic_env(key, repo_policy_present)
+        repo_effective_semantic_env(key, repo_env_policy)
     })
 }
 

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -120,6 +120,11 @@ impl RepoSemanticEmbeddingPolicy {
         existing: &Self,
     ) -> Self {
         let profile_name = profile_name.into();
+        let summary_embeddings = existing
+            .inference
+            .summary_embeddings
+            .as_ref()
+            .map(|_| profile_name.clone());
         Self {
             present: true,
             summary_mode: existing.summary_mode,
@@ -127,7 +132,7 @@ impl RepoSemanticEmbeddingPolicy {
             inference: SemanticClonesInferenceBindings {
                 summary_generation: existing.inference.summary_generation.clone(),
                 code_embeddings: Some(profile_name.clone()),
-                summary_embeddings: Some(profile_name),
+                summary_embeddings,
             },
         }
     }
@@ -551,11 +556,12 @@ pub fn set_repo_semantic_embedding_policy(
         } else if let Some(table) = doc["semantic_clones"].as_table_mut() {
             table.remove("summary_mode");
         }
-        let mode = policy
-            .embedding_mode
-            .unwrap_or(SemanticCloneEmbeddingMode::Off)
-            .to_string();
-        doc["semantic_clones"]["embedding_mode"] = Item::Value(TomlValue::from(mode.as_str()));
+        if let Some(embedding_mode) = policy.embedding_mode {
+            let mode = embedding_mode.to_string();
+            doc["semantic_clones"]["embedding_mode"] = Item::Value(TomlValue::from(mode.as_str()));
+        } else if let Some(table) = doc["semantic_clones"].as_table_mut() {
+            table.remove("embedding_mode");
+        }
         ensure_semantic_clones_inference_table(doc);
         set_optional_string(
             &mut doc["semantic_clones"]["inference"],
@@ -883,6 +889,46 @@ code_embeddings = "code_local"
         assert!(content.contains("[semantic_clones.inference]"));
         assert!(content.contains("code_embeddings = \"local_code\""));
         assert!(content.contains("summary_embeddings = \"local_code\""));
+    }
+
+    #[test]
+    fn enabled_embedding_profile_preserves_only_existing_summary_embedding_choice() {
+        let existing_without_summary_embeddings = RepoSemanticEmbeddingPolicy {
+            present: true,
+            summary_mode: Some(SemanticSummaryMode::Auto),
+            embedding_mode: Some(SemanticCloneEmbeddingMode::Off),
+            inference: SemanticClonesInferenceBindings {
+                summary_generation: Some("summary_local".to_string()),
+                code_embeddings: None,
+                summary_embeddings: None,
+            },
+        };
+        let policy = RepoSemanticEmbeddingPolicy::enabled_with_profile_preserving_summaries(
+            "local_code",
+            &existing_without_summary_embeddings,
+        );
+        assert_eq!(
+            policy.inference.code_embeddings.as_deref(),
+            Some("local_code")
+        );
+        assert_eq!(
+            policy.inference.summary_generation.as_deref(),
+            Some("summary_local")
+        );
+        assert_eq!(policy.inference.summary_embeddings, None);
+
+        let mut existing_with_summary_embeddings = existing_without_summary_embeddings.clone();
+        existing_with_summary_embeddings
+            .inference
+            .summary_embeddings = Some("old_summary".to_string());
+        let policy = RepoSemanticEmbeddingPolicy::enabled_with_profile_preserving_summaries(
+            "platform_code",
+            &existing_with_summary_embeddings,
+        );
+        assert_eq!(
+            policy.inference.summary_embeddings.as_deref(),
+            Some("platform_code")
+        );
     }
 
     #[test]

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -531,6 +531,8 @@ pub fn set_repo_semantic_embedding_policy(
         if let Some(summary_mode) = policy.summary_mode {
             let mode = summary_mode.to_string();
             doc["semantic_clones"]["summary_mode"] = Item::Value(TomlValue::from(mode.as_str()));
+        } else if let Some(table) = doc["semantic_clones"].as_table_mut() {
+            table.remove("summary_mode");
         }
         let mode = policy
             .embedding_mode
@@ -939,6 +941,38 @@ code_embeddings = "code_local"
         assert!(content.contains("code_embeddings = \"code_local\""));
         assert!(!content.contains("summary_generation = "));
         assert!(!content.contains("summary_embeddings = "));
+    }
+
+    #[test]
+    fn set_repo_semantic_embedding_policy_removes_summary_mode_when_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(REPO_POLICY_LOCAL_FILE_NAME);
+        fs::write(
+            &path,
+            r#"
+[semantic_clones]
+summary_mode = "auto"
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+summary_generation = "summary_local"
+code_embeddings = "old_code"
+"#,
+        )
+        .expect("write initial policy");
+
+        set_repo_semantic_embedding_policy(
+            &path,
+            &RepoSemanticEmbeddingPolicy::enabled_with_profile("new_code"),
+        )
+        .expect("write embedding-only policy");
+
+        let content = fs::read_to_string(path).expect("read repo policy");
+        assert!(!content.contains("summary_mode = "));
+        assert!(!content.contains("summary_generation = "));
+        assert!(content.contains("embedding_mode = \"semantic_aware_once\""));
+        assert!(content.contains("code_embeddings = \"new_code\""));
+        assert!(content.contains("summary_embeddings = \"new_code\""));
     }
 
     #[test]

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -10,8 +10,8 @@ use toml_edit::{Array, DocumentMut, Item, Table, Value as TomlValue};
 
 use super::{
     REPO_POLICY_FILE_NAME, REPO_POLICY_LOCAL_FILE_NAME, SemanticCloneEmbeddingMode,
-    SemanticClonesInferenceBindings, discover_repo_policy, discover_repo_policy_optional,
-    load_daemon_settings,
+    SemanticClonesInferenceBindings, SemanticSummaryMode, discover_repo_policy,
+    discover_repo_policy_optional, load_daemon_settings,
 };
 
 pub const SETTINGS_FILE: &str = REPO_POLICY_FILE_NAME;
@@ -86,6 +86,7 @@ impl Default for DevqlProducerSettings {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepoSemanticEmbeddingPolicy {
     pub present: bool,
+    pub summary_mode: Option<SemanticSummaryMode>,
     pub embedding_mode: Option<SemanticCloneEmbeddingMode>,
     pub inference: SemanticClonesInferenceBindings,
 }
@@ -94,6 +95,7 @@ impl RepoSemanticEmbeddingPolicy {
     pub fn disabled() -> Self {
         Self {
             present: true,
+            summary_mode: None,
             embedding_mode: Some(SemanticCloneEmbeddingMode::Off),
             inference: SemanticClonesInferenceBindings::default(),
         }
@@ -103,6 +105,7 @@ impl RepoSemanticEmbeddingPolicy {
         let profile_name = profile_name.into();
         Self {
             present: true,
+            summary_mode: None,
             embedding_mode: Some(SemanticCloneEmbeddingMode::SemanticAwareOnce),
             inference: SemanticClonesInferenceBindings {
                 summary_generation: None,
@@ -157,6 +160,7 @@ pub fn repo_semantic_embedding_policy_from_policy(
     if !policy.semantic_clones_present {
         return Ok(RepoSemanticEmbeddingPolicy {
             present: false,
+            summary_mode: None,
             embedding_mode: None,
             inference: SemanticClonesInferenceBindings::default(),
         });
@@ -166,6 +170,14 @@ pub fn repo_semantic_embedding_policy_from_policy(
         .semantic_clones
         .as_object()
         .ok_or_else(|| anyhow!("`[semantic_clones]` must be a table"))?;
+    let summary_mode = root
+        .get("summary_mode")
+        .map(|raw| {
+            raw.as_str()
+                .ok_or_else(|| anyhow!("`[semantic_clones].summary_mode` must be a string"))
+                .and_then(parse_repo_summary_mode)
+        })
+        .transpose()?;
     let embedding_mode = root
         .get("embedding_mode")
         .map(|raw| {
@@ -197,13 +209,22 @@ pub fn repo_semantic_embedding_policy_from_policy(
 
     Ok(RepoSemanticEmbeddingPolicy {
         present: true,
+        summary_mode,
         embedding_mode,
         inference: SemanticClonesInferenceBindings {
-            summary_generation: None,
+            summary_generation: read_profile("summary_generation")?,
             code_embeddings: read_profile("code_embeddings")?,
             summary_embeddings: read_profile("summary_embeddings")?,
         },
     })
+}
+
+fn parse_repo_summary_mode(raw: &str) -> Result<SemanticSummaryMode> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "" | "auto" => Ok(SemanticSummaryMode::Auto),
+        "off" | "disabled" | "none" => Ok(SemanticSummaryMode::Off),
+        other => bail!("unsupported `[semantic_clones].summary_mode` value `{other}`"),
+    }
 }
 
 fn parse_repo_embedding_mode(raw: &str) -> Result<SemanticCloneEmbeddingMode> {
@@ -507,12 +528,21 @@ pub fn set_repo_semantic_embedding_policy(
 ) -> Result<()> {
     write_repo_policy_file(path, |doc| {
         ensure_semantic_clones_table(doc);
+        if let Some(summary_mode) = policy.summary_mode {
+            let mode = summary_mode.to_string();
+            doc["semantic_clones"]["summary_mode"] = Item::Value(TomlValue::from(mode.as_str()));
+        }
         let mode = policy
             .embedding_mode
             .unwrap_or(SemanticCloneEmbeddingMode::Off)
             .to_string();
         doc["semantic_clones"]["embedding_mode"] = Item::Value(TomlValue::from(mode.as_str()));
         ensure_semantic_clones_inference_table(doc);
+        set_optional_string(
+            &mut doc["semantic_clones"]["inference"],
+            "summary_generation",
+            policy.inference.summary_generation.as_deref(),
+        );
         set_optional_string(
             &mut doc["semantic_clones"]["inference"],
             "code_embeddings",
@@ -782,6 +812,42 @@ embedding_mode = "off"
     }
 
     #[test]
+    fn repo_semantic_embedding_policy_reads_summary_mode_and_generation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join(REPO_POLICY_LOCAL_FILE_NAME),
+            r#"
+[semantic_clones]
+summary_mode = "auto"
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+summary_generation = "summary_local"
+code_embeddings = "code_local"
+"#,
+        )
+        .expect("write local repo policy");
+
+        let policy = repo_semantic_embedding_policy(dir.path()).expect("load semantic policy");
+
+        assert!(policy.present);
+        assert_eq!(policy.summary_mode, Some(SemanticSummaryMode::Auto));
+        assert_eq!(
+            policy.embedding_mode,
+            Some(SemanticCloneEmbeddingMode::SemanticAwareOnce)
+        );
+        assert_eq!(
+            policy.inference.summary_generation.as_deref(),
+            Some("summary_local")
+        );
+        assert_eq!(
+            policy.inference.code_embeddings.as_deref(),
+            Some("code_local")
+        );
+        assert_eq!(policy.inference.summary_embeddings, None);
+    }
+
+    #[test]
     fn set_repo_semantic_embedding_policy_persists_profile_bindings() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join(REPO_POLICY_LOCAL_FILE_NAME);
@@ -817,6 +883,62 @@ embedding_mode = "off"
         assert!(content.contains("embedding_mode = \"off\""));
         assert!(!content.contains("code_embeddings"));
         assert!(!content.contains("summary_embeddings"));
+    }
+
+    #[test]
+    fn set_repo_semantic_embedding_policy_persists_summary_mode_and_generation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(REPO_POLICY_LOCAL_FILE_NAME);
+
+        set_repo_semantic_embedding_policy(
+            &path,
+            &RepoSemanticEmbeddingPolicy {
+                present: true,
+                summary_mode: Some(SemanticSummaryMode::Auto),
+                embedding_mode: Some(SemanticCloneEmbeddingMode::SemanticAwareOnce),
+                inference: SemanticClonesInferenceBindings {
+                    summary_generation: Some("summary_local".to_string()),
+                    code_embeddings: Some("code_local".to_string()),
+                    summary_embeddings: None,
+                },
+            },
+        )
+        .expect("write semantic policy");
+
+        let content = fs::read_to_string(path).expect("read repo policy");
+        assert!(content.contains("summary_mode = \"auto\""));
+        assert!(content.contains("embedding_mode = \"semantic_aware_once\""));
+        assert!(content.contains("summary_generation = \"summary_local\""));
+        assert!(content.contains("code_embeddings = \"code_local\""));
+        assert!(!content.contains("summary_embeddings = "));
+    }
+
+    #[test]
+    fn set_repo_semantic_embedding_policy_can_disable_summaries_without_disabling_embeddings() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(REPO_POLICY_LOCAL_FILE_NAME);
+
+        set_repo_semantic_embedding_policy(
+            &path,
+            &RepoSemanticEmbeddingPolicy {
+                present: true,
+                summary_mode: Some(SemanticSummaryMode::Off),
+                embedding_mode: Some(SemanticCloneEmbeddingMode::SemanticAwareOnce),
+                inference: SemanticClonesInferenceBindings {
+                    summary_generation: None,
+                    code_embeddings: Some("code_local".to_string()),
+                    summary_embeddings: None,
+                },
+            },
+        )
+        .expect("write semantic policy");
+
+        let content = fs::read_to_string(path).expect("read repo policy");
+        assert!(content.contains("summary_mode = \"off\""));
+        assert!(content.contains("embedding_mode = \"semantic_aware_once\""));
+        assert!(content.contains("code_embeddings = \"code_local\""));
+        assert!(!content.contains("summary_generation = "));
+        assert!(!content.contains("summary_embeddings = "));
     }
 
     #[test]

--- a/bitloops/src/config/settings.rs
+++ b/bitloops/src/config/settings.rs
@@ -114,6 +114,23 @@ impl RepoSemanticEmbeddingPolicy {
             },
         }
     }
+
+    pub fn enabled_with_profile_preserving_summaries(
+        profile_name: impl Into<String>,
+        existing: &Self,
+    ) -> Self {
+        let profile_name = profile_name.into();
+        Self {
+            present: true,
+            summary_mode: existing.summary_mode,
+            embedding_mode: Some(SemanticCloneEmbeddingMode::SemanticAwareOnce),
+            inference: SemanticClonesInferenceBindings {
+                summary_generation: existing.inference.summary_generation.clone(),
+                code_embeddings: Some(profile_name.clone()),
+                summary_embeddings: Some(profile_name),
+            },
+        }
+    }
 }
 
 pub fn settings_path(repo_root: &Path) -> PathBuf {

--- a/bitloops/src/config/unified_consumer_tests.rs
+++ b/bitloops/src/config/unified_consumer_tests.rs
@@ -507,7 +507,7 @@ summary_generation = "repo_summary"
 }
 
 #[test]
-fn summary_only_repo_semantic_policy_preserves_daemon_embedding_bindings() {
+fn summary_only_repo_semantic_policy_ignores_daemon_embedding_bindings() {
     let (repo, _daemon) = create_repo_with_daemon_config(
         r#"
 [semantic_clones]
@@ -565,23 +565,12 @@ summary_mode = "off"
     );
     assert_eq!(
         capability.semantic_clones.embedding_mode,
-        SemanticCloneEmbeddingMode::RefreshOnUpgrade
+        SemanticCloneEmbeddingMode::SemanticAwareOnce
     );
+    assert_eq!(capability.semantic_clones.inference.code_embeddings, None);
     assert_eq!(
-        capability
-            .semantic_clones
-            .inference
-            .code_embeddings
-            .as_deref(),
-        Some("daemon_code")
-    );
-    assert_eq!(
-        capability
-            .semantic_clones
-            .inference
-            .summary_embeddings
-            .as_deref(),
-        Some("daemon_summary_embedding")
+        capability.semantic_clones.inference.summary_embeddings,
+        None
     );
     assert!(capability.inference.profiles.contains_key("daemon_code"));
     assert!(
@@ -636,7 +625,7 @@ embedding_mode = "off"
 }
 
 #[test]
-fn invalid_repo_summary_mode_preserves_daemon_semantic_config() {
+fn invalid_repo_summary_mode_ignores_daemon_semantic_config() {
     let (repo, _daemon) = create_repo_with_daemon_config(
         r#"
 [semantic_clones]
@@ -683,24 +672,13 @@ summary_mode = "eventually"
     );
     assert_eq!(
         capability.semantic_clones.embedding_mode,
-        SemanticCloneEmbeddingMode::RefreshOnUpgrade
+        SemanticCloneEmbeddingMode::SemanticAwareOnce
     );
     assert_eq!(
-        capability
-            .semantic_clones
-            .inference
-            .summary_generation
-            .as_deref(),
-        Some("daemon_generation")
+        capability.semantic_clones.inference.summary_generation,
+        None
     );
-    assert_eq!(
-        capability
-            .semantic_clones
-            .inference
-            .code_embeddings
-            .as_deref(),
-        Some("daemon_code")
-    );
+    assert_eq!(capability.semantic_clones.inference.code_embeddings, None);
     assert!(
         capability
             .inference
@@ -711,7 +689,7 @@ summary_mode = "eventually"
 }
 
 #[test]
-fn repo_semantic_policy_without_mode_inherits_daemon_mode_with_profile_bindings() {
+fn repo_semantic_policy_without_mode_uses_default_mode_with_profile_bindings() {
     let (repo, _daemon) = create_repo_with_daemon_config(
         r#"
 [semantic_clones]
@@ -768,7 +746,7 @@ code_embeddings = "repo_code"
 }
 
 #[test]
-fn daemon_global_semantic_bindings_remain_legacy_when_repo_policy_absent() {
+fn daemon_global_semantic_bindings_are_ignored_when_repo_policy_absent() {
     let (repo, _daemon) = create_repo_with_daemon_config(
         r#"
 [semantic_clones]
@@ -799,23 +777,12 @@ model = "daemon-summary-model"
 
     assert_eq!(
         capability.semantic_clones.embedding_mode,
-        SemanticCloneEmbeddingMode::RefreshOnUpgrade
+        SemanticCloneEmbeddingMode::SemanticAwareOnce
     );
+    assert_eq!(capability.semantic_clones.inference.code_embeddings, None);
     assert_eq!(
-        capability
-            .semantic_clones
-            .inference
-            .code_embeddings
-            .as_deref(),
-        Some("daemon_code")
-    );
-    assert_eq!(
-        capability
-            .semantic_clones
-            .inference
-            .summary_embeddings
-            .as_deref(),
-        Some("daemon_summary")
+        capability.semantic_clones.inference.summary_embeddings,
+        None
     );
     assert!(capability.inference.profiles.contains_key("daemon_code"));
 }

--- a/bitloops/src/config/unified_consumer_tests.rs
+++ b/bitloops/src/config/unified_consumer_tests.rs
@@ -507,6 +507,210 @@ summary_generation = "repo_summary"
 }
 
 #[test]
+fn summary_only_repo_semantic_policy_preserves_daemon_embedding_bindings() {
+    let (repo, _daemon) = create_repo_with_daemon_config(
+        r#"
+[semantic_clones]
+summary_mode = "auto"
+embedding_mode = "refresh_on_upgrade"
+
+[semantic_clones.inference]
+summary_generation = "daemon_generation"
+code_embeddings = "daemon_code"
+summary_embeddings = "daemon_summary_embedding"
+
+[inference.runtimes.bitloops_local_embeddings]
+command = "bitloops-local-embeddings"
+
+[inference.runtimes.bitloops_inference]
+command = "bitloops-inference"
+
+[inference.profiles.daemon_generation]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "daemon-generation-model"
+
+[inference.profiles.daemon_code]
+task = "embeddings"
+driver = "bitloops_embeddings_ipc"
+runtime = "bitloops_local_embeddings"
+model = "daemon-code-model"
+
+[inference.profiles.daemon_summary_embedding]
+task = "embeddings"
+driver = "bitloops_embeddings_ipc"
+runtime = "bitloops_local_embeddings"
+model = "daemon-summary-embedding-model"
+"#,
+    );
+    fs::write(
+        repo.path().join(REPO_POLICY_FILE_NAME),
+        r#"
+[semantic_clones]
+summary_mode = "off"
+"#,
+    )
+    .expect("write repo semantic policy");
+
+    let capability = resolve_inference_capability_config_for_repo(repo.path());
+
+    assert_eq!(
+        capability.semantic_clones.summary_mode,
+        SemanticSummaryMode::Off
+    );
+    assert_eq!(
+        capability.semantic_clones.inference.summary_generation,
+        None
+    );
+    assert_eq!(
+        capability.semantic_clones.embedding_mode,
+        SemanticCloneEmbeddingMode::RefreshOnUpgrade
+    );
+    assert_eq!(
+        capability
+            .semantic_clones
+            .inference
+            .code_embeddings
+            .as_deref(),
+        Some("daemon_code")
+    );
+    assert_eq!(
+        capability
+            .semantic_clones
+            .inference
+            .summary_embeddings
+            .as_deref(),
+        Some("daemon_summary_embedding")
+    );
+    assert!(capability.inference.profiles.contains_key("daemon_code"));
+    assert!(
+        capability
+            .inference
+            .profiles
+            .contains_key("daemon_summary_embedding")
+    );
+}
+
+#[test]
+fn embedding_only_repo_semantic_policy_allows_summary_mode_env_override() {
+    let (repo, _daemon) = create_repo_with_daemon_config(
+        r#"
+[semantic_clones]
+embedding_mode = "semantic_aware_once"
+
+[semantic_clones.inference]
+code_embeddings = "daemon_code"
+
+[inference.runtimes.bitloops_local_embeddings]
+command = "bitloops-local-embeddings"
+
+[inference.profiles.daemon_code]
+task = "embeddings"
+driver = "bitloops_embeddings_ipc"
+runtime = "bitloops_local_embeddings"
+model = "daemon-code-model"
+"#,
+    );
+    fs::write(
+        repo.path().join(REPO_POLICY_FILE_NAME),
+        r#"
+[semantic_clones]
+embedding_mode = "off"
+"#,
+    )
+    .expect("write repo semantic policy");
+
+    crate::test_support::process_state::with_env_var(
+        "BITLOOPS_SEMANTIC_CLONES_SUMMARY_MODE",
+        Some("off"),
+        || {
+            let semantic_clones = resolve_semantic_clones_config_for_repo(repo.path());
+            assert_eq!(semantic_clones.summary_mode, SemanticSummaryMode::Off);
+            assert_eq!(
+                semantic_clones.embedding_mode,
+                SemanticCloneEmbeddingMode::Off
+            );
+        },
+    );
+}
+
+#[test]
+fn invalid_repo_summary_mode_preserves_daemon_semantic_config() {
+    let (repo, _daemon) = create_repo_with_daemon_config(
+        r#"
+[semantic_clones]
+summary_mode = "auto"
+embedding_mode = "refresh_on_upgrade"
+
+[semantic_clones.inference]
+summary_generation = "daemon_generation"
+code_embeddings = "daemon_code"
+
+[inference.runtimes.bitloops_local_embeddings]
+command = "bitloops-local-embeddings"
+
+[inference.runtimes.bitloops_inference]
+command = "bitloops-inference"
+
+[inference.profiles.daemon_generation]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "daemon-generation-model"
+
+[inference.profiles.daemon_code]
+task = "embeddings"
+driver = "bitloops_embeddings_ipc"
+runtime = "bitloops_local_embeddings"
+model = "daemon-code-model"
+"#,
+    );
+    fs::write(
+        repo.path().join(REPO_POLICY_FILE_NAME),
+        r#"
+[semantic_clones]
+summary_mode = "eventually"
+"#,
+    )
+    .expect("write repo semantic policy");
+
+    let capability = resolve_inference_capability_config_for_repo(repo.path());
+
+    assert_eq!(
+        capability.semantic_clones.summary_mode,
+        SemanticSummaryMode::Auto
+    );
+    assert_eq!(
+        capability.semantic_clones.embedding_mode,
+        SemanticCloneEmbeddingMode::RefreshOnUpgrade
+    );
+    assert_eq!(
+        capability
+            .semantic_clones
+            .inference
+            .summary_generation
+            .as_deref(),
+        Some("daemon_generation")
+    );
+    assert_eq!(
+        capability
+            .semantic_clones
+            .inference
+            .code_embeddings
+            .as_deref(),
+        Some("daemon_code")
+    );
+    assert!(
+        capability
+            .inference
+            .profiles
+            .contains_key("daemon_generation")
+    );
+    assert!(capability.inference.profiles.contains_key("daemon_code"));
+}
+
+#[test]
 fn repo_semantic_policy_without_mode_inherits_daemon_mode_with_profile_bindings() {
     let (repo, _daemon) = create_repo_with_daemon_config(
         r#"

--- a/bitloops/src/config/unified_consumer_tests.rs
+++ b/bitloops/src/config/unified_consumer_tests.rs
@@ -268,6 +268,44 @@ embedding_mode = "off"
 }
 
 #[test]
+fn repo_semantic_policy_disables_daemon_global_summary_generation() {
+    let (repo, _daemon) = create_repo_with_daemon_config(
+        r#"
+[semantic_clones]
+summary_mode = "auto"
+
+[semantic_clones.inference]
+summary_generation = "daemon_summary"
+
+[inference.runtimes.bitloops_inference]
+command = "bitloops-inference"
+
+[inference.profiles.daemon_summary]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "daemon-summary-model"
+"#,
+    );
+    fs::write(
+        repo.path().join(REPO_POLICY_FILE_NAME),
+        r#"
+[semantic_clones]
+summary_mode = "off"
+"#,
+    )
+    .expect("write repo semantic policy");
+
+    let semantic_clones = resolve_semantic_clones_config_for_repo(repo.path());
+    let capability = resolve_inference_capability_config_for_repo(repo.path());
+
+    assert_eq!(semantic_clones.summary_mode, SemanticSummaryMode::Off);
+    assert_eq!(semantic_clones.inference.summary_generation, None);
+    assert_eq!(capability.semantic_clones, semantic_clones);
+    assert!(capability.inference.profiles.contains_key("daemon_summary"));
+}
+
+#[test]
 fn repo_semantic_policy_uses_repo_profile_bindings_with_daemon_profiles() {
     let (repo, _daemon) = create_repo_with_daemon_config(
         r#"
@@ -401,6 +439,70 @@ summary_embeddings = "repo_summary"
             fact_synthesis: Some("local_agent".to_string()),
             role_adjudication: None,
         }
+    );
+}
+
+#[test]
+fn repo_semantic_policy_selects_repo_summary_generation_with_daemon_profiles() {
+    let (repo, _daemon) = create_repo_with_daemon_config(
+        r#"
+[semantic_clones]
+summary_mode = "auto"
+
+[semantic_clones.inference]
+summary_generation = "daemon_summary"
+
+[inference.runtimes.bitloops_inference]
+command = "bitloops-inference"
+
+[inference.profiles.daemon_summary]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "daemon-summary-model"
+
+[inference.profiles.repo_summary]
+task = "text_generation"
+driver = "ollama_chat"
+runtime = "bitloops_inference"
+model = "repo-summary-model"
+"#,
+    );
+    fs::write(
+        repo.path().join(REPO_POLICY_FILE_NAME),
+        r#"
+[semantic_clones]
+summary_mode = "auto"
+
+[semantic_clones.inference]
+summary_generation = "repo_summary"
+"#,
+    )
+    .expect("write repo semantic policy");
+
+    let capability = resolve_inference_capability_config_for_repo(repo.path());
+
+    assert_eq!(
+        capability.semantic_clones.summary_mode,
+        SemanticSummaryMode::Auto
+    );
+    assert_eq!(
+        capability
+            .semantic_clones
+            .inference
+            .summary_generation
+            .as_deref(),
+        Some("repo_summary")
+    );
+    assert_eq!(
+        capability
+            .inference
+            .profiles
+            .get("repo_summary")
+            .expect("repo summary profile")
+            .model
+            .as_deref(),
+        Some("repo-summary-model")
     );
 }
 

--- a/bitloops/src/daemon/embeddings_bootstrap.rs
+++ b/bitloops/src/daemon/embeddings_bootstrap.rs
@@ -16,7 +16,7 @@ use crate::cli::embeddings::{
     pull_profile_with_config_path_and_progress, selected_inference_profile_name,
 };
 use crate::config::{
-    BITLOOPS_CONFIG_RELATIVE_PATH, DaemonEmbeddingsInstallMode, prepare_daemon_embeddings_install,
+    BITLOOPS_CONFIG_RELATIVE_PATH, prepare_daemon_embeddings_install,
     prepare_daemon_platform_embeddings_install,
 };
 use crate::daemon::DevqlTaskStatus;
@@ -377,78 +377,49 @@ where
             &capability,
             requested_profile_name,
             report,
-            None,
+            false,
         );
     }
 
     let install_plan = prepare_daemon_embeddings_install(config_path)?;
     let target_profile_name = install_plan.profile_name.clone();
     let result = (|| -> Result<EmbeddingsBootstrapResult> {
-        match install_plan.mode {
-            DaemonEmbeddingsInstallMode::SkipHosted => Ok(EmbeddingsBootstrapResult {
-                version: None,
-                binary_path: None,
-                cache_dir: None,
-                runtime_name: install_plan.profile_driver.clone(),
-                model_name: Some(target_profile_name.clone()),
-                freshly_installed: false,
-                message: format!(
-                    "Embeddings already use profile `{}`; no local bootstrap was required.",
-                    target_profile_name
-                ),
-            }),
-            DaemonEmbeddingsInstallMode::WarmExisting => {
-                let capability = embedding_capability_for_config_path(config_path)?;
-                warm_existing_profile(
-                    repo_root,
-                    config_path,
-                    &capability,
-                    &target_profile_name,
-                    report,
-                    Some(install_plan.mode),
+        let ensure =
+            ensure_managed_embeddings_runtime_with_progress(repo_root, None, &mut *report)?;
+        report(EmbeddingsBootstrapProgress {
+            phase: EmbeddingsBootstrapPhase::RewritingRuntime,
+            version: Some(ensure.install.version.clone()),
+            message: Some(format!(
+                "Applying embeddings config in {}",
+                config_path.display()
+            )),
+            ..Default::default()
+        })?;
+        install_plan
+            .apply_with_managed_runtime_path(&ensure.install.binary_path)
+            .with_context(|| {
+                format!(
+                    "applying staged embeddings config in {}",
+                    config_path.display()
                 )
-            }
-            DaemonEmbeddingsInstallMode::Bootstrap => {
-                let ensure =
-                    ensure_managed_embeddings_runtime_with_progress(repo_root, None, &mut *report)?;
-                report(EmbeddingsBootstrapProgress {
-                    phase: EmbeddingsBootstrapPhase::RewritingRuntime,
-                    version: Some(ensure.install.version.clone()),
-                    message: Some(format!(
-                        "Applying embeddings config in {}",
-                        config_path.display()
-                    )),
-                    ..Default::default()
-                })?;
-                install_plan
-                    .apply_with_managed_runtime_path(&ensure.install.binary_path)
-                    .with_context(|| {
-                        format!(
-                            "applying staged embeddings config in {}",
-                            config_path.display()
-                        )
-                    })?;
-                let capability = embedding_capability_for_config_path(config_path)?;
-                let pulled = pull_profile_with_config_path_and_progress(
-                    repo_root,
-                    config_path,
-                    &capability,
-                    &target_profile_name,
-                    &mut *report,
-                )?;
-                Ok(EmbeddingsBootstrapResult {
-                    version: Some(ensure.install.version.clone()),
-                    binary_path: Some(ensure.install.binary_path.clone()),
-                    cache_dir: Some(pulled.cache_dir),
-                    runtime_name: Some(pulled.runtime_name),
-                    model_name: Some(pulled.model_name),
-                    freshly_installed: ensure.install.freshly_installed,
-                    message: format!(
-                        "Configured embeddings and warmed profile `{target_profile_name}`."
-                    ),
-                })
-            }
-        }
+            })?;
+        let capability = embedding_capability_for_config_path(config_path)?;
+        let pulled = pull_profile_with_config_path_and_progress(
+            repo_root,
+            config_path,
+            &capability,
+            &target_profile_name,
+            &mut *report,
+        )?;
+        Ok(EmbeddingsBootstrapResult {
+            version: Some(ensure.install.version.clone()),
+            binary_path: Some(ensure.install.binary_path.clone()),
+            cache_dir: Some(pulled.cache_dir),
+            runtime_name: Some(pulled.runtime_name),
+            model_name: Some(pulled.model_name),
+            freshly_installed: ensure.install.freshly_installed,
+            message: format!("Configured embeddings and warmed profile `{target_profile_name}`."),
+        })
     })();
 
     match result {
@@ -525,7 +496,7 @@ fn warm_existing_profile<R>(
     capability: &crate::config::EmbeddingCapabilityConfig,
     profile_name: &str,
     report: &mut R,
-    install_mode: Option<DaemonEmbeddingsInstallMode>,
+    bootstrap_configured_profile: bool,
 ) -> Result<EmbeddingsBootstrapResult>
 where
     R: FnMut(EmbeddingsBootstrapProgress) -> Result<()>,
@@ -553,14 +524,10 @@ where
         report,
     )?;
 
-    let message = match install_mode {
-        Some(DaemonEmbeddingsInstallMode::Bootstrap) => {
-            format!("Configured embeddings and warmed profile `{profile_name}`.")
-        }
-        Some(DaemonEmbeddingsInstallMode::WarmExisting) => {
-            format!("Warmed configured embeddings profile `{profile_name}`.")
-        }
-        _ => format!("Pulled embedding profile `{profile_name}`."),
+    let message = if bootstrap_configured_profile {
+        format!("Configured embeddings and warmed profile `{profile_name}`.")
+    } else {
+        format!("Pulled embedding profile `{profile_name}`.")
     };
 
     Ok(EmbeddingsBootstrapResult {

--- a/bitloops/tests/qat_support/helpers/capability_runtime.rs
+++ b/bitloops/tests/qat_support/helpers/capability_runtime.rs
@@ -56,6 +56,7 @@ fn write_scenario_repo_semantic_clone_policy(world: &QatWorld) -> Result<()> {
     let policy_path = settings_local_path(world.repo_dir());
     let policy = RepoSemanticEmbeddingPolicy {
         present: true,
+        summary_mode: None,
         embedding_mode: Some(SemanticCloneEmbeddingMode::Deterministic),
         inference: SemanticClonesInferenceBindings {
             summary_generation: None,


### PR DESCRIPTION
## Summary
- Keep `bitloops init` semantic enablement repo-local for sync, ingest, code embeddings, summaries, and summary embeddings.
- Keep daemon config as the provider/runtime registry only; repo-local policy stores enablement and selected bindings.
- Preserve existing summary choices when embeddings are installed or reconfigured.
- Prompt for summary embeddings when a repo has summaries plus code embeddings but has not made a repo-local summary-embedding choice yet.
- Add a `RepoPolicySource` port with the current TOML-backed `FileRepoPolicySource` adapter, leaving existing public repo-policy helpers and file-backed behavior intact.
- Refresh enrichment worker capacity against the repo root after summary bootstrap so repo-local summary policy can affect worker budgets before work is queued.
- Allow rerunning init to re-enable summaries after a repo previously had `summary_mode = "off"`.
- No config options are deprecated.

## Notes
- The final setup prompt remains sync/import-history only. Semantic choices stay in the semantic setup section before final setup.
- Existing daemon-level semantic enablement is ignored/stripped for new init output; daemon profiles remain usable as provider definitions.
- Repo policy still uses live file reads at decision time; this change only introduces the source boundary for future storage backends.

## Verification
- `cargo clippy --manifest-path bitloops/Cargo.toml --all-targets --no-default-features -- -D warnings`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features daemon::enrichment::execution::execution_tests`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features slim_select_artefacts_search`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features daemon::enrichment::tests`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features daemon::enrichment::worker_count::tests`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features daemon::enrichment::workplane::mailbox_claim::tests`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features enable_prompts_for_embeddings_and_defaults_to_yes`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features enable_does_not_prompt_when_embeddings_are_already_configured`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features gateway_uses_same_daemon_config_path_as_host_inference_resolution`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features refresh_enrichment_capacity_after_summary_bootstrap_promotes_cloud_summary_workers`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features config::repo_policy::tests`
- `git diff --check HEAD~1..HEAD`