### PR TITLE
Fix current coverage ingest artefact mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Current coverage ingest now maps LCOV reports to current DevQL artefacts**: `bitloops devql test-harness ingest-coverage` now defaults to current-workspace mode when `--commit` is omitted, maps LCOV and LLVM JSON line hits against `artefacts_current`, replaces stale coverage rows on re-ingest, and keeps historical commit-scoped ingest behind explicit `--commit` usage.
+
 ## [0.0.30] - 2026-05-21
 
 ### Fixed

--- a/bitloops/qat/features/devql/cross_capability_smoke.feature
+++ b/bitloops/qat/features/devql/cross_capability_smoke.feature
@@ -18,9 +18,9 @@ Feature: Cross-capability deterministic smoke
     And DevQL pack health for semantic clones is ready in bitloops
     And I make a first change using Claude Code to bitloops
     And I committed today in bitloops
+    And I enqueue DevQL sync task with status in bitloops
     And I run DevQL semantic clones rebuild in bitloops
-    And I run TestHarness ingest-tests for latest commit in bitloops
-    And I run TestHarness ingest-coverage for latest commit in bitloops
+    Then daemon capability-event status shows TestHarness sync handler completed in bitloops
 
   @devql @integration @develop_gate
   Scenario: Hardened DevQL capability surfaces compose in one offline workflow

--- a/bitloops/qat/features/devql/test_harness_proof_map.feature
+++ b/bitloops/qat/features/devql/test_harness_proof_map.feature
@@ -11,9 +11,10 @@ Feature: TestHarness proof-map for pre-change safety assessment
     And I run InitCommit for bitloops
     And I init bitloops in bitloops
     And I run DevQL init in bitloops
+    And I enqueue DevQL sync task with status in bitloops
     And I enqueue DevQL ingest task with status in bitloops
     And I run TestHarness ingest-tests for latest commit in bitloops
-    And I run TestHarness ingest-coverage for latest commit in bitloops
+    Then daemon capability-event status shows TestHarness sync handler completed in bitloops
 
   @devql @testharness
   Scenario: Test summary returns counts for `UserService.createUser`
@@ -25,8 +26,15 @@ Feature: TestHarness proof-map for pre-change safety assessment
     Then TestHarness query for "UserService.createUser" at latest commit with view "tests" returns results in bitloops
     And TestHarness tests include at least 1 test with a classification in bitloops
 
-  @devql @testharness
-  Scenario: Coverage query returns line coverage data for `UserService.createUser`
+  @devql @testharness @testharness-coverage
+  Scenario: Current workspace coverage query uses current artefacts for `UserService.createUser`
+    Given I run TestHarness ingest-coverage for current workspace in bitloops
+    Then TestHarness query for "UserService.createUser" at current workspace state with view "coverage" returns results in bitloops
+    And TestHarness coverage shows line coverage percentage in bitloops
+
+  @devql @testharness @testharness-coverage
+  Scenario: Historical coverage query uses historical artefacts for `UserService.createUser`
+    Given I run TestHarness ingest-coverage for latest commit in bitloops
     Then TestHarness query for "UserService.createUser" at latest commit with view "coverage" returns results in bitloops
     And TestHarness coverage shows line coverage percentage in bitloops
 

--- a/bitloops/src/capability_packs/test_harness/ingest/coverage.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/coverage.rs
@@ -33,9 +33,7 @@ pub struct CurrentCoverageProvenance {
 
 impl CurrentCoverageProvenance {
     fn capture_commit_sha(&self) -> String {
-        self.observed_head_sha
-            .clone()
-            .unwrap_or_else(|| "current".to_string())
+        "current".to_string()
     }
 
     fn metadata_json(&self) -> String {
@@ -163,7 +161,7 @@ pub fn execute_current(
         subject_test_symbol_id: test_artefact_id.map(|s| s.to_string()),
         line_truth: true,
         branch_truth: has_branches,
-        captured_at: provenance.ingested_at_unix.to_string(),
+        captured_at: chrono_now(),
         status: "complete".to_string(),
         metadata_json: Some(provenance.metadata_json()),
     };
@@ -327,12 +325,7 @@ where
 }
 
 fn chrono_now() -> String {
-    // Simple ISO-8601-ish timestamp without pulling in chrono crate
-    use std::time::SystemTime;
-    let duration = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default();
-    format!("{}", duration.as_secs())
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 fn parse_lcov_report(
@@ -782,12 +775,19 @@ end_of_record
 
         assert_eq!(summary.hits, 2);
         assert_eq!(store.captures.len(), 1);
-        assert_eq!(store.captures[0].commit_sha, "abc123");
+        assert_eq!(store.captures[0].commit_sha, "current");
+        assert!(
+            store.captures[0].captured_at.ends_with('Z')
+                && store.captures[0].captured_at.contains('T'),
+            "captured_at should be RFC3339 UTC, got {}",
+            store.captures[0].captured_at
+        );
         let metadata = store.captures[0].metadata_json.as_deref().unwrap();
         assert!(metadata.contains("\"reference_mode\":\"current\""));
+        assert!(metadata.contains("\"observed_head_sha\":\"abc123\""));
         assert!(metadata.contains("\"repo_dirty\":true"));
         assert_eq!(store.hits[0].production_symbol_id, "symbol::current");
-        assert_eq!(store.rebuild_commits, vec!["abc123".to_string()]);
+        assert_eq!(store.rebuild_commits, vec!["current".to_string()]);
         Ok(())
     }
 }

--- a/bitloops/src/capability_packs/test_harness/ingest/coverage.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/coverage.rs
@@ -23,6 +23,35 @@ pub struct IngestCoverageSummary {
 }
 
 #[derive(Debug, Clone)]
+pub struct CurrentCoverageProvenance {
+    pub observed_head_sha: Option<String>,
+    pub repo_dirty: Option<bool>,
+    pub coverage_file_modified_at_unix: Option<u64>,
+    pub ingested_at_unix: u64,
+    pub coverage_path: String,
+}
+
+impl CurrentCoverageProvenance {
+    fn capture_commit_sha(&self) -> String {
+        self.observed_head_sha
+            .clone()
+            .unwrap_or_else(|| "current".to_string())
+    }
+
+    fn metadata_json(&self) -> String {
+        serde_json::json!({
+            "reference_mode": "current",
+            "observed_head_sha": self.observed_head_sha,
+            "repo_dirty": self.repo_dirty,
+            "coverage_file_modified_at_unix": self.coverage_file_modified_at_unix,
+            "ingested_at_unix": self.ingested_at_unix,
+            "coverage_path": self.coverage_path,
+        })
+        .to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
 struct LcovFileCoverage {
     source_file: String,
     line_hits: HashMap<i64, i64>,
@@ -103,11 +132,91 @@ pub fn execute(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn execute_current(
+    store: &mut dyn TestHarnessCoverageGateway,
+    relational: &dyn RelationalGateway,
+    coverage_path: &Path,
+    repo_id: &str,
+    scope_kind: ScopeKind,
+    tool: &str,
+    test_artefact_id: Option<&str>,
+    format: CoverageFormat,
+    provenance: CurrentCoverageProvenance,
+) -> Result<IngestCoverageSummary> {
+    let commit_sha = provenance.capture_commit_sha();
+    let capture_id = format!(
+        "capture:current:{repo_id}:{}:{}",
+        scope_kind,
+        test_artefact_id.unwrap_or("all")
+    );
+
+    let has_branches = format == CoverageFormat::LlvmJson;
+
+    let capture = CoverageCaptureRecord {
+        capture_id: capture_id.clone(),
+        repo_id: repo_id.to_string(),
+        commit_sha: commit_sha.clone(),
+        tool: tool.to_string(),
+        format,
+        scope_kind,
+        subject_test_symbol_id: test_artefact_id.map(|s| s.to_string()),
+        line_truth: true,
+        branch_truth: has_branches,
+        captured_at: provenance.ingested_at_unix.to_string(),
+        status: "complete".to_string(),
+        metadata_json: Some(provenance.metadata_json()),
+    };
+
+    let (hits, diagnostics) = match format {
+        CoverageFormat::Lcov => {
+            ingest_lcov_current(relational, coverage_path, repo_id, &commit_sha, &capture_id)?
+        }
+        CoverageFormat::LlvmJson => {
+            crate::capability_packs::test_harness::ingest::parse_llvm_json::ingest_llvm_json_current(
+                relational,
+                coverage_path,
+                repo_id,
+                &commit_sha,
+                &capture_id,
+            )?
+        }
+    };
+
+    store.replace_coverage_capture(&capture, &hits, &diagnostics)?;
+
+    let classifications = store.rebuild_classifications_from_coverage(&commit_sha)?;
+
+    Ok(IngestCoverageSummary {
+        format,
+        scope_kind,
+        hits: hits.len(),
+        classifications,
+        diagnostics: diagnostics.len(),
+    })
+}
+
 pub fn format_summary(commit_sha: &str, summary: &IngestCoverageSummary) -> String {
     format!(
         "ingested {} coverage for commit {} (scope: {}, hits: {}, classifications: {}, diagnostics: {})",
         summary.format,
         commit_sha,
+        summary.scope_kind,
+        summary.hits,
+        summary.classifications,
+        summary.diagnostics
+    )
+}
+
+pub fn format_current_summary(
+    summary: &IngestCoverageSummary,
+    observed_head_sha: Option<&str>,
+) -> String {
+    let head = observed_head_sha.unwrap_or("unborn-or-unavailable");
+    format!(
+        "ingested {} coverage for current workspace (observed HEAD: {}, scope: {}, hits: {}, classifications: {}, diagnostics: {})",
+        summary.format,
+        head,
         summary.scope_kind,
         summary.hits,
         summary.classifications,
@@ -126,6 +235,33 @@ fn ingest_lcov(
     repo_id: &str,
     capture_id: &str,
 ) -> Result<(Vec<CoverageHitRecord>, Vec<CoverageDiagnosticRecord>)> {
+    ingest_lcov_with_lookup(lcov_path, commit_sha, repo_id, capture_id, |file_path| {
+        relational.load_artefacts_for_file_lines(commit_sha, file_path)
+    })
+}
+
+fn ingest_lcov_current(
+    relational: &dyn RelationalGateway,
+    lcov_path: &Path,
+    repo_id: &str,
+    commit_sha: &str,
+    capture_id: &str,
+) -> Result<(Vec<CoverageHitRecord>, Vec<CoverageDiagnosticRecord>)> {
+    ingest_lcov_with_lookup(lcov_path, commit_sha, repo_id, capture_id, |file_path| {
+        relational.load_current_artefacts_for_file_lines(repo_id, file_path)
+    })
+}
+
+fn ingest_lcov_with_lookup<F>(
+    lcov_path: &Path,
+    commit_sha: &str,
+    repo_id: &str,
+    capture_id: &str,
+    mut load_artefacts: F,
+) -> Result<(Vec<CoverageHitRecord>, Vec<CoverageDiagnosticRecord>)>
+where
+    F: FnMut(&str) -> Result<Vec<(String, i64, i64)>>,
+{
     let (report, parse_diagnostics) =
         parse_lcov_report(lcov_path, capture_id, repo_id, commit_sha)?;
     let mut hits = Vec::new();
@@ -133,7 +269,7 @@ fn ingest_lcov(
     let mut diag_idx = diagnostics.len();
 
     for file in &report {
-        let artefacts = relational.load_artefacts_for_file_lines(commit_sha, &file.source_file)?;
+        let artefacts = load_artefacts(&file.source_file)?;
         if artefacts.is_empty() {
             diagnostics.push(CoverageDiagnosticRecord {
                 diagnostic_id: format!("diag:{capture_id}:unmapped:{diag_idx}"),
@@ -346,7 +482,9 @@ mod tests {
 
     use anyhow::Result;
 
-    use super::{execute, format_summary, parse_lcov_report};
+    use super::{
+        CurrentCoverageProvenance, execute, execute_current, format_summary, parse_lcov_report,
+    };
     use crate::capability_packs::test_harness::storage::TestHarnessCoverageGateway;
     use crate::host::capability_host::gateways::RelationalGateway;
     use crate::models::{
@@ -382,6 +520,23 @@ mod tests {
             Ok(())
         }
 
+        fn replace_coverage_capture(
+            &mut self,
+            capture: &CoverageCaptureRecord,
+            hits: &[CoverageHitRecord],
+            diagnostics: &[CoverageDiagnosticRecord],
+        ) -> Result<()> {
+            self.captures
+                .retain(|existing| existing.capture_id != capture.capture_id);
+            self.hits.retain(|hit| hit.capture_id != capture.capture_id);
+            self.diagnostics
+                .retain(|diag| diag.capture_id != capture.capture_id);
+            self.captures.push(capture.clone());
+            self.hits.extend_from_slice(hits);
+            self.diagnostics.extend_from_slice(diagnostics);
+            Ok(())
+        }
+
         fn rebuild_classifications_from_coverage(&mut self, commit_sha: &str) -> Result<usize> {
             self.rebuild_commits.push(commit_sha.to_string());
             Ok(self.classifications)
@@ -392,6 +547,7 @@ mod tests {
     struct FakeRelationalGateway {
         repo_id: String,
         artefacts_by_file: HashMap<String, Vec<(String, i64, i64)>>,
+        current_artefacts_by_file: HashMap<String, Vec<(String, i64, i64)>>,
     }
 
     impl RelationalGateway for FakeRelationalGateway {
@@ -412,6 +568,18 @@ mod tests {
             _repo_id: &str,
         ) -> Result<Vec<crate::models::ProductionArtefact>> {
             unreachable!("unused in coverage tests")
+        }
+
+        fn load_current_artefacts_for_file_lines(
+            &self,
+            _repo_id: &str,
+            file_path: &str,
+        ) -> Result<Vec<(String, i64, i64)>> {
+            Ok(self
+                .current_artefacts_by_file
+                .get(file_path)
+                .cloned()
+                .unwrap_or_default())
         }
 
         fn load_production_artefacts(
@@ -483,6 +651,7 @@ end_of_record
                     ("prod:branch".to_string(), 11, 11),
                 ],
             )]),
+            current_artefacts_by_file: HashMap::new(),
         };
         let temp = tempfile::NamedTempFile::new().expect("temp lcov");
         std::fs::write(
@@ -566,5 +735,59 @@ end_of_record
         assert!(summary_text.contains("ingested lcov coverage for commit commit-sha-123"));
         assert!(summary_text.contains("hits: 5"));
         assert!(summary_text.contains("diagnostics: 1"));
+    }
+
+    #[test]
+    fn execute_current_lcov_maps_against_current_artefacts_and_records_metadata() -> Result<()> {
+        let temp = tempfile::NamedTempFile::new().expect("temp lcov");
+        std::fs::write(
+            temp.path(),
+            "\
+SF:/tmp/work/src/lib.rs
+DA:10,1
+DA:11,0
+DA:99,1
+end_of_record
+",
+        )
+        .expect("write lcov");
+
+        let mut store = FakeCoverageStore::default();
+        let relational = FakeRelationalGateway {
+            repo_id: "repo-current".to_string(),
+            artefacts_by_file: HashMap::new(),
+            current_artefacts_by_file: HashMap::from([(
+                "/tmp/work/src/lib.rs".to_string(),
+                vec![("symbol::current".to_string(), 10, 12)],
+            )]),
+        };
+
+        let summary = execute_current(
+            &mut store,
+            &relational,
+            temp.path(),
+            "repo-current",
+            ScopeKind::Workspace,
+            "cargo-llvm-cov",
+            None,
+            CoverageFormat::Lcov,
+            CurrentCoverageProvenance {
+                observed_head_sha: Some("abc123".to_string()),
+                repo_dirty: Some(true),
+                coverage_file_modified_at_unix: Some(123),
+                ingested_at_unix: 456,
+                coverage_path: temp.path().display().to_string(),
+            },
+        )?;
+
+        assert_eq!(summary.hits, 2);
+        assert_eq!(store.captures.len(), 1);
+        assert_eq!(store.captures[0].commit_sha, "abc123");
+        let metadata = store.captures[0].metadata_json.as_deref().unwrap();
+        assert!(metadata.contains("\"reference_mode\":\"current\""));
+        assert!(metadata.contains("\"repo_dirty\":true"));
+        assert_eq!(store.hits[0].production_symbol_id, "symbol::current");
+        assert_eq!(store.rebuild_commits, vec!["abc123".to_string()]);
+        Ok(())
     }
 }

--- a/bitloops/src/capability_packs/test_harness/ingest/parse_llvm_json.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/parse_llvm_json.rs
@@ -39,6 +39,33 @@ pub fn ingest_llvm_json(
     repo_id: &str,
     capture_id: &str,
 ) -> Result<(Vec<CoverageHitRecord>, Vec<CoverageDiagnosticRecord>)> {
+    ingest_llvm_json_with_lookup(json_path, commit_sha, repo_id, capture_id, |file_path| {
+        relational.load_artefacts_for_file_lines(commit_sha, file_path)
+    })
+}
+
+pub fn ingest_llvm_json_current(
+    relational: &dyn RelationalGateway,
+    json_path: &Path,
+    repo_id: &str,
+    commit_sha: &str,
+    capture_id: &str,
+) -> Result<(Vec<CoverageHitRecord>, Vec<CoverageDiagnosticRecord>)> {
+    ingest_llvm_json_with_lookup(json_path, commit_sha, repo_id, capture_id, |file_path| {
+        relational.load_current_artefacts_for_file_lines(repo_id, file_path)
+    })
+}
+
+fn ingest_llvm_json_with_lookup<F>(
+    json_path: &Path,
+    commit_sha: &str,
+    repo_id: &str,
+    capture_id: &str,
+    mut load_artefacts: F,
+) -> Result<(Vec<CoverageHitRecord>, Vec<CoverageDiagnosticRecord>)>
+where
+    F: FnMut(&str) -> Result<Vec<(String, i64, i64)>>,
+{
     let raw = fs::read_to_string(json_path)
         .with_context(|| format!("failed to read LLVM JSON file {}", json_path.display()))?;
 
@@ -52,7 +79,7 @@ pub fn ingest_llvm_json(
     for data in &export.data {
         for file in &data.files {
             let line_hits = extract_line_hits(&file.segments);
-            let artefacts = relational.load_artefacts_for_file_lines(commit_sha, &file.filename)?;
+            let artefacts = load_artefacts(&file.filename)?;
 
             if artefacts.is_empty() {
                 diagnostics.push(CoverageDiagnosticRecord {

--- a/bitloops/src/capability_packs/test_harness/ingest/results.rs
+++ b/bitloops/src/capability_packs/test_harness/ingest/results.rs
@@ -205,6 +205,15 @@ mod tests {
             unreachable!("unused in results tests")
         }
 
+        fn replace_coverage_capture(
+            &mut self,
+            _capture: &CoverageCaptureRecord,
+            _hits: &[CoverageHitRecord],
+            _diagnostics: &[CoverageDiagnosticRecord],
+        ) -> Result<()> {
+            unreachable!("unused in results tests")
+        }
+
         fn rebuild_classifications_from_coverage(&mut self, _commit_sha: &str) -> Result<usize> {
             unreachable!("unused in results tests")
         }

--- a/bitloops/src/capability_packs/test_harness/ingesters/coverage.rs
+++ b/bitloops/src/capability_packs/test_harness/ingesters/coverage.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
@@ -8,6 +9,7 @@ use crate::capability_packs::test_harness::ingest::coverage;
 use crate::host::capability_host::{
     BoxFuture, CapabilityIngestContext, IngestRequest, IngestResult, IngesterHandler,
 };
+use crate::host::checkpoints::strategy::manual_commit::{run_git, try_head_hash};
 use crate::models::{CoverageFormat, ScopeKind};
 
 use super::super::types::TEST_HARNESS_COVERAGE_INGESTER_ID;
@@ -15,7 +17,8 @@ use super::super::types::TEST_HARNESS_COVERAGE_INGESTER_ID;
 #[derive(Debug, Deserialize)]
 struct CoverageIngestPayload {
     coverage_path: String,
-    commit_sha: String,
+    commit_sha: Option<String>,
+    #[serde(default = "default_scope_kind")]
     scope_kind: String,
     tool: String,
     test_artefact_id: Option<String>,
@@ -73,28 +76,84 @@ impl IngesterHandler for CoverageIngestIngester {
                 ctx.repo_root().join(&path)
             };
 
+            let commit_sha = payload
+                .commit_sha
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
             let relational = ctx.host_relational();
+
+            if let Some(commit_sha) = commit_sha {
+                let mut g = store
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("test harness store lock poisoned: {e}"))?;
+                let summary = coverage::execute(
+                    &mut *g,
+                    relational,
+                    &coverage_path,
+                    commit_sha,
+                    scope_kind,
+                    &payload.tool,
+                    payload.test_artefact_id.as_deref(),
+                    format,
+                )?;
+
+                let human = coverage::format_summary(commit_sha, &summary);
+                return Ok(IngestResult::new(
+                    json!({
+                        "capability": "test_harness",
+                        "ingester": TEST_HARNESS_COVERAGE_INGESTER_ID,
+                        "status": "ok",
+                        "reference_mode": "commit",
+                        "commit_sha": commit_sha,
+                        "summary": {
+                            "format": summary.format.as_str(),
+                            "scope_kind": summary.scope_kind.to_string(),
+                            "hits": summary.hits,
+                            "classifications": summary.classifications,
+                            "diagnostics": summary.diagnostics,
+                        }
+                    }),
+                    human,
+                ));
+            }
+
+            let observed_head_sha = try_head_hash(ctx.repo_root())
+                .context("resolve current git HEAD for coverage provenance")?;
+            let stored_commit_sha = observed_head_sha
+                .clone()
+                .unwrap_or_else(|| "current".to_string());
+            let provenance = coverage::CurrentCoverageProvenance {
+                observed_head_sha: observed_head_sha.clone(),
+                repo_dirty: repo_dirty(ctx.repo_root()),
+                coverage_file_modified_at_unix: file_modified_unix(&coverage_path),
+                ingested_at_unix: unix_now(),
+                coverage_path: coverage_path.display().to_string(),
+            };
             let mut g = store
                 .lock()
                 .map_err(|e| anyhow::anyhow!("test harness store lock poisoned: {e}"))?;
-            let summary = coverage::execute(
+            let summary = coverage::execute_current(
                 &mut *g,
                 relational,
                 &coverage_path,
-                &payload.commit_sha,
+                &ctx.repo().repo_id,
                 scope_kind,
                 &payload.tool,
                 payload.test_artefact_id.as_deref(),
                 format,
+                provenance,
             )?;
 
-            let human = coverage::format_summary(&payload.commit_sha, &summary);
+            let human = coverage::format_current_summary(&summary, observed_head_sha.as_deref());
             Ok(IngestResult::new(
                 json!({
                     "capability": "test_harness",
                     "ingester": TEST_HARNESS_COVERAGE_INGESTER_ID,
                     "status": "ok",
-                    "commit_sha": payload.commit_sha,
+                    "reference_mode": "current",
+                    "commit_sha": stored_commit_sha,
+                    "observed_head_sha": observed_head_sha,
                     "summary": {
                         "format": summary.format.as_str(),
                         "scope_kind": summary.scope_kind.to_string(),
@@ -107,4 +166,34 @@ impl IngesterHandler for CoverageIngestIngester {
             ))
         })
     }
+}
+
+fn default_scope_kind() -> String {
+    ScopeKind::Workspace.to_string()
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn file_modified_unix(path: &Path) -> Option<u64> {
+    std::fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+}
+
+fn repo_dirty(repo_root: &Path) -> Option<bool> {
+    run_git(
+        repo_root,
+        &["status", "--porcelain=v1", "--untracked-files=all"],
+    )
+    .ok()
+    .map(|status| !status.is_empty())
 }

--- a/bitloops/src/capability_packs/test_harness/ingesters/coverage.rs
+++ b/bitloops/src/capability_packs/test_harness/ingesters/coverage.rs
@@ -120,15 +120,12 @@ impl IngesterHandler for CoverageIngestIngester {
 
             let observed_head_sha = try_head_hash(ctx.repo_root())
                 .context("resolve current git HEAD for coverage provenance")?;
-            let stored_commit_sha = observed_head_sha
-                .clone()
-                .unwrap_or_else(|| "current".to_string());
             let provenance = coverage::CurrentCoverageProvenance {
                 observed_head_sha: observed_head_sha.clone(),
                 repo_dirty: repo_dirty(ctx.repo_root()),
                 coverage_file_modified_at_unix: file_modified_unix(&coverage_path),
                 ingested_at_unix: unix_now(),
-                coverage_path: coverage_path.display().to_string(),
+                coverage_path: coverage_metadata_path(ctx.repo_root(), &coverage_path),
             };
             let mut g = store
                 .lock()
@@ -152,7 +149,7 @@ impl IngesterHandler for CoverageIngestIngester {
                     "ingester": TEST_HARNESS_COVERAGE_INGESTER_ID,
                     "status": "ok",
                     "reference_mode": "current",
-                    "commit_sha": stored_commit_sha,
+                    "commit_sha": "current",
                     "observed_head_sha": observed_head_sha,
                     "summary": {
                         "format": summary.format.as_str(),
@@ -187,6 +184,17 @@ fn file_modified_unix(path: &Path) -> Option<u64> {
         .duration_since(UNIX_EPOCH)
         .ok()
         .map(|duration| duration.as_secs())
+}
+
+fn coverage_metadata_path(repo_root: &Path, coverage_path: &Path) -> String {
+    if let Ok(relative) = coverage_path.strip_prefix(repo_root) {
+        return relative.to_string_lossy().to_string();
+    }
+
+    coverage_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| coverage_path.display().to_string())
 }
 
 fn repo_dirty(repo_root: &Path) -> Option<bool> {

--- a/bitloops/src/capability_packs/test_harness/storage.rs
+++ b/bitloops/src/capability_packs/test_harness/storage.rs
@@ -30,6 +30,12 @@ pub trait TestHarnessCoverageGateway: Send {
         &mut self,
         diagnostics: &[CoverageDiagnosticRecord],
     ) -> Result<()>;
+    fn replace_coverage_capture(
+        &mut self,
+        capture: &CoverageCaptureRecord,
+        hits: &[CoverageHitRecord],
+        diagnostics: &[CoverageDiagnosticRecord],
+    ) -> Result<()>;
     fn rebuild_classifications_from_coverage(&mut self, commit_sha: &str) -> Result<usize>;
 }
 
@@ -46,6 +52,12 @@ pub trait TestHarnessRepository {
     fn insert_coverage_hits(&mut self, hits: &[CoverageHitRecord]) -> Result<()>;
     fn insert_coverage_diagnostics(
         &mut self,
+        diagnostics: &[CoverageDiagnosticRecord],
+    ) -> Result<()>;
+    fn replace_coverage_capture(
+        &mut self,
+        capture: &CoverageCaptureRecord,
+        hits: &[CoverageHitRecord],
         diagnostics: &[CoverageDiagnosticRecord],
     ) -> Result<()>;
     fn rebuild_classifications_from_coverage(&mut self, commit_sha: &str) -> Result<usize>;

--- a/bitloops/src/capability_packs/test_harness/storage/dispatch.rs
+++ b/bitloops/src/capability_packs/test_harness/storage/dispatch.rs
@@ -128,6 +128,22 @@ impl TestHarnessRepository for BitloopsTestHarnessRepository {
         }
     }
 
+    fn replace_coverage_capture(
+        &mut self,
+        capture: &CoverageCaptureRecord,
+        hits: &[CoverageHitRecord],
+        diagnostics: &[CoverageDiagnosticRecord],
+    ) -> Result<()> {
+        match self {
+            Self::Sqlite(repository) => {
+                repository.replace_coverage_capture(capture, hits, diagnostics)
+            }
+            Self::Postgres(repository) => {
+                repository.replace_coverage_capture(capture, hits, diagnostics)
+            }
+        }
+    }
+
     fn rebuild_classifications_from_coverage(&mut self, commit_sha: &str) -> Result<usize> {
         match self {
             Self::Sqlite(repository) => {
@@ -154,6 +170,15 @@ impl TestHarnessCoverageGateway for BitloopsTestHarnessRepository {
         diagnostics: &[CoverageDiagnosticRecord],
     ) -> Result<()> {
         TestHarnessRepository::insert_coverage_diagnostics(self, diagnostics)
+    }
+
+    fn replace_coverage_capture(
+        &mut self,
+        capture: &CoverageCaptureRecord,
+        hits: &[CoverageHitRecord],
+        diagnostics: &[CoverageDiagnosticRecord],
+    ) -> Result<()> {
+        TestHarnessRepository::replace_coverage_capture(self, capture, hits, diagnostics)
     }
 
     fn rebuild_classifications_from_coverage(&mut self, commit_sha: &str) -> Result<usize> {

--- a/bitloops/src/capability_packs/test_harness/storage/postgres.rs
+++ b/bitloops/src/capability_packs/test_harness/storage/postgres.rs
@@ -349,6 +349,148 @@ ON CONFLICT(diagnostic_id) DO UPDATE SET
         })
     }
 
+    fn replace_coverage_capture(
+        &mut self,
+        capture: &CoverageCaptureRecord,
+        hits: &[CoverageHitRecord],
+        diagnostics: &[CoverageDiagnosticRecord],
+    ) -> Result<()> {
+        let capture = capture.clone();
+        let hits = hits.to_vec();
+        let diagnostics = diagnostics.to_vec();
+        self.with_client(move |client| {
+            Box::pin(async move {
+                let tx = client
+                    .transaction()
+                    .await
+                    .context("failed to start coverage replacement transaction")?;
+
+                tx.execute(
+                    "DELETE FROM coverage_hits WHERE capture_id = $1",
+                    &[&capture.capture_id],
+                )
+                .await
+                .context("failed deleting stale coverage hits")?;
+                tx.execute(
+                    "DELETE FROM coverage_diagnostics WHERE capture_id = $1",
+                    &[&capture.capture_id],
+                )
+                .await
+                .context("failed deleting stale coverage diagnostics")?;
+
+                tx.execute(
+                    r#"
+INSERT INTO coverage_captures (
+  capture_id, repo_id, commit_sha, tool, format, scope_kind,
+  subject_test_symbol_id, line_truth, branch_truth, captured_at, status, metadata_json
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+ON CONFLICT(capture_id) DO UPDATE SET
+  repo_id = excluded.repo_id,
+  commit_sha = excluded.commit_sha,
+  tool = excluded.tool,
+  format = excluded.format,
+  scope_kind = excluded.scope_kind,
+  subject_test_symbol_id = excluded.subject_test_symbol_id,
+  line_truth = excluded.line_truth,
+  branch_truth = excluded.branch_truth,
+  captured_at = excluded.captured_at,
+  status = excluded.status,
+  metadata_json = excluded.metadata_json
+"#,
+                    &[
+                        &capture.capture_id,
+                        &capture.repo_id,
+                        &capture.commit_sha,
+                        &capture.tool,
+                        &capture.format.as_str(),
+                        &capture.scope_kind.as_str(),
+                        &capture.subject_test_symbol_id,
+                        &(capture.line_truth as i64),
+                        &(capture.branch_truth as i64),
+                        &capture.captured_at,
+                        &capture.status,
+                        &capture.metadata_json,
+                    ],
+                )
+                .await
+                .with_context(|| {
+                    format!("failed inserting coverage capture {}", capture.capture_id)
+                })?;
+
+                for hit in hits {
+                    tx.execute(
+                        r#"
+INSERT INTO coverage_hits (
+  capture_id, production_symbol_id, file_path, line, branch_id, covered, hit_count
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT(capture_id, production_symbol_id, line, branch_id) DO UPDATE SET
+  file_path = excluded.file_path,
+  covered = excluded.covered,
+  hit_count = excluded.hit_count
+"#,
+                        &[
+                            &hit.capture_id,
+                            &hit.production_symbol_id,
+                            &hit.file_path,
+                            &hit.line,
+                            &hit.branch_id,
+                            &(hit.covered as i64),
+                            &hit.hit_count,
+                        ],
+                    )
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed inserting coverage hit for capture {} symbol {} line {}",
+                            hit.capture_id, hit.production_symbol_id, hit.line
+                        )
+                    })?;
+                }
+
+                for diag in diagnostics {
+                    tx.execute(
+                        r#"
+INSERT INTO coverage_diagnostics (
+  diagnostic_id, capture_id, repo_id, commit_sha, path, line,
+  severity, code, message, metadata_json
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT(diagnostic_id) DO UPDATE SET
+  capture_id = excluded.capture_id,
+  severity = excluded.severity,
+  code = excluded.code,
+  message = excluded.message,
+  metadata_json = excluded.metadata_json
+"#,
+                        &[
+                            &diag.diagnostic_id,
+                            &diag.capture_id,
+                            &diag.repo_id,
+                            &diag.commit_sha,
+                            &diag.path,
+                            &diag.line,
+                            &diag.severity,
+                            &diag.code,
+                            &diag.message,
+                            &diag.metadata_json,
+                        ],
+                    )
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed inserting coverage diagnostic {}",
+                            diag.diagnostic_id
+                        )
+                    })?;
+                }
+
+                tx.commit()
+                    .await
+                    .context("failed to commit coverage replacement transaction")?;
+                Ok(())
+            })
+        })
+    }
+
     fn rebuild_classifications_from_coverage(&mut self, commit_sha: &str) -> Result<usize> {
         let commit_sha = commit_sha.to_string();
         self.with_client(move |client| {

--- a/bitloops/src/capability_packs/test_harness/storage/sqlite.rs
+++ b/bitloops/src/capability_packs/test_harness/storage/sqlite.rs
@@ -129,43 +129,7 @@ ORDER BY ts.path ASC, ts.start_line ASC
     }
 
     fn insert_coverage_capture(&mut self, capture: &CoverageCaptureRecord) -> Result<()> {
-        self.conn
-            .execute(
-                r#"
-INSERT INTO coverage_captures (
-  capture_id, repo_id, commit_sha, tool, format, scope_kind,
-  subject_test_symbol_id, line_truth, branch_truth, captured_at, status, metadata_json
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-ON CONFLICT(capture_id) DO UPDATE SET
-  repo_id = excluded.repo_id,
-  commit_sha = excluded.commit_sha,
-  tool = excluded.tool,
-  format = excluded.format,
-  scope_kind = excluded.scope_kind,
-  subject_test_symbol_id = excluded.subject_test_symbol_id,
-  line_truth = excluded.line_truth,
-  branch_truth = excluded.branch_truth,
-  captured_at = excluded.captured_at,
-  status = excluded.status,
-  metadata_json = excluded.metadata_json
-"#,
-                params![
-                    capture.capture_id,
-                    capture.repo_id,
-                    capture.commit_sha,
-                    capture.tool,
-                    capture.format.as_str(),
-                    capture.scope_kind.as_str(),
-                    capture.subject_test_symbol_id,
-                    capture.line_truth as i64,
-                    capture.branch_truth as i64,
-                    capture.captured_at,
-                    capture.status,
-                    capture.metadata_json,
-                ],
-            )
-            .with_context(|| format!("failed inserting coverage capture {}", capture.capture_id))?;
-        Ok(())
+        upsert_coverage_capture(&self.conn, capture)
     }
 
     fn insert_coverage_hits(&mut self, hits: &[CoverageHitRecord]) -> Result<()> {
@@ -175,32 +139,7 @@ ON CONFLICT(capture_id) DO UPDATE SET
             .context("failed to start coverage hits transaction")?;
 
         for hit in hits {
-            tx.execute(
-                r#"
-INSERT INTO coverage_hits (
-  capture_id, production_symbol_id, file_path, line, branch_id, covered, hit_count
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-ON CONFLICT(capture_id, production_symbol_id, line, branch_id) DO UPDATE SET
-  file_path = excluded.file_path,
-  covered = excluded.covered,
-  hit_count = excluded.hit_count
-"#,
-                params![
-                    hit.capture_id,
-                    hit.production_symbol_id,
-                    hit.file_path,
-                    hit.line,
-                    hit.branch_id,
-                    hit.covered as i64,
-                    hit.hit_count,
-                ],
-            )
-            .with_context(|| {
-                format!(
-                    "failed inserting coverage hit for capture {} symbol {} line {}",
-                    hit.capture_id, hit.production_symbol_id, hit.line
-                )
-            })?;
+            upsert_coverage_hit(&tx, hit)?;
         }
 
         tx.commit()
@@ -222,42 +161,46 @@ ON CONFLICT(capture_id, production_symbol_id, line, branch_id) DO UPDATE SET
             .context("failed to start coverage diagnostics transaction")?;
 
         for diag in diagnostics {
-            tx.execute(
-                r#"
-INSERT INTO coverage_diagnostics (
-  diagnostic_id, capture_id, repo_id, commit_sha, path, line,
-  severity, code, message, metadata_json
-) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-ON CONFLICT(diagnostic_id) DO UPDATE SET
-  capture_id = excluded.capture_id,
-  severity = excluded.severity,
-  code = excluded.code,
-  message = excluded.message,
-  metadata_json = excluded.metadata_json
-"#,
-                params![
-                    diag.diagnostic_id,
-                    diag.capture_id,
-                    diag.repo_id,
-                    diag.commit_sha,
-                    diag.path,
-                    diag.line,
-                    diag.severity,
-                    diag.code,
-                    diag.message,
-                    diag.metadata_json,
-                ],
-            )
-            .with_context(|| {
-                format!(
-                    "failed inserting coverage diagnostic {}",
-                    diag.diagnostic_id
-                )
-            })?;
+            upsert_coverage_diagnostic(&tx, diag)?;
         }
 
         tx.commit()
             .context("failed to commit coverage diagnostics transaction")?;
+        Ok(())
+    }
+
+    fn replace_coverage_capture(
+        &mut self,
+        capture: &CoverageCaptureRecord,
+        hits: &[CoverageHitRecord],
+        diagnostics: &[CoverageDiagnosticRecord],
+    ) -> Result<()> {
+        let tx = self
+            .conn
+            .transaction()
+            .context("failed to start coverage replacement transaction")?;
+
+        tx.execute(
+            "DELETE FROM coverage_hits WHERE capture_id = ?1",
+            params![capture.capture_id],
+        )
+        .context("failed deleting stale coverage hits")?;
+        tx.execute(
+            "DELETE FROM coverage_diagnostics WHERE capture_id = ?1",
+            params![capture.capture_id],
+        )
+        .context("failed deleting stale coverage diagnostics")?;
+
+        upsert_coverage_capture(&tx, capture)?;
+        for hit in hits {
+            upsert_coverage_hit(&tx, hit)?;
+        }
+        for diag in diagnostics {
+            upsert_coverage_diagnostic(&tx, diag)?;
+        }
+
+        tx.commit()
+            .context("failed to commit coverage replacement transaction")?;
         Ok(())
     }
 
@@ -336,6 +279,111 @@ WHERE cc.commit_sha = ?1
 
         Ok(inserted)
     }
+}
+
+fn upsert_coverage_capture(conn: &Connection, capture: &CoverageCaptureRecord) -> Result<()> {
+    conn.execute(
+        r#"
+INSERT INTO coverage_captures (
+  capture_id, repo_id, commit_sha, tool, format, scope_kind,
+  subject_test_symbol_id, line_truth, branch_truth, captured_at, status, metadata_json
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+ON CONFLICT(capture_id) DO UPDATE SET
+  repo_id = excluded.repo_id,
+  commit_sha = excluded.commit_sha,
+  tool = excluded.tool,
+  format = excluded.format,
+  scope_kind = excluded.scope_kind,
+  subject_test_symbol_id = excluded.subject_test_symbol_id,
+  line_truth = excluded.line_truth,
+  branch_truth = excluded.branch_truth,
+  captured_at = excluded.captured_at,
+  status = excluded.status,
+  metadata_json = excluded.metadata_json
+"#,
+        params![
+            capture.capture_id,
+            capture.repo_id,
+            capture.commit_sha,
+            capture.tool,
+            capture.format.as_str(),
+            capture.scope_kind.as_str(),
+            capture.subject_test_symbol_id,
+            capture.line_truth as i64,
+            capture.branch_truth as i64,
+            capture.captured_at,
+            capture.status,
+            capture.metadata_json,
+        ],
+    )
+    .with_context(|| format!("failed inserting coverage capture {}", capture.capture_id))?;
+    Ok(())
+}
+
+fn upsert_coverage_hit(conn: &Connection, hit: &CoverageHitRecord) -> Result<()> {
+    conn.execute(
+        r#"
+INSERT INTO coverage_hits (
+  capture_id, production_symbol_id, file_path, line, branch_id, covered, hit_count
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+ON CONFLICT(capture_id, production_symbol_id, line, branch_id) DO UPDATE SET
+  file_path = excluded.file_path,
+  covered = excluded.covered,
+  hit_count = excluded.hit_count
+"#,
+        params![
+            hit.capture_id,
+            hit.production_symbol_id,
+            hit.file_path,
+            hit.line,
+            hit.branch_id,
+            hit.covered as i64,
+            hit.hit_count,
+        ],
+    )
+    .with_context(|| {
+        format!(
+            "failed inserting coverage hit for capture {} symbol {} line {}",
+            hit.capture_id, hit.production_symbol_id, hit.line
+        )
+    })?;
+    Ok(())
+}
+
+fn upsert_coverage_diagnostic(conn: &Connection, diag: &CoverageDiagnosticRecord) -> Result<()> {
+    conn.execute(
+        r#"
+INSERT INTO coverage_diagnostics (
+  diagnostic_id, capture_id, repo_id, commit_sha, path, line,
+  severity, code, message, metadata_json
+) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+ON CONFLICT(diagnostic_id) DO UPDATE SET
+  capture_id = excluded.capture_id,
+  severity = excluded.severity,
+  code = excluded.code,
+  message = excluded.message,
+  metadata_json = excluded.metadata_json
+"#,
+        params![
+            diag.diagnostic_id,
+            diag.capture_id,
+            diag.repo_id,
+            diag.commit_sha,
+            diag.path,
+            diag.line,
+            diag.severity,
+            diag.code,
+            diag.message,
+            diag.metadata_json,
+        ],
+    )
+    .with_context(|| {
+        format!(
+            "failed inserting coverage diagnostic {}",
+            diag.diagnostic_id
+        )
+    })?;
+    Ok(())
 }
 
 impl TestHarnessQueryRepository for SqliteTestHarnessRepository {

--- a/bitloops/src/capability_packs/test_harness/storage/sqlite/tests.rs
+++ b/bitloops/src/capability_packs/test_harness/storage/sqlite/tests.rs
@@ -7,8 +7,8 @@ use super::SqliteTestHarnessRepository;
 use crate::capability_packs::test_harness::storage::TestHarnessRepository;
 use crate::models::ScopeKind;
 use crate::models::{
-    CoverageCaptureRecord, CoverageFormat, CoverageHitRecord, TestArtefactCurrentRecord,
-    TestArtefactEdgeCurrentRecord, TestRunRecord,
+    CoverageCaptureRecord, CoverageDiagnosticRecord, CoverageFormat, CoverageHitRecord,
+    TestArtefactCurrentRecord, TestArtefactEdgeCurrentRecord, TestRunRecord,
 };
 use crate::storage::init::init_database;
 
@@ -93,6 +93,46 @@ fn replace_test_discovery_clears_stale_runs_coverage_and_classifications() {
         .expect("load fresh test scenarios");
     assert_eq!(scenarios.len(), 1);
     assert_eq!(scenarios[0].scenario_id, SCENARIO_ID);
+}
+
+#[test]
+fn replace_coverage_capture_removes_stale_hits_and_diagnostics() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let db_path = temp_dir.path().join("coverage-replacement.db");
+    init_database(&db_path, false, "seed").expect("failed to initialize db");
+
+    let mut repository = SqliteTestHarnessRepository::open_existing(&db_path).expect("open db");
+    let capture = coverage_capture_record();
+    let first_hits = coverage_hits();
+    let first_diagnostics = coverage_diagnostics();
+
+    repository
+        .replace_coverage_capture(&capture, &first_hits, &first_diagnostics)
+        .expect("insert first coverage payload");
+
+    let replacement_hits = vec![first_hits[0].clone()];
+    repository
+        .replace_coverage_capture(&capture, &replacement_hits, &[])
+        .expect("replace coverage payload");
+
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    let hit_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM coverage_hits WHERE capture_id = ?1",
+            rusqlite::params![capture.capture_id],
+            |row| row.get(0),
+        )
+        .expect("count coverage hits");
+    assert_eq!(hit_count, 1);
+
+    let diagnostic_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM coverage_diagnostics WHERE capture_id = ?1",
+            rusqlite::params![capture.capture_id],
+            |row| row.get(0),
+        )
+        .expect("count coverage diagnostics");
+    assert_eq!(diagnostic_count, 0);
 }
 
 fn table_count(db_path: &Path, table: &str) -> i64 {
@@ -239,6 +279,21 @@ fn coverage_hits() -> Vec<CoverageHitRecord> {
             hit_count: 0,
         },
     ]
+}
+
+fn coverage_diagnostics() -> Vec<CoverageDiagnosticRecord> {
+    vec![CoverageDiagnosticRecord {
+        diagnostic_id: "diag:coverage:stale".to_string(),
+        capture_id: CAPTURE_ID.to_string(),
+        repo_id: REPO_ID.to_string(),
+        commit_sha: COMMIT_SHA.to_string(),
+        path: Some(FILE_USER.to_string()),
+        line: Some(12),
+        severity: "warning".to_string(),
+        code: "unmapped_file".to_string(),
+        message: "stale diagnostic".to_string(),
+        metadata_json: None,
+    }]
 }
 
 fn test_artefacts() -> Vec<TestArtefactCurrentRecord> {

--- a/bitloops/src/cli/devql/args.rs
+++ b/bitloops/src/cli/devql/args.rs
@@ -649,8 +649,8 @@ pub struct DevqlTestHarnessIngestCoverageArgs {
     #[arg(long)]
     pub input: Option<std::path::PathBuf>,
     #[arg(long)]
-    pub commit: String,
-    #[arg(long)]
+    pub commit: Option<String>,
+    #[arg(long, default_value = "workspace")]
     pub scope: String,
     #[arg(long, default_value = "unknown")]
     pub tool: String,

--- a/bitloops/src/cli/devql/test_harness.rs
+++ b/bitloops/src/cli/devql/test_harness.rs
@@ -79,14 +79,16 @@ async fn run_ingest_coverage(
     let host = DevqlCapabilityHost::builtin(repo_root.to_path_buf(), repo)?;
     host.ensure_migrations_applied_sync()?;
 
-    let payload = serde_json::json!({
+    let mut payload = serde_json::json!({
         "coverage_path": coverage_path.to_string_lossy(),
-        "commit_sha": args.commit,
         "scope_kind": args.scope,
         "tool": args.tool,
         "test_artefact_id": args.test_artefact_id,
         "format": format.as_str(),
     });
+    if let Some(commit) = args.commit.as_ref() {
+        payload["commit_sha"] = serde_json::json!(commit);
+    }
 
     let result = host
         .invoke_ingester("test_harness", TEST_HARNESS_COVERAGE_INGESTER_ID, payload)

--- a/bitloops/src/host/capability_host/gateways/relational.rs
+++ b/bitloops/src/host/capability_host/gateways/relational.rs
@@ -56,6 +56,15 @@ pub trait RelationalGateway: Send + Sync {
         Ok(())
     }
     fn load_current_production_artefacts(&self, repo_id: &str) -> Result<Vec<ProductionArtefact>>;
+    fn load_current_artefacts_for_file_lines(
+        &self,
+        repo_id: &str,
+        file_path: &str,
+    ) -> Result<Vec<(String, i64, i64)>> {
+        bail!(
+            "current artefact line lookup is not implemented by this relational gateway (repo {repo_id}, file {file_path})"
+        )
+    }
     fn load_production_artefacts(&self, commit_sha: &str) -> Result<Vec<ProductionArtefact>>;
     fn load_artefacts_for_file_lines(
         &self,

--- a/bitloops/src/host/capability_host/gateways/sqlite_relational.rs
+++ b/bitloops/src/host/capability_host/gateways/sqlite_relational.rs
@@ -488,7 +488,7 @@ SELECT DISTINCT
 FROM artefacts_current a
 WHERE a.repo_id = ?1
   AND a.canonical_kind != 'file'
-  AND (a.path = ?2 OR ?2 LIKE '%' || a.path)
+  AND (a.path = ?2 OR substr(?2, -length(a.path)) = a.path)
 ORDER BY a.path ASC, a.start_line ASC
 "#,
                 )
@@ -839,6 +839,20 @@ mod tests {
                 )",
                 rusqlite::params!["repo-current"],
             )?;
+            conn.execute(
+                "INSERT INTO artefacts_current (
+                    repo_id, path, content_id, symbol_id, artefact_id, language,
+                    extraction_fingerprint, canonical_kind, language_kind, symbol_fqn,
+                    parent_symbol_id, parent_artefact_id, start_line, end_line,
+                    start_byte, end_byte, signature, modifiers, docstring, updated_at
+                ) VALUES (
+                    ?1, 'crates/demo/src/lib_rs', 'content-b', 'symbol::underscore', 'artefact::underscore', 'rust',
+                    'fingerprint-b', 'function', 'function_item',
+                    'crates/demo/src/lib_rs::underscore', NULL, NULL, 10, 14,
+                    0, 40, NULL, '[]', NULL, '2026-05-20T10:00:00Z'
+                )",
+                rusqlite::params!["repo-current"],
+            )?;
             Ok(())
         })?;
 
@@ -848,6 +862,14 @@ mod tests {
         )?;
 
         assert_eq!(rows, vec![("symbol::covered".to_string(), 10, 14)]);
+        let wildcard_rows = gateway.load_current_artefacts_for_file_lines(
+            "repo-current",
+            "/tmp/work/crates/demo/src/libXrs",
+        )?;
+        assert!(
+            wildcard_rows.is_empty(),
+            "underscore in stored path must not act as a LIKE wildcard"
+        );
         Ok(())
     }
 

--- a/bitloops/src/host/capability_host/gateways/sqlite_relational.rs
+++ b/bitloops/src/host/capability_host/gateways/sqlite_relational.rs
@@ -470,6 +470,48 @@ ORDER BY path ASC, start_line ASC
         })
     }
 
+    pub fn load_current_artefacts_for_file_lines(
+        &self,
+        repo_id: &str,
+        file_path: &str,
+    ) -> Result<Vec<(String, i64, i64)>> {
+        let repo_id = repo_id.to_string();
+        let file_path = file_path.to_string();
+        self.sqlite.with_connection(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    r#"
+SELECT DISTINCT
+  COALESCE(NULLIF(a.symbol_id, ''), a.artefact_id) AS production_symbol_id,
+  a.start_line,
+  a.end_line
+FROM artefacts_current a
+WHERE a.repo_id = ?1
+  AND a.canonical_kind != 'file'
+  AND (a.path = ?2 OR ?2 LIKE '%' || a.path)
+ORDER BY a.path ASC, a.start_line ASC
+"#,
+                )
+                .context("failed preparing current artefacts-for-file query")?;
+
+            let rows = stmt
+                .query_map(params![repo_id, file_path], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })
+                .context("failed querying current artefacts for file")?;
+
+            let mut result = Vec::new();
+            for row in rows {
+                result.push(row.context("failed mapping current artefact-for-file row")?);
+            }
+            Ok(result)
+        })
+    }
+
     pub fn load_artefacts_for_file_lines(
         &self,
         commit_sha: &str,
@@ -611,6 +653,14 @@ impl RelationalGateway for SqliteRelationalGateway {
         SqliteRelationalGateway::load_current_production_artefacts(self, repo_id)
     }
 
+    fn load_current_artefacts_for_file_lines(
+        &self,
+        repo_id: &str,
+        file_path: &str,
+    ) -> Result<Vec<(String, i64, i64)>> {
+        SqliteRelationalGateway::load_current_artefacts_for_file_lines(self, repo_id, file_path)
+    }
+
     fn load_production_artefacts(&self, commit_sha: &str) -> Result<Vec<ProductionArtefact>> {
         SqliteRelationalGateway::load_production_artefacts(self, commit_sha)
     }
@@ -744,6 +794,60 @@ mod tests {
             Some("packages/api/src/target.ts::target")
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn load_current_artefacts_for_file_lines_reads_artefacts_current_by_suffix() -> Result<()> {
+        let temp = TempDir::new()?;
+        let db_path = temp.path().join("runtime.sqlite");
+        init_database(&db_path, false, "seed-commit")?;
+        let sqlite = SqliteConnectionPool::connect_existing(db_path)?;
+        let gateway = SqliteRelationalGateway::new(sqlite.clone());
+
+        sqlite.with_write_connection(|conn| {
+            conn.execute(
+                "INSERT INTO repositories (repo_id, provider, organization, name, default_branch)
+                 VALUES (?1, 'local', 'bitloops', 'demo', 'main')",
+                rusqlite::params!["repo-current"],
+            )?;
+            conn.execute(
+                "INSERT INTO artefacts_current (
+                    repo_id, path, content_id, symbol_id, artefact_id, language,
+                    extraction_fingerprint, canonical_kind, language_kind, symbol_fqn,
+                    parent_symbol_id, parent_artefact_id, start_line, end_line,
+                    start_byte, end_byte, signature, modifiers, docstring, updated_at
+                ) VALUES (
+                    ?1, 'crates/demo/src/lib.rs', 'content-a', 'symbol::covered', 'artefact::covered', 'rust',
+                    'fingerprint-a', 'function', 'function_item',
+                    'crates/demo/src/lib.rs::covered', NULL, NULL, 10, 14,
+                    0, 40, NULL, '[]', NULL, '2026-05-20T10:00:00Z'
+                )",
+                rusqlite::params!["repo-current"],
+            )?;
+            conn.execute(
+                "INSERT INTO artefacts_current (
+                    repo_id, path, content_id, symbol_id, artefact_id, language,
+                    extraction_fingerprint, canonical_kind, language_kind, symbol_fqn,
+                    parent_symbol_id, parent_artefact_id, start_line, end_line,
+                    start_byte, end_byte, signature, modifiers, docstring, updated_at
+                ) VALUES (
+                    ?1, 'crates/demo/src/lib.rs', 'content-a', 'file-symbol', 'file-artefact', 'rust',
+                    'fingerprint-file', 'file', 'source_file',
+                    'crates/demo/src/lib.rs', NULL, NULL, 1, 30,
+                    0, 240, NULL, '[]', NULL, '2026-05-20T10:00:00Z'
+                )",
+                rusqlite::params!["repo-current"],
+            )?;
+            Ok(())
+        })?;
+
+        let rows = gateway.load_current_artefacts_for_file_lines(
+            "repo-current",
+            "/tmp/work/crates/demo/src/lib.rs",
+        )?;
+
+        assert_eq!(rows, vec![("symbol::covered".to_string(), 10, 14)]);
         Ok(())
     }
 

--- a/bitloops/tests/qat_support/helpers/deps_and_testlens.rs
+++ b/bitloops/tests/qat_support/helpers/deps_and_testlens.rs
@@ -538,6 +538,28 @@ pub fn run_testlens_ingest_coverage(world: &mut QatWorld, repo_name: &str) -> Re
     Ok(())
 }
 
+pub fn run_testlens_ingest_current_coverage(world: &mut QatWorld, repo_name: &str) -> Result<()> {
+    ensure_bitloops_repo_name(repo_name)?;
+    let tool = if world.repo_dir().join("Cargo.toml").exists() {
+        "cargo-test"
+    } else {
+        "jest"
+    };
+    run_testlens_command_strict(
+        world,
+        &[
+            "devql",
+            "test-harness",
+            "ingest-coverage",
+            "--lcov",
+            "coverage/lcov.info",
+            "--tool",
+            tool,
+        ],
+        "bitloops devql test-harness ingest-coverage",
+    )
+}
+
 fn run_testlens_command_strict(world: &mut QatWorld, args: &[&str], label: &str) -> Result<()> {
     let output = run_command_capture(world, label, build_bitloops_command(world, args)?)
         .with_context(|| format!("running {label}"))?;

--- a/bitloops/tests/qat_support/steps/given.rs
+++ b/bitloops/tests/qat_support/steps/given.rs
@@ -1092,6 +1092,19 @@ pub(super) fn given_testlens_ingest_coverage(
     })
 }
 
+pub(super) fn given_testlens_ingest_current_coverage(
+    world: &mut QatWorld,
+    ctx: cucumber::step::Context,
+) -> LocalBoxFuture<'_, ()> {
+    Box::pin(async move {
+        let repo_name = ctx.matches[1].1.clone();
+        run_step(
+            "I run TestHarness ingest-coverage for current workspace",
+            helpers::run_testlens_ingest_current_coverage(world, &repo_name),
+        );
+    })
+}
+
 pub(super) fn given_testlens_ingest_results_failing(
     world: &mut QatWorld,
     ctx: cucumber::step::Context,

--- a/bitloops/tests/qat_support/steps/mod.rs
+++ b/bitloops/tests/qat_support/steps/mod.rs
@@ -445,6 +445,13 @@ pub fn collection() -> Collection<QatWorld> {
         .given(
             None,
             regex(
+                r"^I run (?:TestHarness|TestLens) ingest-coverage for current workspace in (\S+)$",
+            ),
+            step_fn(given_testlens_ingest_current_coverage),
+        )
+        .given(
+            None,
+            regex(
                 r"^I run (?:TestHarness|TestLens) ingest-results with a failing test for latest commit in (\S+)$",
             ),
             step_fn(given_testlens_ingest_results_failing),

--- a/bitloops/tests/test_harness_support/mod.rs
+++ b/bitloops/tests/test_harness_support/mod.rs
@@ -247,6 +247,32 @@ pub fn ingest_test_harness_coverage(
     });
 }
 
+pub fn ingest_current_test_harness_coverage(
+    workspace: &Workspace,
+    coverage_path: &Path,
+    scope_kind: bitloops::models::ScopeKind,
+    tool: &str,
+    format: bitloops::models::CoverageFormat,
+) {
+    with_devql_host(workspace, |host| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime for current ingest-coverage")
+            .block_on(host.invoke_ingester(
+                "test_harness",
+                bitloops::capability_packs::test_harness::types::TEST_HARNESS_COVERAGE_INGESTER_ID,
+                json!({
+                    "coverage_path": coverage_path.to_string_lossy(),
+                    "scope_kind": scope_kind.to_string(),
+                    "tool": tool,
+                    "format": format.as_str(),
+                }),
+            ))
+            .expect("ingest current test harness coverage");
+    });
+}
+
 pub fn open_test_harness_repository(
     workspace: &Workspace,
 ) -> bitloops::capability_packs::test_harness::storage::BitloopsTestHarnessRepository {

--- a/bitloops/tests/testlens_sqlite_acceptance.rs
+++ b/bitloops/tests/testlens_sqlite_acceptance.rs
@@ -5,9 +5,9 @@ use bitloops::capability_packs::test_harness::storage::TestHarnessQueryRepositor
 use bitloops::models::{CoverageFormat, ScopeKind};
 use rusqlite::{Connection, params};
 use test_harness_support::{
-    Workspace, bootstrap_minimal_workspace, ingest_test_harness_coverage,
-    ingest_test_harness_tests, open_test_harness_repository, run_devql_init,
-    seed_production_artefacts, write_rust_coverage_fixture,
+    Workspace, bootstrap_minimal_workspace, ingest_current_test_harness_coverage,
+    ingest_test_harness_coverage, ingest_test_harness_tests, open_test_harness_repository,
+    run_bitloops_or_panic, run_devql_init, seed_production_artefacts, write_rust_coverage_fixture,
 };
 
 #[test]
@@ -163,4 +163,138 @@ LIMIT 1
         .expect("count C0 coverage hits");
     assert_eq!(c0_hit_count, 0, "expected no coverage hits for C0");
     assert!(c1_hit_count > 0, "expected coverage hits for C1");
+}
+
+#[test]
+fn bitloops_testlens_ingest_current_lcov_uses_current_artefacts_without_commit() {
+    let workspace = Workspace::new("sqlite-current-coverage");
+    write_rust_coverage_fixture(&workspace);
+
+    bootstrap_minimal_workspace(&workspace);
+    run_devql_init(&workspace);
+    seed_production_artefacts(&workspace, "C1");
+
+    let lcov_path = workspace.repo_dir().join("rust-current-coverage.lcov");
+    fs::write(
+        &lcov_path,
+        r#"
+TN:
+SF:src/lib.rs
+DA:4,1
+DA:5,1
+DA:8,0
+DA:9,0
+end_of_record
+"#
+        .trim_start(),
+    )
+    .expect("write current lcov");
+
+    ingest_current_test_harness_coverage(
+        &workspace,
+        &lcov_path,
+        ScopeKind::Workspace,
+        "cargo-llvm-cov",
+        CoverageFormat::Lcov,
+    );
+
+    let conn = Connection::open(workspace.db_path()).expect("open sqlite db");
+    let (commit_sha, metadata_json): (String, String) = conn
+        .query_row(
+            r#"
+SELECT commit_sha, metadata_json
+FROM coverage_captures
+ORDER BY capture_id
+LIMIT 1
+"#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("load current coverage capture");
+    assert_eq!(
+        commit_sha, "current",
+        "fresh test repositories should store current coverage under the current placeholder"
+    );
+    assert!(
+        metadata_json.contains("\"reference_mode\":\"current\""),
+        "expected current reference metadata, got {metadata_json}"
+    );
+
+    let hit_count: i64 = conn
+        .query_row(
+            r#"
+SELECT COUNT(*)
+FROM coverage_hits ch
+JOIN coverage_captures cc ON cc.capture_id = ch.capture_id
+WHERE cc.commit_sha = ?1
+  AND ch.production_symbol_id IN (
+    SELECT symbol_id FROM artefacts_current WHERE path = 'src/lib.rs'
+  )
+"#,
+            params!["current"],
+            |row| row.get(0),
+        )
+        .expect("count current coverage hits");
+    assert!(
+        hit_count > 0,
+        "expected current LCOV hits to map through artefacts_current"
+    );
+}
+
+#[test]
+fn bitloops_devql_ingest_coverage_defaults_to_current_workspace_without_commit() {
+    let workspace = Workspace::new("sqlite-current-coverage-cli");
+    write_rust_coverage_fixture(&workspace);
+
+    bootstrap_minimal_workspace(&workspace);
+    run_devql_init(&workspace);
+    seed_production_artefacts(&workspace, "C1");
+
+    let lcov_path = workspace.repo_dir().join("rust-current-cli.lcov");
+    fs::write(
+        &lcov_path,
+        r#"
+TN:
+SF:src/lib.rs
+DA:4,1
+DA:5,1
+end_of_record
+"#
+        .trim_start(),
+    )
+    .expect("write current cli lcov");
+
+    let lcov_arg = lcov_path.to_string_lossy().into_owned();
+    let output = run_bitloops_or_panic(
+        workspace.repo_dir(),
+        &[
+            "devql",
+            "test-harness",
+            "ingest-coverage",
+            "--lcov",
+            &lcov_arg,
+        ],
+    );
+    assert!(
+        output.contains("coverage for current workspace"),
+        "expected current-workspace ingest output, got {output}"
+    );
+
+    let conn = Connection::open(workspace.db_path()).expect("open sqlite db");
+    let hit_count: i64 = conn
+        .query_row(
+            r#"
+SELECT COUNT(*)
+FROM coverage_hits ch
+JOIN coverage_captures cc ON cc.capture_id = ch.capture_id
+WHERE cc.commit_sha = 'current'
+"#,
+            [],
+            |row| row.get(0),
+        )
+        .expect("count current CLI coverage hits");
+    assert!(
+        hit_count > 0,
+        "expected CLI current ingest to persist coverage hits"
+    );
 }

--- a/bitloops/tests/testlens_sqlite_acceptance.rs
+++ b/bitloops/tests/testlens_sqlite_acceptance.rs
@@ -199,16 +199,16 @@ end_of_record
     );
 
     let conn = Connection::open(workspace.db_path()).expect("open sqlite db");
-    let (commit_sha, metadata_json): (String, String) = conn
+    let (commit_sha, captured_at, metadata_json): (String, String, String) = conn
         .query_row(
             r#"
-SELECT commit_sha, metadata_json
+SELECT commit_sha, captured_at, metadata_json
 FROM coverage_captures
 ORDER BY capture_id
 LIMIT 1
 "#,
             [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .expect("load current coverage capture");
     assert_eq!(
@@ -216,8 +216,20 @@ LIMIT 1
         "fresh test repositories should store current coverage under the current placeholder"
     );
     assert!(
+        captured_at.ends_with('Z') && captured_at.contains('T'),
+        "expected RFC3339 UTC captured_at, got {captured_at}"
+    );
+    assert!(
         metadata_json.contains("\"reference_mode\":\"current\""),
         "expected current reference metadata, got {metadata_json}"
+    );
+    assert!(
+        !metadata_json.contains(&workspace.repo_dir().to_string_lossy().to_string()),
+        "metadata should not persist absolute workspace path, got {metadata_json}"
+    );
+    assert!(
+        metadata_json.contains("\"coverage_path\":\"rust-current-coverage.lcov\""),
+        "metadata should persist repo-relative coverage path, got {metadata_json}"
     );
 
     let hit_count: i64 = conn

--- a/documentation/docs/guides/test-harness-sync-and-queries.md
+++ b/documentation/docs/guides/test-harness-sync-and-queries.md
@@ -4,7 +4,7 @@ title: Test Harness Sync And DevQL Queries
 
 # Test Harness Sync And DevQL Queries
 
-This guide explains how `tests()` in DevQL gets populated, what `sync` updates automatically, and how to query covering tests for a specific artefact.
+This guide explains how `tests()` and `coverage()` in DevQL get populated, what `sync` updates automatically, and how to query test-harness data for a specific artefact.
 
 ## How `sync` Updates Test Artefacts
 
@@ -38,9 +38,20 @@ Sync-side updates cover source-based discovery and linkage refresh for current t
 Coverage and test-run results are separate ingestion flows. Use `devql test-harness` commands for those:
 
 ```bash
-bitloops devql test-harness ingest-coverage --lcov coverage/lcov.info --commit <sha> --scope workspace
+bitloops devql test-harness ingest-coverage --lcov bitloops/target/llvm-cov.info --tool cargo-llvm-cov
 bitloops devql test-harness ingest-results --jest-json reports/jest.json --commit <sha>
 ```
+
+Coverage ingest defaults to the current workspace when `--commit` is omitted. In current mode, the ingester maps LCOV file/line entries to `artefacts_current`, so run a current-state sync before ingesting a fresh coverage report:
+
+```bash
+bitloops devql init
+bitloops devql tasks enqueue --kind sync --full --status
+cargo dev-coverage
+bitloops devql test-harness ingest-coverage --lcov bitloops/target/llvm-cov.info --tool cargo-llvm-cov
+```
+
+Pass `--commit <sha>` only for the legacy historical coverage path. Historical mode maps coverage to historical file state and commit-scoped artefacts.
 
 ## Query One Artefact And Its Covering Tests
 
@@ -92,6 +103,88 @@ Typical shape:
 ```bash
 bitloops devql query 'artefacts(symbol_fqn:"src/lib.rs::add")->tests(min_confidence:0.6, linkage_source:"static_analysis")'
 ```
+
+## Query Coverage
+
+Run current coverage queries after generating an LCOV report, running `ingest-coverage` without `--commit`, and syncing current artefacts.
+
+### 1) Check one function
+
+Use `symbol_fqn` for exact matching. Function `name` may be absent in the current artefact payload, so prefer `symbolFqn` when scripting.
+
+```bash
+bitloops devql query --compact \
+  'repo("bitloops")->artefacts(symbol_fqn:"bitloops/src/capability_packs/test_harness/ingest/coverage.rs::execute_current")->coverage()->limit(5)' \
+  | jq '.[] | {
+      path,
+      symbolFqn,
+      hasCoverageData: ((.coverage // []) | length > 0),
+      lineCoveragePct: (.coverage[0].coverage.lineCoveragePct // null),
+      lineDataAvailable: (.coverage[0].coverage.lineDataAvailable // false),
+      uncoveredLineCount: (.coverage[0].summary.uncoveredLineCount // null)
+    }'
+```
+
+### 2) List functions with coverage data
+
+```bash
+bitloops devql query --compact \
+  'repo("bitloops")->artefacts(kind:"function")->coverage()->limit(1000)' \
+  | jq '.[] | select((.coverage // []) | length > 0) | {
+      path,
+      symbolFqn,
+      lineCoveragePct: .coverage[0].coverage.lineCoveragePct
+    }'
+```
+
+### 3) List functions with no coverage row
+
+```bash
+bitloops devql query --compact \
+  'repo("bitloops")->artefacts(kind:"function")->coverage()->limit(1000)' \
+  | jq '.[] | select(((.coverage // []) | length) == 0) | {
+      path,
+      symbolFqn
+    }'
+```
+
+No output means every artefact returned within the query window had a mapped coverage row. That is different from `0%` coverage: `0%` means the report mapped to the artefact and none of its executable lines were hit.
+
+### 4) List functions with mapped coverage but zero hits
+
+```bash
+bitloops devql query --compact \
+  'repo("bitloops")->artefacts(kind:"function")->coverage()->limit(1000)' \
+  | jq '.[] | select((.coverage[0].coverage.lineCoveragePct // null) == 0) | {
+      path,
+      symbolFqn,
+      uncoveredLineCount: .coverage[0].summary.uncoveredLineCount
+    }'
+```
+
+The artefact-nested DSL shape is:
+
+```json
+[
+  {
+    "path": "bitloops/src/example.rs",
+    "symbolFqn": "bitloops/src/example.rs::run",
+    "coverage": [
+      {
+        "coverage": {
+          "lineCoveragePct": 84.5,
+          "lineDataAvailable": true
+        },
+        "summary": {
+          "uncoveredLineCount": 7
+        }
+      }
+    ]
+  }
+]
+```
+
+If you add `project("...")`, the CLI checks that the project matches the directory scope. From the repository root, omit `project(...)`; from a crate subdirectory, use the matching project path.
 
 ## GraphQL Equivalents (Concrete Example)
 
@@ -203,6 +296,8 @@ Example output:
 
 - DevQL DSL mode is used when the query contains `->`.
 - `tests()` is a stage and must follow `artefacts(...)`.
+- `coverage()` is a stage and must follow `artefacts(...)`.
 - `tests()` by itself is not a valid DSL pipeline.
+- `coverage()` by itself is not a valid DSL pipeline.
 
 For broader DevQL syntax and GraphQL mode details, see [DevQL GraphQL](/guides/devql-graphql) and [DevQL Query Cookbook](/guides/devql-query-cookbook).


### PR DESCRIPTION
## Summary
- Make coverage ingest default to the current workspace when no commit is provided.
- Map LCOV/LLVM coverage lines to artefacts_current and replace stale capture rows on re-ingest.
- Update QAT coverage scenarios and docs to distinguish current coverage from historical coverage.

## Validation
- cargo dev-loop
- cargo qat-develop-gate --parallel 2