### PR TITLE
[codex] Requeue cancelled DevQL ingest tasks

### DIFF
--- a/bitloops/src/daemon/tasks/coordinator/state.rs
+++ b/bitloops/src/daemon/tasks/coordinator/state.rs
@@ -296,6 +296,9 @@ impl DevqlTaskCoordinator {
     pub(super) fn finish_task_failed(&self, task_id: &str, err: anyhow::Error) -> Result<()> {
         let task_id = task_id.to_string();
         let error = format!("{err:#}");
+        if is_cancelled_join_error(&error) {
+            return self.requeue_task_after_cancelled_join(&task_id, &error);
+        }
         let mut task_context: Option<(String, String, DevqlTaskKind, DevqlTaskSource)> = None;
         self.mutate_state(|state| {
             let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
@@ -321,6 +324,44 @@ impl DevqlTaskCoordinator {
         if let Some((task_id, repo_id, kind, source)) = task_context {
             log::error!(
                 "DevQL task failed: id={} repo={} kind={} source={} error={}",
+                task_id,
+                repo_id,
+                kind,
+                source,
+                error
+            );
+        }
+        Ok(())
+    }
+
+    fn requeue_task_after_cancelled_join(&self, task_id: &str, error: &str) -> Result<()> {
+        let task_id = task_id.to_string();
+        let error = error.to_string();
+        let mut task_context: Option<(String, String, DevqlTaskKind, DevqlTaskSource)> = None;
+        self.mutate_state(|state| {
+            let Some(task) = state.tasks.iter_mut().find(|task| task.task_id == task_id) else {
+                return Ok(());
+            };
+            task.status = DevqlTaskStatus::Queued;
+            task.started_at_unix = None;
+            task.completed_at_unix = None;
+            task.updated_at_unix = unix_timestamp_now();
+            task.error = None;
+            task.result = None;
+            task.progress = default_progress_for_spec(&task.spec);
+            task_context = Some((
+                task.task_id.clone(),
+                task.repo_id.clone(),
+                task.kind,
+                task.source,
+            ));
+            state.last_action = Some("requeued".to_string());
+            Ok(())
+        })
+        .map(|_: ()| ())?;
+        if let Some((task_id, repo_id, kind, source)) = task_context {
+            log::warn!(
+                "DevQL task requeued after cancelled join: id={} repo={} kind={} source={} error={}",
                 task_id,
                 repo_id,
                 kind,
@@ -485,4 +526,11 @@ impl DevqlTaskCoordinator {
         };
         hub.publish_checkpoint(repo_name, checkpoint);
     }
+}
+
+fn is_cancelled_join_error(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("joining ")
+        && lower.contains(" task: task ")
+        && (lower.contains(" was cancelled") || lower.contains(" was canceled"))
 }

--- a/bitloops/src/daemon/tasks/coordinator_tests.rs
+++ b/bitloops/src/daemon/tasks/coordinator_tests.rs
@@ -963,3 +963,82 @@ fn daemon_devql_task_execution_logs_terminal_failure() {
         "expected terminal task failure log, got logs: {logs:?}"
     );
 }
+
+#[test]
+fn daemon_devql_task_execution_requeues_cancelled_sqlite_join() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_root = dir.path().join("config");
+    let repo_root = dir.path().join("repo");
+    std::fs::create_dir_all(&config_root).expect("create config root");
+    std::fs::create_dir_all(&repo_root).expect("create repo root");
+
+    crate::test_support::git_fixtures::init_test_repo(
+        &repo_root,
+        "main",
+        "Bitloops Test",
+        "bitloops-test@example.com",
+    );
+    crate::test_support::git_fixtures::write_test_daemon_config(&config_root);
+
+    let repo = crate::host::devql::resolve_repo_identity(&repo_root).expect("resolve repo");
+    let cfg = DevqlConfig::from_roots(config_root.clone(), repo_root.clone(), repo)
+        .expect("build devql config");
+    let coordinator = Arc::new(DevqlTaskCoordinator {
+        runtime_store: DaemonSqliteRuntimeStore::open_at(dir.path().join("daemon-runtime.sqlite"))
+            .expect("open daemon runtime store"),
+        lock: Mutex::new(()),
+        notify: Notify::new(),
+        worker_started: AtomicBool::new(false),
+        subscription_hub: Mutex::new(None),
+    });
+    let task = coordinator
+        .enqueue(
+            &cfg,
+            DevqlTaskSource::PostMerge,
+            DevqlTaskSpec::Ingest(crate::daemon::IngestTaskSpec {
+                commits: vec!["8f1545adecc86036ed9c8f252edcc099f7016103".to_string()],
+                backfill: None,
+            }),
+        )
+        .expect("enqueue ingest task")
+        .task;
+
+    coordinator
+        .mutate_state(|state| {
+            let task = state
+                .tasks
+                .iter_mut()
+                .find(|candidate| candidate.task_id == task.task_id)
+                .expect("queued task should exist");
+            let now = unix_timestamp_now();
+            task.status = DevqlTaskStatus::Running;
+            task.started_at_unix = Some(now);
+            task.updated_at_unix = now;
+            Ok(())
+        })
+        .expect("mark task running");
+
+    let (result, logs) = capture_logs(|| {
+        coordinator.finish_task_failed(
+            &task.task_id,
+            anyhow::anyhow!("joining SQLite query task: task 16152 was cancelled"),
+        )
+    });
+
+    result.expect("finish task failed should requeue transient cancellation");
+    let task = coordinator
+        .task(&task.task_id)
+        .expect("load task")
+        .expect("task should remain in queue");
+    assert_eq!(task.status, DevqlTaskStatus::Queued);
+    assert!(task.started_at_unix.is_none());
+    assert!(task.completed_at_unix.is_none());
+    assert!(task.error.is_none());
+    assert!(
+        !logs
+            .iter()
+            .any(|entry| entry.level == log::Level::Error
+                && entry.message.contains("DevQL task failed")),
+        "cooperative cancellation should not log terminal failure, got logs: {logs:?}"
+    );
+}


### PR DESCRIPTION
Task: https://bitloops.atlassian.net/browse/CLI-1848
## Summary

- Requeue DevQL tasks when the failure is a cancelled SQLite join from daemon shutdown.
- Clear running/completion/error state and reset progress before retrying the task.
- Keep normal execution failures on the existing terminal `failed` path.
- Add a regression test for the cancelled SQLite join transition.

## Root Cause

DevQL ingest work is tracked as a task that moves through `queued -> running -> completed/failed`. When the daemon stops while ingest is doing SQLite work, Tokio can cancel the worker task and return an error like:

```text
joining SQLite query task: task 16152 was cancelled
```

That is not an ingest data failure. It means the daemon stopped while this background SQLite job was still running.

Before this change, the coordinator treated every error the same and persisted the task as `failed`. On daemon restart, recovery only requeues tasks that are still `running`, so an already-`failed` task stayed failed forever.

## Fix

The task failure handler now recognizes cancelled join errors: `joining ... task: task ... was cancelled` and `joining ... task: task ... was canceled`. For those errors only, it requeues the task, clears transient execution state, resets progress, and logs a warning instead of a terminal `DevQL task failed` error.

## Validation

- `cargo nextest run --manifest-path bitloops/Cargo.toml -p bitloops --lib daemon::tasks::coordinator::tests::daemon_devql_task_execution --no-capture`
- `git diff --check`
