### PR TITLE
Cli 1898 bitloops init skips oversized generated files in semantic summary pipeline warning

### DIFF
--- a/bitloops/src/adapters/languages/ts_js/extraction.rs
+++ b/bitloops/src/adapters/languages/ts_js/extraction.rs
@@ -397,9 +397,12 @@ pub(crate) fn extract_js_ts_docstring(node: tree_sitter::Node, content: &str) ->
             if start < 0 {
                 break;
             }
-            blocks.push(normalize_js_ts_block_comment_block(
-                &lines[start as usize..=line_idx as usize],
-            ));
+            let Some(block) =
+                normalize_js_ts_block_comment_block(&lines[start as usize..=line_idx as usize])
+            else {
+                return None;
+            };
+            blocks.push(block);
             line_idx = start - 1;
             continue;
         }
@@ -463,29 +466,37 @@ pub(crate) fn normalize_js_ts_line_comment_block(lines: &[&str]) -> String {
         .to_string()
 }
 
-pub(crate) fn normalize_js_ts_block_comment_block(lines: &[&str]) -> String {
-    let mut normalized = Vec::new();
-    for (index, line) in lines.iter().enumerate() {
-        let mut text = line.trim().to_string();
-        if index == 0 {
-            text = text
-                .trim_start_matches('/')
-                .trim_start_matches('*')
-                .trim_start_matches('*')
-                .trim()
-                .to_string();
-        }
-        if index + 1 == lines.len() {
-            text = text
-                .trim_end_matches('/')
-                .trim_end_matches('*')
-                .trim()
-                .to_string();
-        }
-        text = text.trim_start_matches('*').trim().to_string();
-        normalized.push(text);
+pub(crate) fn normalize_js_ts_block_comment_block(lines: &[&str]) -> Option<String> {
+    let first = lines.first()?.trim();
+    let last = lines.last()?.trim();
+
+    let opening_index = first.find("/*")?;
+    if !first[..opening_index].trim().is_empty() {
+        return None;
     }
-    normalized.join("\n").trim().to_string()
+
+    let closing_index = last.rfind("*/")?;
+    if !last[closing_index + 2..].trim().is_empty() {
+        return None;
+    }
+
+    let joined = lines.join("\n");
+    let start = joined.find("/*")? + 2;
+    let end = joined.rfind("*/")?;
+    if end < start {
+        return None;
+    }
+
+    let inner = &joined[start..end];
+    Some(
+        inner
+            .lines()
+            .map(|line| line.trim().trim_start_matches('*').trim().to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string(),
+    )
 }
 
 pub(crate) fn is_js_ts_top_level_variable(node: tree_sitter::Node) -> bool {
@@ -506,4 +517,85 @@ pub(crate) fn is_js_ts_top_level_variable(node: tree_sitter::Node) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_js_ts_artefacts;
+
+    fn docstring_for_first_artefact(source: &str) -> Option<String> {
+        extract_js_ts_artefacts(source, "src/example.js")
+            .expect("ts/js extraction should succeed")
+            .into_iter()
+            .next()
+            .and_then(|artefact| artefact.docstring)
+    }
+
+    #[test]
+    fn extract_js_ts_docstring_keeps_standalone_jsdoc_block() {
+        let source = r#"/**
+ * Normalizes email text.
+ * Keeps trailing spaces out.
+ */
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}"#;
+
+        let docstring =
+            docstring_for_first_artefact(source).expect("expected docstring for standalone jsdoc");
+
+        assert!(docstring.contains("Normalizes email text."));
+        assert!(docstring.contains("Keeps trailing spaces out."));
+    }
+
+    #[test]
+    fn extract_js_ts_docstring_keeps_single_line_jsdoc_block() {
+        let source = r#"/** Normalizes email text. */
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}"#;
+
+        assert_eq!(
+            docstring_for_first_artefact(source).as_deref(),
+            Some("Normalizes email text.")
+        );
+    }
+
+    #[test]
+    fn extract_js_ts_docstring_rejects_block_comment_with_trailing_code_on_closing_line() {
+        let source = r#"/**
+ * helper text
+ */function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}"#;
+
+        assert_eq!(docstring_for_first_artefact(source), None);
+    }
+
+    #[test]
+    fn extract_js_ts_docstring_rejects_block_comment_with_leading_code_on_opening_line() {
+        let source = r#"const marker = 1; /**
+ * helper text
+ */
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}"#;
+
+        assert_eq!(docstring_for_first_artefact(source), None);
+    }
+
+    #[test]
+    fn extract_js_ts_docstring_keeps_contiguous_line_comments() {
+        let source = r#"// Normalizes email text.
+// Keeps trailing spaces out.
+function normalizeEmail(email) {
+  return email.trim().toLowerCase();
+}"#;
+
+        let docstring = docstring_for_first_artefact(source)
+            .expect("expected docstring for contiguous line comments");
+
+        assert!(docstring.contains("Normalizes email text."));
+        assert!(docstring.contains("Keeps trailing spaces out."));
+    }
 }

--- a/bitloops/src/adapters/languages/ts_js/extraction.rs
+++ b/bitloops/src/adapters/languages/ts_js/extraction.rs
@@ -397,11 +397,8 @@ pub(crate) fn extract_js_ts_docstring(node: tree_sitter::Node, content: &str) ->
             if start < 0 {
                 break;
             }
-            let Some(block) =
-                normalize_js_ts_block_comment_block(&lines[start as usize..=line_idx as usize])
-            else {
-                return None;
-            };
+            let block =
+                normalize_js_ts_block_comment_block(&lines[start as usize..=line_idx as usize])?;
             blocks.push(block);
             line_idx = start - 1;
             continue;

--- a/bitloops/src/capability_packs/semantic_clones/features/semantic.rs
+++ b/bitloops/src/capability_packs/semantic_clones/features/semantic.rs
@@ -4,6 +4,8 @@ use super::common::{normalize_repo_path, render_dependency_context, split_identi
 use super::{MAX_SUMMARY_BODY_CHARS, SemanticFeatureInput};
 
 const MINIMUM_SUMMARY_LENGTH: usize = 12;
+const MAX_SUMMARY_SIGNATURE_CHARS: usize = 500;
+const MAX_SUMMARY_DOCSTRING_CHARS: usize = 1_000;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemanticSummaryCandidate {
@@ -81,14 +83,11 @@ impl SemanticSummaryProvider for DeterministicFallbackSummaryProvider {
 }
 
 fn build_semantic_summary_prompt(input: &SemanticFeatureInput) -> String {
-    let body = input.body.trim();
-    let body = if body.chars().count() > MAX_SUMMARY_BODY_CHARS {
-        body.chars()
-            .take(MAX_SUMMARY_BODY_CHARS)
-            .collect::<String>()
-    } else {
-        body.to_string()
-    };
+    let body = normalize_summary_prompt_field(Some(input.body.as_str()), MAX_SUMMARY_BODY_CHARS);
+    let signature =
+        normalize_summary_prompt_field(input.signature.as_deref(), MAX_SUMMARY_SIGNATURE_CHARS);
+    let docstring =
+        normalize_summary_prompt_field(input.docstring.as_deref(), MAX_SUMMARY_DOCSTRING_CHARS);
 
     let dependency_context = render_dependency_context(&input.dependency_signals);
 
@@ -118,13 +117,21 @@ body:\n{body}",
         path = normalize_repo_path(&input.path),
         symbol_fqn = input.symbol_fqn,
         name = input.name,
-        signature = input.signature.as_deref().unwrap_or(""),
+        signature = signature,
         modifiers = input.modifiers.join(", "),
-        docstring = input.docstring.as_deref().unwrap_or(""),
+        docstring = docstring,
         parent_kind = input.parent_kind.as_deref().unwrap_or(""),
         dependencies = dependency_context,
         body = body,
     )
+}
+
+fn normalize_summary_prompt_field(value: Option<&str>, max_chars: usize) -> String {
+    let trimmed = value.unwrap_or("").trim();
+    if trimmed.chars().count() <= max_chars {
+        return trimmed.to_string();
+    }
+    trimmed.chars().take(max_chars).collect()
 }
 
 fn parse_semantic_summary_candidate_text(content: &str) -> Option<String> {
@@ -539,6 +546,38 @@ mod tests {
             .nth(1)
             .expect("prompt should include body section");
         assert_eq!(body_section.chars().count(), MAX_SUMMARY_BODY_CHARS);
+    }
+
+    #[test]
+    fn semantic_features_prompt_truncates_signature_and_docstring() {
+        let mut input = sample_input("function", "normalizeEmail");
+        input.signature = Some("s".repeat(650));
+        input.docstring = Some("d".repeat(1_250));
+
+        let prompt = build_semantic_summary_prompt(&input);
+        let signature_line = prompt
+            .lines()
+            .find(|line| line.starts_with("signature: "))
+            .expect("prompt should include signature");
+        let docstring_line = prompt
+            .lines()
+            .find(|line| line.starts_with("docstring: "))
+            .expect("prompt should include docstring");
+
+        assert_eq!(
+            signature_line
+                .trim_start_matches("signature: ")
+                .chars()
+                .count(),
+            500
+        );
+        assert_eq!(
+            docstring_line
+                .trim_start_matches("docstring: ")
+                .chars()
+                .count(),
+            1_000
+        );
     }
 
     #[test]

--- a/bitloops/src/capability_packs/semantic_clones/features/semantic_features.rs
+++ b/bitloops/src/capability_packs/semantic_clones/features/semantic_features.rs
@@ -220,7 +220,7 @@ fn is_typescript_output_javascript_artefact(input: &SemanticFeatureInput) -> boo
         };
         segment
             .to_str()
-            .is_some_and(|value| matches_output_directory_segment(value))
+            .is_some_and(matches_output_directory_segment)
     })
 }
 

--- a/bitloops/src/capability_packs/semantic_clones/features/semantic_features.rs
+++ b/bitloops/src/capability_packs/semantic_clones/features/semantic_features.rs
@@ -203,7 +203,29 @@ pub fn is_semantic_enrichment_candidate(input: &SemanticFeatureInput) -> bool {
     if input.canonical_kind.eq_ignore_ascii_case("import") {
         return false;
     }
+    if is_typescript_output_javascript_artefact(input) {
+        return false;
+    }
     true
+}
+
+fn is_typescript_output_javascript_artefact(input: &SemanticFeatureInput) -> bool {
+    if !input.language.eq_ignore_ascii_case("javascript") {
+        return false;
+    }
+
+    Path::new(&input.path).components().any(|component| {
+        let std::path::Component::Normal(segment) = component else {
+            return false;
+        };
+        segment
+            .to_str()
+            .is_some_and(|value| matches_output_directory_segment(value))
+    })
+}
+
+fn matches_output_directory_segment(segment: &str) -> bool {
+    matches!(segment, "dist" | "out" | "build")
 }
 
 fn build_semantic_feature_input_from_artefact(
@@ -716,6 +738,174 @@ mod tests {
 
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].artefact_id, "artefact-1");
+    }
+
+    #[test]
+    fn semantic_features_exclude_javascript_inside_dist_output_folder() {
+        let input = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "packages/web/dist/index.js".to_string(),
+            language: "javascript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function_declaration".to_string(),
+            symbol_fqn: "packages/web/dist/index.js::render".to_string(),
+            name: "render".to_string(),
+            signature: Some("function render() {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return view;".to_string(),
+            docstring: None,
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec![],
+            content_hash: Some("hash-1".to_string()),
+        };
+
+        assert!(
+            !is_semantic_enrichment_candidate(&input),
+            "javascript artefacts inside dist should be excluded"
+        );
+    }
+
+    #[test]
+    fn semantic_features_exclude_javascript_inside_out_output_folder() {
+        let input = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "packages/web/out/index.js".to_string(),
+            language: "javascript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function_declaration".to_string(),
+            symbol_fqn: "packages/web/out/index.js::render".to_string(),
+            name: "render".to_string(),
+            signature: Some("function render() {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return view;".to_string(),
+            docstring: None,
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec![],
+            content_hash: Some("hash-1".to_string()),
+        };
+
+        assert!(
+            !is_semantic_enrichment_candidate(&input),
+            "javascript artefacts inside out should be excluded"
+        );
+    }
+
+    #[test]
+    fn semantic_features_exclude_javascript_inside_build_output_folder() {
+        let input = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "packages/web/build/index.js".to_string(),
+            language: "javascript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function_declaration".to_string(),
+            symbol_fqn: "packages/web/build/index.js::render".to_string(),
+            name: "render".to_string(),
+            signature: Some("function render() {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return view;".to_string(),
+            docstring: None,
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec![],
+            content_hash: Some("hash-1".to_string()),
+        };
+
+        assert!(
+            !is_semantic_enrichment_candidate(&input),
+            "javascript artefacts inside build should be excluded"
+        );
+    }
+
+    #[test]
+    fn semantic_features_keep_typescript_inside_dist_output_folder() {
+        let input = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "packages/web/dist/index.ts".to_string(),
+            language: "typescript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function_declaration".to_string(),
+            symbol_fqn: "packages/web/dist/index.ts::render".to_string(),
+            name: "render".to_string(),
+            signature: Some("function render() {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return view;".to_string(),
+            docstring: None,
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec![],
+            content_hash: Some("hash-1".to_string()),
+        };
+
+        assert!(
+            is_semantic_enrichment_candidate(&input),
+            "typescript artefacts should not be excluded by the javascript output-folder heuristic"
+        );
+    }
+
+    #[test]
+    fn semantic_features_keep_javascript_outside_output_folders() {
+        let input = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "packages/web/src/index.js".to_string(),
+            language: "javascript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function_declaration".to_string(),
+            symbol_fqn: "packages/web/src/index.js::render".to_string(),
+            name: "render".to_string(),
+            signature: Some("function render() {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return view;".to_string(),
+            docstring: None,
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec![],
+            content_hash: Some("hash-1".to_string()),
+        };
+
+        assert!(
+            is_semantic_enrichment_candidate(&input),
+            "javascript artefacts in normal source folders should remain eligible"
+        );
+    }
+
+    #[test]
+    fn semantic_features_keep_paths_with_output_substrings_but_no_matching_segment() {
+        let input = SemanticFeatureInput {
+            artefact_id: "artefact-1".to_string(),
+            symbol_id: Some("symbol-1".to_string()),
+            repo_id: "repo-1".to_string(),
+            blob_sha: "blob-1".to_string(),
+            path: "packages/web/src/building-blocks/index.js".to_string(),
+            language: "javascript".to_string(),
+            canonical_kind: "function".to_string(),
+            language_kind: "function_declaration".to_string(),
+            symbol_fqn: "packages/web/src/building-blocks/index.js::render".to_string(),
+            name: "render".to_string(),
+            signature: Some("function render() {".to_string()),
+            modifiers: vec!["export".to_string()],
+            body: "return view;".to_string(),
+            docstring: None,
+            parent_kind: Some("file".to_string()),
+            dependency_signals: vec![],
+            content_hash: Some("hash-1".to_string()),
+        };
+
+        assert!(
+            is_semantic_enrichment_candidate(&input),
+            "only full path segments should trigger the output-folder heuristic"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix the semantic summary overflow behind `CLI-1898` and `CLI-1906`.

The root cause was two fold:
- the summary prompt bounded `body` but left `signature` and `docstring` unbounded
- JS/TS extraction could misread generated/minified code as a giant docstring

This change hardens the summary prompt, tightens JS/TS docstring extraction, and skips obvious TypeScript build output JavaScript before semantic enrichment.

## Changes

- Bound all summary prompt inputs before sending them to the LLM:
  - `body`: `2000` chars
  - `signature`: `500` chars
  - `docstring`: `1000` chars
- Added a shared prompt-field normalization helper for trimming and truncation.
- Tightened JS/TS block-comment docstring extraction so a block comment is treated as a docstring only when it is an isolated comment block immediately above the symbol.
- Rejected malformed block-comment cases where code appears before `/*` or after `*/`.
- Updated block-comment normalization to capture only text inside `/* ... */`.
- Preserved valid existing JS/TS doc comment behavior for:
  - multi-line JSDoc
  - single-line `/** ... */`
  - contiguous `//` comment blocks
- Added a semantic-enrichment candidate helper that skips `javascript` artefacts only when they are inside full path segments named `dist`, `out`, or `build`.
- Kept original TypeScript source files eligible, even if they live under those folders.
- Fixed follow-up clippy warnings from the new code.

## Validation

- [x] I ran the relevant tests locally.
- [x] Linked Jira issue(s) are updated with implementation notes and test results.
- [x] Final status transitions match the task definition of done.

