### PR TITLE
CLI-1915 Error: Bitloops daemon did not become ready within 45 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Failed daemon startup no longer leaves the spawned daemon process running**: detached and service-managed daemon starts now stop the process they just spawned when readiness times out, preventing orphaned `bitloops` processes from holding local DuckDB event-store locks after startup failure.
+
 - **Dashboard config saves now apply safe daemon changes without a manual restart**: daemon `config.toml` saves now validate, atomically write, and immediately hot-reload reloadable fields such as inference profiles and capability bindings for future work. Structural changes still schedule a deduplicated delayed daemon restart, and the daemon watches the config directory so manual TOML edits go through the same reload-or-restart decision path.
 
 - **Init and configure semantic setup now match the repo-local config split**: `bitloops configure` writes the default daemon config, starts or restarts the always-on daemon by default, and avoids opening store databases during configuration so DuckDB event-store locks from a running daemon do not block setup. `bitloops init` now keeps final setup focused on sync/ingest while restoring separate interactive setup choices for code embeddings, semantic summaries, and summary embeddings. Summary embeddings can be configured and run independently of code embeddings, so skipping code embeddings no longer hides the summary-embeddings prompt or lane.

--- a/bitloops/src/daemon/lifecycle.rs
+++ b/bitloops/src/daemon/lifecycle.rs
@@ -92,7 +92,7 @@ pub(super) async fn start_detached(
         })?;
         let child_pid = child.id();
         log::debug!("spawned detached daemon pid={child_pid}");
-        wait_until_ready_for_spawned_daemon(child_pid, "detached", READY_TIMEOUT).await
+        wait_until_ready_for_spawned_daemon(child, "detached", READY_TIMEOUT).await
     }
     .await;
     if let Err(err) = &result {
@@ -352,24 +352,52 @@ pub(super) async fn wait_until_ready(timeout: Duration) -> Result<DaemonRuntimeS
 }
 
 pub(super) async fn wait_until_ready_for_spawned_daemon(
-    pid: u32,
+    mut child: std::process::Child,
     launch_mode: &str,
     timeout: Duration,
 ) -> Result<DaemonRuntimeState> {
-    match wait_until_ready(timeout).await {
-        Ok(state) => Ok(state),
-        Err(err) => {
+    let pid = child.id();
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .with_context(|| format!("checking spawned {launch_mode} daemon pid={pid} status"))?
+        {
+            if let Err(cleanup_err) =
+                cleanup_spawned_daemon_after_startup_failure(&mut child, launch_mode)
+            {
+                log::warn!(
+                    "failed to clean runtime state after spawned {launch_mode} daemon pid={pid} exited before readiness: {cleanup_err:#}"
+                );
+            }
+            bail!("spawned {launch_mode} daemon pid={pid} exited before becoming ready: {status}");
+        }
+
+        if started.elapsed() > timeout {
+            let err = anyhow::anyhow!(
+                "Bitloops daemon did not become ready within {} seconds",
+                timeout.as_secs()
+            );
             log::warn!(
                 "spawned {launch_mode} daemon pid={pid} failed to become ready; stopping spawned process before returning startup failure: {err:#}"
             );
-            if let Err(cleanup_err) = cleanup_spawned_daemon_after_startup_failure(pid, launch_mode)
+            if let Err(cleanup_err) =
+                cleanup_spawned_daemon_after_startup_failure(&mut child, launch_mode)
             {
                 log::error!(
                     "failed to stop spawned {launch_mode} daemon pid={pid} after startup failure: {cleanup_err:#}"
                 );
             }
-            Err(err)
+            return Err(err);
         }
+
+        if let Some(state) = read_runtime_state(Path::new("."))?
+            && daemon_http_ready(&state).await
+        {
+            return Ok(state);
+        }
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
     }
 }
 

--- a/bitloops/src/daemon/lifecycle.rs
+++ b/bitloops/src/daemon/lifecycle.rs
@@ -90,8 +90,9 @@ pub(super) async fn start_detached(
                 daemon_config.config_path.display()
             )
         })?;
-        log::debug!("spawned detached daemon pid={}", child.id());
-        wait_until_ready(READY_TIMEOUT).await
+        let child_pid = child.id();
+        log::debug!("spawned detached daemon pid={child_pid}");
+        wait_until_ready_for_spawned_daemon(child_pid, "detached", READY_TIMEOUT).await
     }
     .await;
     if let Err(err) = &result {
@@ -347,6 +348,28 @@ pub(super) async fn wait_until_ready(timeout: Duration) -> Result<DaemonRuntimeS
         }
 
         tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+pub(super) async fn wait_until_ready_for_spawned_daemon(
+    pid: u32,
+    launch_mode: &str,
+    timeout: Duration,
+) -> Result<DaemonRuntimeState> {
+    match wait_until_ready(timeout).await {
+        Ok(state) => Ok(state),
+        Err(err) => {
+            log::warn!(
+                "spawned {launch_mode} daemon pid={pid} failed to become ready; stopping spawned process before returning startup failure: {err:#}"
+            );
+            if let Err(cleanup_err) = cleanup_spawned_daemon_after_startup_failure(pid, launch_mode)
+            {
+                log::error!(
+                    "failed to stop spawned {launch_mode} daemon pid={pid} after startup failure: {cleanup_err:#}"
+                );
+            }
+            Err(err)
+        }
     }
 }
 

--- a/bitloops/src/daemon/process.rs
+++ b/bitloops/src/daemon/process.rs
@@ -349,11 +349,16 @@ pub(super) fn terminate_process_and_wait_for_shutdown_cleanup(
 }
 
 pub(super) fn cleanup_spawned_daemon_after_startup_failure(
-    pid: u32,
+    child: &mut std::process::Child,
     launch_mode: &str,
 ) -> Result<()> {
-    if !process_is_running(pid)? {
-        log::debug!("spawned {launch_mode} daemon pid={pid} exited before startup cleanup");
+    let pid = child.id();
+    if let Some(status) = child.try_wait().with_context(|| {
+        format!("checking spawned {launch_mode} daemon pid={pid} status before cleanup")
+    })? {
+        log::debug!(
+            "spawned {launch_mode} daemon pid={pid} exited before startup cleanup: {status}"
+        );
         if let Err(err) = read_runtime_state(Path::new(".")) {
             log::warn!(
                 "failed to inspect daemon runtime state after spawned {launch_mode} daemon pid={pid} exited: {err:#}"
@@ -362,8 +367,26 @@ pub(super) fn cleanup_spawned_daemon_after_startup_failure(
         return Ok(());
     }
 
-    terminate_process_and_wait_for_shutdown_cleanup(
-        pid,
+    if let Err(err) = terminate_process(pid) {
+        if child
+            .try_wait()
+            .with_context(|| {
+                format!(
+                    "checking spawned {launch_mode} daemon pid={pid} status after terminate failure"
+                )
+            })?
+            .is_none()
+        {
+            return Err(err);
+        }
+        log::debug!(
+            "spawned {launch_mode} daemon pid={pid} exited before terminate completed: {err:#}"
+        );
+    }
+
+    wait_for_spawned_child_shutdown_cleanup(
+        child,
+        launch_mode,
         STOP_TIMEOUT,
         STOP_RUNTIME_CLEAN_EXIT_GRACE,
         FORCE_KILL_TIMEOUT,
@@ -417,6 +440,119 @@ fn force_kill_process(pid: u32) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn wait_for_spawned_child_shutdown_cleanup(
+    child: &mut std::process::Child,
+    launch_mode: &str,
+    timeout: Duration,
+    runtime_clean_exit_grace: Duration,
+    force_kill_timeout: Duration,
+) -> Result<()> {
+    let pid = child.id();
+    let graceful_started = Instant::now();
+    let mut runtime_cleaned_since = None::<Instant>;
+    let mut force_kill_started = None::<Instant>;
+
+    loop {
+        let status = spawned_child_shutdown_cleanup_status(child)?;
+        if status.complete() {
+            return Ok(());
+        }
+
+        if let Some(force_started) = force_kill_started {
+            if status.process_exited {
+                cleanup_stale_runtime_state_after_forced_shutdown(status);
+                return Ok(());
+            }
+            if force_started.elapsed() > force_kill_timeout {
+                bail!(
+                    "Bitloops daemon did not shut down after forced termination (process_exited={}, runtime_cleaned={})",
+                    status.process_exited,
+                    status.runtime_cleaned
+                );
+            }
+        } else {
+            if status.runtime_cleaned && !status.process_exited {
+                let cleaned_since = runtime_cleaned_since.get_or_insert_with(Instant::now);
+                if cleaned_since.elapsed() >= runtime_clean_exit_grace {
+                    log::warn!(
+                        "spawned {launch_mode} daemon process {pid} remained alive for {:?} after runtime cleanup; forcing termination",
+                        runtime_clean_exit_grace
+                    );
+                    force_kill_spawned_child(child, launch_mode)?;
+                    force_kill_started = Some(Instant::now());
+                    continue;
+                }
+            } else {
+                runtime_cleaned_since = None;
+            }
+
+            if graceful_started.elapsed() > timeout {
+                if !status.process_exited {
+                    log::warn!(
+                        "spawned {launch_mode} daemon process {pid} exceeded startup cleanup timeout of {:?}; forcing termination (runtime_cleaned={})",
+                        timeout,
+                        status.runtime_cleaned
+                    );
+                    force_kill_spawned_child(child, launch_mode)?;
+                    force_kill_started = Some(Instant::now());
+                    continue;
+                }
+
+                cleanup_stale_runtime_state_after_forced_shutdown(status);
+                return Ok(());
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn spawned_child_shutdown_cleanup_status(
+    child: &mut std::process::Child,
+) -> Result<ShutdownCleanupStatus> {
+    Ok(ShutdownCleanupStatus {
+        process_exited: child
+            .try_wait()
+            .context("checking spawned Bitloops daemon process")?
+            .is_some(),
+        runtime_cleaned: read_runtime_state(Path::new("."))?.is_none(),
+    })
+}
+
+fn force_kill_spawned_child(child: &mut std::process::Child, launch_mode: &str) -> Result<()> {
+    let pid = child.id();
+    if child
+        .try_wait()
+        .with_context(|| {
+            format!("checking spawned {launch_mode} daemon pid={pid} status before force kill")
+        })?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    match child.kill() {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            if child
+                .try_wait()
+                .with_context(|| {
+                    format!(
+                        "checking spawned {launch_mode} daemon pid={pid} status after force kill failure"
+                    )
+                })?
+                .is_some()
+            {
+                Ok(())
+            } else {
+                Err(err).with_context(|| {
+                    format!("force-killing spawned {launch_mode} daemon pid={pid}")
+                })
+            }
+        }
+    }
 }
 
 #[cfg(unix)]

--- a/bitloops/src/daemon/process.rs
+++ b/bitloops/src/daemon/process.rs
@@ -348,6 +348,28 @@ pub(super) fn terminate_process_and_wait_for_shutdown_cleanup(
     )
 }
 
+pub(super) fn cleanup_spawned_daemon_after_startup_failure(
+    pid: u32,
+    launch_mode: &str,
+) -> Result<()> {
+    if !process_is_running(pid)? {
+        log::debug!("spawned {launch_mode} daemon pid={pid} exited before startup cleanup");
+        if let Err(err) = read_runtime_state(Path::new(".")) {
+            log::warn!(
+                "failed to inspect daemon runtime state after spawned {launch_mode} daemon pid={pid} exited: {err:#}"
+            );
+        }
+        return Ok(());
+    }
+
+    terminate_process_and_wait_for_shutdown_cleanup(
+        pid,
+        STOP_TIMEOUT,
+        STOP_RUNTIME_CLEAN_EXIT_GRACE,
+        FORCE_KILL_TIMEOUT,
+    )
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ShutdownCleanupStatus {
     process_exited: bool,

--- a/bitloops/src/daemon/server_runtime.rs
+++ b/bitloops/src/daemon/server_runtime.rs
@@ -203,14 +203,21 @@ pub(super) async fn ensure_service_managed_repo_runtime(
         .stdout(Stdio::null())
         .stderr(Stdio::null());
 
-    command.spawn().with_context(|| {
+    let child = command.spawn().with_context(|| {
         format!(
             "spawning service-managed Bitloops daemon for {}",
             daemon_config.config_path.display()
         )
     })?;
+    let child_pid = child.id();
+    log::debug!("spawned service-managed daemon pid={child_pid}");
 
-    wait_until_ready(READY_TIMEOUT).await
+    super::lifecycle::wait_until_ready_for_spawned_daemon(
+        child_pid,
+        "service-managed",
+        READY_TIMEOUT,
+    )
+    .await
 }
 
 pub(super) fn stop_service_managed_repo_runtime() -> Result<()> {

--- a/bitloops/src/daemon/server_runtime.rs
+++ b/bitloops/src/daemon/server_runtime.rs
@@ -212,12 +212,8 @@ pub(super) async fn ensure_service_managed_repo_runtime(
     let child_pid = child.id();
     log::debug!("spawned service-managed daemon pid={child_pid}");
 
-    super::lifecycle::wait_until_ready_for_spawned_daemon(
-        child_pid,
-        "service-managed",
-        READY_TIMEOUT,
-    )
-    .await
+    super::lifecycle::wait_until_ready_for_spawned_daemon(child, "service-managed", READY_TIMEOUT)
+        .await
 }
 
 pub(super) fn stop_service_managed_repo_runtime() -> Result<()> {

--- a/bitloops/src/daemon/tests.rs
+++ b/bitloops/src/daemon/tests.rs
@@ -79,6 +79,38 @@ fn spawn_detached_long_lived_process() -> u32 {
         .expect("detached pid should parse")
 }
 
+#[cfg(unix)]
+fn spawn_long_lived_child_process() -> std::process::Child {
+    std::process::Command::new("sh")
+        .args(["-c", "exec sleep 60"])
+        .spawn()
+        .expect("spawn long-lived child process")
+}
+
+#[cfg(windows)]
+fn spawn_long_lived_child_process() -> std::process::Child {
+    std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", "Start-Sleep -Seconds 60"])
+        .spawn()
+        .expect("spawn long-lived child process")
+}
+
+#[cfg(unix)]
+fn spawn_exiting_child_process() -> std::process::Child {
+    std::process::Command::new("sh")
+        .args(["-c", "exit 42"])
+        .spawn()
+        .expect("spawn exiting child process")
+}
+
+#[cfg(windows)]
+fn spawn_exiting_child_process() -> std::process::Child {
+    std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", "exit 42"])
+        .spawn()
+        .expect("spawn exiting child process")
+}
+
 fn wait_for_pid_exit(pid: u32) {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
@@ -187,16 +219,49 @@ async fn spawned_daemon_readiness_timeout_stops_spawned_process() {
         )],
     );
 
-    let pid = spawn_detached_long_lived_process();
-    let err = lifecycle::wait_until_ready_for_spawned_daemon(pid, "test", Duration::from_millis(1))
-        .await
-        .expect_err("readiness should time out without daemon runtime state");
+    let child = spawn_long_lived_child_process();
+    let pid = child.id();
+    let err =
+        lifecycle::wait_until_ready_for_spawned_daemon(child, "test", Duration::from_millis(1))
+            .await
+            .expect_err("readiness should time out without daemon runtime state");
     let message = err.to_string();
     assert!(
         message.contains("did not become ready"),
         "expected readiness timeout, got: {message}"
     );
     wait_for_pid_exit(pid);
+}
+
+#[tokio::test]
+async fn spawned_daemon_exits_before_readiness_fails_fast() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let state_root = TempDir::new().expect("temp state root");
+    let state_root_str = state_root.path().to_string_lossy().to_string();
+    let _guard = enter_process_state(
+        Some(cwd.path()),
+        &[(
+            "BITLOOPS_TEST_STATE_DIR_OVERRIDE",
+            Some(state_root_str.as_str()),
+        )],
+    );
+
+    let child = spawn_exiting_child_process();
+    let started = Instant::now();
+    let err =
+        lifecycle::wait_until_ready_for_spawned_daemon(child, "test", Duration::from_secs(30))
+            .await
+            .expect_err("child exit should fail readiness immediately");
+    let message = err.to_string();
+    assert!(
+        message.contains("exited before becoming ready"),
+        "expected child exit failure, got: {message}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "expected readiness to fail fast after child exit, elapsed={:?}",
+        started.elapsed()
+    );
 }
 
 #[test]

--- a/bitloops/src/daemon/tests.rs
+++ b/bitloops/src/daemon/tests.rs
@@ -174,6 +174,31 @@ async fn daemon_lifecycle_logs_terminal_restart_failure() {
     );
 }
 
+#[tokio::test]
+async fn spawned_daemon_readiness_timeout_stops_spawned_process() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let state_root = TempDir::new().expect("temp state root");
+    let state_root_str = state_root.path().to_string_lossy().to_string();
+    let _guard = enter_process_state(
+        Some(cwd.path()),
+        &[(
+            "BITLOOPS_TEST_STATE_DIR_OVERRIDE",
+            Some(state_root_str.as_str()),
+        )],
+    );
+
+    let pid = spawn_detached_long_lived_process();
+    let err = lifecycle::wait_until_ready_for_spawned_daemon(pid, "test", Duration::from_millis(1))
+        .await
+        .expect_err("readiness should time out without daemon runtime state");
+    let message = err.to_string();
+    assert!(
+        message.contains("did not become ready"),
+        "expected readiness timeout, got: {message}"
+    );
+    wait_for_pid_exit(pid);
+}
+
 #[test]
 fn supervisor_service_name_is_global_and_stable() {
     assert_eq!(GLOBAL_SUPERVISOR_SERVICE_NAME, "com.bitloops.daemon");


### PR DESCRIPTION
## Summary

Fixes #320 Implement daemon process cleanup on startup failure and enhance readiness checks. Update CHANGELOG to reflect changes in daemon behavior, ensuring spawned processes are terminated if they fail to become ready. Add tests for readiness timeout scenarios.
## Validation

- [X] I ran the relevant tests locally.
- [X] Linked Jira issue(s) are updated with implementation notes and test results.
