### PR TITLE
CLI-1918: fallback dashboard bundle install on 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Dashboard bundle install now falls back once when the newest compatible bundle archive 404s** (`CLI-1918`): `fetchBundle` now tries the next compatible `bundle_versions.json` entry when the selected archive returns HTTP 404, while preserving hard failures for checksum mismatches and limiting fallback to one older version.
+
 - **Dashboard config saves now apply safe daemon changes without a manual restart**: daemon `config.toml` saves now validate, atomically write, and immediately hot-reload reloadable fields such as inference profiles and capability bindings for future work. Structural changes still schedule a deduplicated delayed daemon restart, and the daemon watches the config directory so manual TOML edits go through the same reload-or-restart decision path.
 
 - **Init and configure semantic setup now match the repo-local config split**: `bitloops configure` writes the default daemon config, starts or restarts the always-on daemon by default, and avoids opening store databases during configuration so DuckDB event-store locks from a running daemon do not block setup. `bitloops init` now keeps final setup focused on sync/ingest while restoring separate interactive setup choices for code embeddings, semantic summaries, and summary embeddings. Summary embeddings can be configured and run independently of code embeddings, so skipping code embeddings no longer hides the summary-embeddings prompt or lane.

--- a/bitloops/src/api/bundle.rs
+++ b/bitloops/src/api/bundle.rs
@@ -69,24 +69,42 @@ pub(super) async fn fetch_bundle(
 ) -> Result<BundleInstallResult, BundleError> {
     let current_cli_version = current_cli_version()?;
     let manifest = fetch_manifest_for_state(state).await?;
-    let Some(resolved) =
-        resolve_latest_applicable_for_state(&manifest.versions, &current_cli_version, state)?
-    else {
+    let candidates =
+        resolve_applicable_versions_for_state(&manifest.versions, &current_cli_version, state)?;
+    if candidates.is_empty() {
         return Err(BundleError::NoCompatibleVersion);
     };
 
+    let mut latest_not_found = None;
+    for (attempt_index, resolved) in candidates.into_iter().take(2).enumerate() {
+        match install_resolved_bundle(&resolved, &state.bundle_dir).await {
+            Ok(()) => {
+                return Ok(BundleInstallResult {
+                    installed_version: resolved.version,
+                    bundle_dir: state.bundle_dir.display().to_string(),
+                    status: "installed".to_string(),
+                    checksum_verified: true,
+                });
+            }
+            Err(BundleError::BundleDownloadNotFound(message)) if attempt_index == 0 => {
+                latest_not_found = Some(BundleError::BundleDownloadNotFound(message));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(latest_not_found.unwrap_or(BundleError::NoCompatibleVersion))
+}
+
+async fn install_resolved_bundle(
+    resolved: &ResolvedBundleVersion,
+    bundle_dir: &Path,
+) -> Result<(), BundleError> {
     let archive_bytes = download_bytes(&resolved.download_url).await?;
     let checksum_payload = download_text(&resolved.checksum_url).await?;
     verify_sha256(&archive_bytes, &checksum_payload)?;
 
-    install_archive_atomically(&archive_bytes, &state.bundle_dir)?;
-
-    Ok(BundleInstallResult {
-        installed_version: resolved.version,
-        bundle_dir: state.bundle_dir.display().to_string(),
-        status: "installed".to_string(),
-        checksum_verified: true,
-    })
+    install_archive_atomically(&archive_bytes, bundle_dir)
 }
 
 fn current_cli_version() -> Result<Version, BundleError> {
@@ -234,6 +252,12 @@ async fn download_bytes(url: &str) -> Result<Vec<u8>, BundleError> {
         .map_err(|err| BundleError::BundleDownloadFailed(format!("GET {url} failed: {err}")))?;
 
     if !response.status().is_success() {
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(BundleError::BundleDownloadNotFound(format!(
+                "GET {url} returned {}",
+                response.status()
+            )));
+        }
         return Err(BundleError::BundleDownloadFailed(format!(
             "GET {url} returned {}",
             response.status()
@@ -271,12 +295,36 @@ fn resolve_latest_applicable_for_state(
     )
 }
 
+fn resolve_applicable_versions_for_state(
+    versions: &[BundleVersionEntry],
+    current_cli_version: &Version,
+    state: &DashboardState,
+) -> Result<Vec<ResolvedBundleVersion>, BundleError> {
+    resolve_applicable_versions_from_overrides(
+        versions,
+        current_cli_version,
+        Some(&state.bundle_source_overrides),
+    )
+}
+
 fn resolve_latest_applicable_from_overrides(
     versions: &[BundleVersionEntry],
     current_cli_version: &Version,
     overrides: Option<&crate::api::DashboardBundleSourceOverrides>,
 ) -> Result<Option<ResolvedBundleVersion>, BundleError> {
-    let mut best: Option<(Version, ResolvedBundleVersion)> = None;
+    Ok(
+        resolve_applicable_versions_from_overrides(versions, current_cli_version, overrides)?
+            .into_iter()
+            .next(),
+    )
+}
+
+fn resolve_applicable_versions_from_overrides(
+    versions: &[BundleVersionEntry],
+    current_cli_version: &Version,
+    overrides: Option<&crate::api::DashboardBundleSourceOverrides>,
+) -> Result<Vec<ResolvedBundleVersion>, BundleError> {
+    let mut compatible = Vec::new();
 
     for entry in versions {
         if !is_entry_compatible(entry, current_cli_version)? {
@@ -299,15 +347,14 @@ fn resolve_latest_applicable_from_overrides(
             checksum_url,
         };
 
-        match &best {
-            Some((best_version, _)) if parsed_version <= *best_version => {}
-            _ => {
-                best = Some((parsed_version, resolved));
-            }
-        }
+        compatible.push((parsed_version, resolved));
     }
 
-    Ok(best.map(|(_, resolved)| resolved))
+    compatible.sort_by(|(left, _), (right, _)| right.cmp(left));
+    Ok(compatible
+        .into_iter()
+        .map(|(_, resolved)| resolved)
+        .collect())
 }
 
 fn resolve_entry_url_from_overrides(

--- a/bitloops/src/api/bundle_types.rs
+++ b/bitloops/src/api/bundle_types.rs
@@ -68,6 +68,7 @@ pub(super) enum BundleError {
     ManifestFetchFailed(String),
     ManifestParseFailed(String),
     NoCompatibleVersion,
+    BundleDownloadNotFound(String),
     BundleDownloadFailed(String),
     ChecksumMismatch,
     BundleInstallFailed(String),

--- a/bitloops/src/api/dashboard_service/bundle.rs
+++ b/bitloops/src/api/dashboard_service/bundle.rs
@@ -124,6 +124,9 @@ fn map_bundle_error(error: BundleError) -> ApiError {
             "no_compatible_version",
             "no compatible dashboard bundle version is available for this CLI version",
         ),
+        BundleError::BundleDownloadNotFound(message) => {
+            ApiError::with_code(StatusCode::BAD_GATEWAY, "bundle_download_failed", message)
+        }
         BundleError::BundleDownloadFailed(message) => {
             ApiError::with_code(StatusCode::BAD_GATEWAY, "bundle_download_failed", message)
         }
@@ -148,6 +151,7 @@ fn bundle_error_code(error: &BundleError) -> &'static str {
         BundleError::ManifestFetchFailed(_) => "manifest_fetch_failed",
         BundleError::ManifestParseFailed(_) => "internal",
         BundleError::NoCompatibleVersion => "no_compatible_version",
+        BundleError::BundleDownloadNotFound(_) => "bundle_download_failed",
         BundleError::BundleDownloadFailed(_) => "bundle_download_failed",
         BundleError::ChecksumMismatch => "checksum_mismatch",
         BundleError::BundleInstallFailed(_) => "bundle_install_failed",

--- a/bitloops/src/api/tests/dashboard_api_bundle.rs
+++ b/bitloops/src/api/tests/dashboard_api_bundle.rs
@@ -26,6 +26,113 @@ fn dashboard_bundle_version_app(
     )
 }
 
+struct BundleHttpFixture {
+    status_code: u16,
+    content_type: &'static str,
+    body: Vec<u8>,
+}
+
+struct BundleHttpServer {
+    url: String,
+    routes: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, BundleHttpFixture>>>,
+    shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl BundleHttpServer {
+    fn start() -> Self {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind bundle fixture");
+        listener
+            .set_nonblocking(true)
+            .expect("configure nonblocking listener");
+        let url = format!("http://{}", listener.local_addr().expect("fixture address"));
+        let routes = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::<
+            String,
+            BundleHttpFixture,
+        >::new()));
+        let routes_for_thread = std::sync::Arc::clone(&routes);
+        let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let shutdown_for_thread = std::sync::Arc::clone(&shutdown);
+
+        let handle = std::thread::spawn(move || {
+            while !shutdown_for_thread.load(std::sync::atomic::Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buffer = [0_u8; 8192];
+                        let Ok(read) = std::io::Read::read(&mut stream, &mut buffer) else {
+                            continue;
+                        };
+                        let request = String::from_utf8_lossy(&buffer[..read]);
+                        let path = request
+                            .lines()
+                            .next()
+                            .and_then(|line| line.split_whitespace().nth(1))
+                            .unwrap_or("/");
+                        let routes = routes_for_thread.lock().expect("fixture routes");
+                        let (status_code, status_text, content_type, body) = match routes.get(path)
+                        {
+                            Some(fixture) => (
+                                fixture.status_code,
+                                status_text(fixture.status_code),
+                                fixture.content_type,
+                                fixture.body.clone(),
+                            ),
+                            None => (404, "Not Found", "text/plain", b"not found".to_vec()),
+                        };
+                        let response = format!(
+                            "HTTP/1.1 {status_code} {status_text}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        );
+                        let _ = std::io::Write::write_all(&mut stream, response.as_bytes());
+                        let _ = std::io::Write::write_all(&mut stream, &body);
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            url,
+            routes,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    fn insert(&self, path: &str, content_type: &'static str, body: impl Into<Vec<u8>>) {
+        self.routes.lock().expect("fixture routes").insert(
+            path.to_string(),
+            BundleHttpFixture {
+                status_code: 200,
+                content_type,
+                body: body.into(),
+            },
+        );
+    }
+}
+
+impl Drop for BundleHttpServer {
+    fn drop(&mut self) {
+        self.shutdown
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn status_text(status_code: u16) -> &'static str {
+    match status_code {
+        200 => "OK",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "Status",
+    }
+}
+
 fn dashboard_health_query() -> &'static str {
     r#"
     {
@@ -2013,6 +2120,71 @@ async fn dashboard_fetch_bundle_returns_checksum_mismatch() {
 }
 
 #[tokio::test]
+async fn dashboard_fetch_bundle_does_not_fallback_on_checksum_mismatch() {
+    let repo = seed_dashboard_repo();
+    let bundle_parent = TempDir::new().expect("bundle parent");
+    let bundle_dir = bundle_parent.path().join("bundle");
+    let cdn = TempDir::new().expect("cdn temp");
+    let latest_archive = build_bundle_archive("3.0.0");
+    let fallback_archive = build_bundle_archive("2.9.0");
+    let fallback_checksum = checksum_hex(&fallback_archive);
+    fs::write(cdn.path().join("bundle-3.0.0.tar.zst"), latest_archive)
+        .expect("write latest archive");
+    fs::write(
+        cdn.path().join("bundle-3.0.0.tar.zst.sha256"),
+        "0000000000000000000000000000000000000000000000000000000000000000  bundle-3.0.0.tar.zst\n",
+    )
+    .expect("write latest checksum");
+    fs::write(cdn.path().join("bundle-2.9.0.tar.zst"), fallback_archive)
+        .expect("write fallback archive");
+    fs::write(
+        cdn.path().join("bundle-2.9.0.tar.zst.sha256"),
+        format!("{fallback_checksum}  bundle-2.9.0.tar.zst\n"),
+    )
+    .expect("write fallback checksum");
+    fs::write(
+        cdn.path().join("bundle_versions.json"),
+        r#"{
+            "versions": [
+                {
+                    "version": "3.0.0",
+                    "min_required_cli_version": "0.0.1",
+                    "max_required_cli_version": "latest",
+                    "download_url": "bundle-3.0.0.tar.zst",
+                    "checksum_url": "bundle-3.0.0.tar.zst.sha256"
+                },
+                {
+                    "version": "2.9.0",
+                    "min_required_cli_version": "0.0.1",
+                    "max_required_cli_version": "latest",
+                    "download_url": "bundle-2.9.0.tar.zst",
+                    "checksum_url": "bundle-2.9.0.tar.zst.sha256"
+                }
+            ]
+        }"#,
+    )
+    .expect("write manifest");
+    let base_url = format!("file://{}/", cdn.path().display());
+    let app = build_dashboard_router(
+        test_state(
+            repo.path().to_path_buf(),
+            ServeMode::HelloWorld,
+            bundle_dir.clone(),
+        )
+        .with_bundle_source_overrides(dashboard_bundle_source_overrides_for_cdn(&base_url)),
+    );
+
+    let (_status, payload) =
+        request_dashboard_graphql(app, r#"mutation { fetchBundle { installedVersion } }"#).await;
+
+    assert_eq!(
+        payload["errors"][0]["extensions"]["code"], "checksum_mismatch",
+        "{payload:#}"
+    );
+    assert!(!bundle_dir.join("version.json").exists());
+}
+
+#[tokio::test]
 async fn dashboard_fetch_bundle_returns_no_compatible_version() {
     let repo = seed_dashboard_repo();
     let bundle_parent = TempDir::new().expect("bundle parent");
@@ -2054,6 +2226,135 @@ async fn dashboard_fetch_bundle_returns_bundle_download_failed() {
         payload["errors"][0]["extensions"]["code"],
         "bundle_download_failed"
     );
+}
+
+#[tokio::test]
+async fn dashboard_fetch_bundle_falls_back_one_version_when_latest_archive_404s() {
+    let repo = seed_dashboard_repo();
+    let bundle_parent = TempDir::new().expect("bundle parent");
+    let bundle_dir = bundle_parent.path().join("bundle");
+    let server = BundleHttpServer::start();
+    let fallback_archive = build_bundle_archive("2.9.0");
+    let fallback_checksum = checksum_hex(&fallback_archive);
+    let manifest = format!(
+        r#"{{
+            "versions": [
+                {{
+                    "version": "3.0.0",
+                    "min_required_cli_version": "0.0.1",
+                    "max_required_cli_version": "latest",
+                    "download_url": "{base}/missing-3.0.0.tar.zst",
+                    "checksum_url": "{base}/missing-3.0.0.tar.zst.sha256"
+                }},
+                {{
+                    "version": "2.9.0",
+                    "min_required_cli_version": "0.0.1",
+                    "max_required_cli_version": "latest",
+                    "download_url": "{base}/bundle-2.9.0.tar.zst",
+                    "checksum_url": "{base}/bundle-2.9.0.tar.zst.sha256"
+                }}
+            ]
+        }}"#,
+        base = server.url
+    );
+    server.insert(
+        "/bundle_versions.json",
+        "application/json",
+        manifest.into_bytes(),
+    );
+    server.insert(
+        "/bundle-2.9.0.tar.zst",
+        "application/zstd",
+        fallback_archive,
+    );
+    server.insert(
+        "/bundle-2.9.0.tar.zst.sha256",
+        "text/plain",
+        format!("{fallback_checksum}  bundle-2.9.0.tar.zst\n"),
+    );
+    let app = build_dashboard_router(
+        test_state(repo.path().to_path_buf(), ServeMode::HelloWorld, bundle_dir)
+            .with_bundle_source_overrides(dashboard_bundle_source_overrides_for_manifest(
+                &format!("{}/bundle_versions.json", server.url),
+            )),
+    );
+
+    let (status, payload) =
+        request_dashboard_graphql(app, r#"mutation { fetchBundle { installedVersion } }"#).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["data"]["fetchBundle"]["installedVersion"], "2.9.0",
+        "{payload:#}"
+    );
+}
+
+#[tokio::test]
+async fn dashboard_fetch_bundle_only_tries_one_fallback_after_latest_archive_404() {
+    let repo = seed_dashboard_repo();
+    let bundle_parent = TempDir::new().expect("bundle parent");
+    let bundle_dir = bundle_parent.path().join("bundle");
+    let server = BundleHttpServer::start();
+    let third_archive = build_bundle_archive("2.8.0");
+    let third_checksum = checksum_hex(&third_archive);
+    let manifest = format!(
+        r#"{{
+            "versions": [
+                {{
+                    "version": "3.0.0",
+                    "min_required_cli_version": "0.0.1",
+                    "max_required_cli_version": "latest",
+                    "download_url": "{base}/missing-3.0.0.tar.zst",
+                    "checksum_url": "{base}/missing-3.0.0.tar.zst.sha256"
+                }},
+                {{
+                    "version": "2.9.0",
+                    "min_required_cli_version": "0.0.1",
+                    "max_required_cli_version": "latest",
+                    "download_url": "{base}/missing-2.9.0.tar.zst",
+                    "checksum_url": "{base}/missing-2.9.0.tar.zst.sha256"
+                }},
+                {{
+                    "version": "2.8.0",
+                    "min_required_cli_version": "0.0.1",
+                    "max_required_cli_version": "latest",
+                    "download_url": "{base}/bundle-2.8.0.tar.zst",
+                    "checksum_url": "{base}/bundle-2.8.0.tar.zst.sha256"
+                }}
+            ]
+        }}"#,
+        base = server.url
+    );
+    server.insert(
+        "/bundle_versions.json",
+        "application/json",
+        manifest.into_bytes(),
+    );
+    server.insert("/bundle-2.8.0.tar.zst", "application/zstd", third_archive);
+    server.insert(
+        "/bundle-2.8.0.tar.zst.sha256",
+        "text/plain",
+        format!("{third_checksum}  bundle-2.8.0.tar.zst\n"),
+    );
+    let app = build_dashboard_router(
+        test_state(
+            repo.path().to_path_buf(),
+            ServeMode::HelloWorld,
+            bundle_dir.clone(),
+        )
+        .with_bundle_source_overrides(dashboard_bundle_source_overrides_for_manifest(
+            &format!("{}/bundle_versions.json", server.url),
+        )),
+    );
+
+    let (_status, payload) =
+        request_dashboard_graphql(app, r#"mutation { fetchBundle { installedVersion } }"#).await;
+
+    assert_eq!(
+        payload["errors"][0]["extensions"]["code"], "bundle_download_failed",
+        "{payload:#}"
+    );
+    assert!(!bundle_dir.join("version.json").exists());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds a narrow fallback path for dashboard bundle installs when the newest compatible archive listed in `bundle_versions.json` returns HTTP 404. In that case, `fetchBundle` tries the next compatible manifest entry once and installs it if checksum verification and extraction succeed.

## Behavior

- Falls back only when the selected bundle archive returns HTTP 404.
- Tries at most one older compatible version.
- Keeps checksum mismatch as a hard failure with no fallback.
- Leaves `checkBundleVersion` reporting the newest compatible version.

## Validation

- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features dashboard_fetch_bundle`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features dashboard_check_bundle_version`
- `cargo nextest run --manifest-path bitloops/Cargo.toml --no-default-features resolve_latest_applicable`
- `cargo dev-fmt-check`

Jira: CLI-1918