### PR TITLE
[codex] Fix async stop hook slow tests

### DIFF
--- a/bitloops/src/daemon.rs
+++ b/bitloops/src/daemon.rs
@@ -113,7 +113,7 @@ pub(crate) use self::server_runtime::{
     RepoWatcherReconcileAction, RepoWatcherReconcileResult, reconcile_bound_repo_watcher,
     reconcile_bound_repo_watcher_explicit,
 };
-#[cfg(feature = "slow-tests")]
+#[cfg(any(feature = "slow-tests", feature = "qat-tests"))]
 pub use self::tasks::drain_lifecycle_stop_spool_for_repo_for_tests;
 pub use self::tasks::{DevqlTaskCoordinator, DevqlTaskEnqueueResult};
 pub(crate) use self::types::BlockedMailboxStatus;

--- a/bitloops/src/daemon/tasks.rs
+++ b/bitloops/src/daemon/tasks.rs
@@ -7,7 +7,7 @@ mod state;
 
 pub use self::coordinator::{DevqlTaskCoordinator, DevqlTaskEnqueueResult};
 
-#[cfg(feature = "slow-tests")]
+#[cfg(any(feature = "slow-tests", feature = "qat-tests"))]
 pub fn drain_lifecycle_stop_spool_for_repo_for_tests(
     repo_root: &std::path::Path,
 ) -> anyhow::Result<u64> {

--- a/bitloops/src/daemon/tasks/coordinator.rs
+++ b/bitloops/src/daemon/tasks/coordinator.rs
@@ -32,14 +32,14 @@ mod state;
 #[path = "coordinator/worker.rs"]
 mod worker;
 
-#[cfg(feature = "slow-tests")]
+#[cfg(any(feature = "slow-tests", feature = "qat-tests"))]
 pub(crate) fn recover_lifecycle_stop_spool_jobs_for_tests(
     sqlite: &crate::storage::SqliteConnectionPool,
 ) -> anyhow::Result<u64> {
     worker::lifecycle_spool::recover_lifecycle_stop_spool_jobs(sqlite)
 }
 
-#[cfg(feature = "slow-tests")]
+#[cfg(any(feature = "slow-tests", feature = "qat-tests"))]
 pub(crate) fn process_lifecycle_stop_spool_once_for_tests(
     sqlite: &crate::storage::SqliteConnectionPool,
 ) -> anyhow::Result<u64> {

--- a/bitloops/src/host/devql/tests/cucumber_steps/resilience.rs
+++ b/bitloops/src/host/devql/tests/cucumber_steps/resilience.rs
@@ -9,7 +9,10 @@ use crate::cli::devql::graphql::{
 use crate::cli::embeddings::{
     EmbeddingsArgs, EmbeddingsClearCacheArgs, EmbeddingsCommand, EmbeddingsPullArgs,
 };
-use crate::config::{BITLOOPS_CONFIG_RELATIVE_PATH, resolve_embedding_capability_config_for_repo};
+use crate::config::{
+    BITLOOPS_CONFIG_RELATIVE_PATH, REPO_POLICY_FILE_NAME,
+    resolve_embedding_capability_config_for_repo,
+};
 use crate::daemon;
 use crate::host::capability_host::runtime_contexts::LocalCapabilityRuntimeResources;
 use crate::host::devql::cucumber_world::DevqlBddWorld;
@@ -233,6 +236,11 @@ fn write_daemon_config(world: &mut DevqlBddWorld, config: &str) {
     fs::write(&daemon_config_path, config).expect("write daemon config");
 }
 
+fn write_repo_semantic_policy(world: &mut DevqlBddWorld, policy: &str) {
+    let repo_root = ensure_scenario_repo(world);
+    fs::write(repo_root.join(REPO_POLICY_FILE_NAME), policy).expect("write repo semantic policy");
+}
+
 #[cfg(unix)]
 fn fake_runtime_command_and_args(world: &mut DevqlBddWorld) -> (String, Vec<String>) {
     use std::os::unix::fs::PermissionsExt;
@@ -354,6 +362,16 @@ fn given_daemon_config_using_fake_runtime(
     Box::pin(async move {
         let config = config_with_fake_runtime(world, doc_string(&ctx).trim());
         write_daemon_config(world, &config);
+    })
+}
+
+fn given_repo_semantic_policy(
+    world: &mut DevqlBddWorld,
+    ctx: cucumber::step::Context,
+) -> LocalBoxFuture<'_, ()> {
+    Box::pin(async move {
+        let policy = doc_string(&ctx);
+        write_repo_semantic_policy(world, policy.trim());
     })
 }
 
@@ -872,6 +890,11 @@ pub(super) fn register(collection: Collection<DevqlBddWorld>) -> Collection<Devq
             None,
             regex(r"^a daemon config using the fake embeddings runtime:$"),
             step_fn(given_daemon_config_using_fake_runtime),
+        )
+        .given(
+            None,
+            regex(r"^a repo semantic policy:$"),
+            step_fn(given_repo_semantic_policy),
         )
         .given(
             None,

--- a/bitloops/src/host/devql/tests/features/semantic_embeddings_resilience.feature
+++ b/bitloops/src/host/devql/tests/features/semantic_embeddings_resilience.feature
@@ -17,18 +17,20 @@ Feature: Semantic and embeddings resilience BDD scenarios
   Scenario: SE2 Health resolves an arbitrary embedding profile name through the runtime
     Given a daemon config using the fake embeddings runtime:
       """
-      [semantic_clones]
-      summary_mode = "off"
-
-      [semantic_clones.inference]
-      code_embeddings = "default"
-
       [inference.profiles.default]
       task = "embeddings"
       driver = "bitloops_embeddings_ipc"
       runtime = "bitloops_local_embeddings"
       model = "bge-m3"
       cache_dir = ".bitloops/embeddings/default"
+      """
+    And a repo semantic policy:
+      """
+      [semantic_clones]
+      summary_mode = "off"
+
+      [semantic_clones.inference]
+      code_embeddings = "default"
       """
     When semantic clone health checks run
     Then semantic clone health includes:

--- a/bitloops/tests/claude_git_hooks_integration.rs
+++ b/bitloops/tests/claude_git_hooks_integration.rs
@@ -255,6 +255,7 @@ fn stop(repo: &Path, session_id: &str, transcript_path: &str) {
     let input = format!(r#"{{"session_id":"{session_id}","transcript_path":"{transcript_path}"}}"#);
     let out = run_cmd(repo, &["hooks", "claude-code", "stop"], Some(&input));
     assert_success(&out, "hooks claude-code stop");
+    test_command_support::drain_lifecycle_stop_spool(repo);
 }
 
 fn write_test_session_state_for_logging(repo: &Path, session_id: &str) {

--- a/bitloops/tests/copilot_integration.rs
+++ b/bitloops/tests/copilot_integration.rs
@@ -356,6 +356,13 @@ fn temporary_checkpoint_count(repo_root: &Path, home: &Path, session_id: &str) -
     })
 }
 
+fn drain_lifecycle_stop_spool_with_home(repo_root: &Path, home: &Path) {
+    with_home_env(home, || {
+        bitloops::daemon::drain_lifecycle_stop_spool_for_repo_for_tests(repo_root)
+            .expect("drain lifecycle stop spool for Copilot integration repo");
+    });
+}
+
 #[test]
 fn copilot_agent_stop_without_transcript_path_uses_session_fallback() {
     let dir = tempfile::tempdir().unwrap();
@@ -422,6 +429,7 @@ fn copilot_agent_stop_without_transcript_path_uses_session_fallback() {
         ),
         "hooks copilot agent-stop",
     );
+    drain_lifecycle_stop_spool_with_home(dir.path(), home.path());
     assert_eq!(temporary_checkpoint_count(dir.path(), home.path(), sid), 1);
 
     assert_success(
@@ -567,6 +575,7 @@ fn copilot_multi_turn_session_condenses_both_prompts() {
         ),
         "hooks copilot agent-stop first",
     );
+    drain_lifecycle_stop_spool_with_home(dir.path(), home.path());
 
     assert_success(
         &run_cmd_with_home(
@@ -600,6 +609,7 @@ fn copilot_multi_turn_session_condenses_both_prompts() {
         ),
         "hooks copilot agent-stop second",
     );
+    drain_lifecycle_stop_spool_with_home(dir.path(), home.path());
 
     assert_success(
         &run_cmd_with_home(

--- a/bitloops/tests/cursor_e2e_scenarios.rs
+++ b/bitloops/tests/cursor_e2e_scenarios.rs
@@ -199,6 +199,7 @@ fn cursor_stop(repo: &Path, conversation_id: &str, transcript_path: &str) {
     );
     let out = run_cmd(repo, &["hooks", "cursor", "stop"], Some(&input));
     assert_success(&out, "hooks cursor stop");
+    test_command_support::drain_lifecycle_stop_spool(repo);
 }
 
 fn write_transcript(path: &Path, prompt: &str, response: &str) {

--- a/bitloops/tests/e2e_scenario_groups.rs
+++ b/bitloops/tests/e2e_scenario_groups.rs
@@ -303,6 +303,18 @@ fn stop(repo: &Path, session_id: &str, transcript_path: &str) {
     let input = format!(r#"{{"session_id":"{session_id}","transcript_path":"{transcript_path}"}}"#);
     let out = run_cmd(repo, &["hooks", "claude-code", "stop"], Some(&input));
     assert_success(&out, "hooks claude-code stop");
+    drain_lifecycle_stop_spool_if_bound(repo);
+}
+
+fn drain_lifecycle_stop_spool_if_bound(repo: &Path) {
+    test_command_support::with_repo_app_env(repo, || {
+        let policy = bitloops::config::discover_repo_policy_optional(repo)
+            .expect("discover repo policy before draining lifecycle stop spool");
+        if policy.daemon_config_path.is_some() {
+            bitloops::daemon::drain_lifecycle_stop_spool_for_repo_for_tests(repo)
+                .expect("drain lifecycle stop spool for e2e scenario repo");
+        }
+    });
 }
 
 fn session_end(repo: &Path, session_id: &str, transcript_path: &str) {

--- a/bitloops/tests/qat_support/helpers/internals.rs
+++ b/bitloops/tests/qat_support/helpers/internals.rs
@@ -569,7 +569,8 @@ fn run_cursor_prompt(world: &QatWorld, prompt: &str) -> Result<()> {
         &["hooks", "cursor", "stop"],
         "bitloops hooks cursor stop",
         &stop_payload,
-    )
+    )?;
+    drain_lifecycle_stop_spool_for_scenario(world)
 }
 
 fn run_gemini_prompt(world: &QatWorld, prompt: &str) -> Result<()> {
@@ -680,7 +681,8 @@ fn run_copilot_prompt(world: &QatWorld, prompt: &str) -> Result<()> {
         &["hooks", "copilot", "agent-stop"],
         "bitloops hooks copilot agent-stop",
         &stop_payload,
-    )
+    )?;
+    drain_lifecycle_stop_spool_for_scenario(world)
 }
 
 fn run_codex_prompt(world: &QatWorld, prompt: &str) -> Result<()> {
@@ -736,7 +738,8 @@ fn run_codex_prompt(world: &QatWorld, prompt: &str) -> Result<()> {
         &["hooks", "codex", "stop"],
         "bitloops hooks codex stop",
         &stop_payload,
-    )
+    )?;
+    drain_lifecycle_stop_spool_for_scenario(world)
 }
 
 fn run_opencode_prompt(world: &QatWorld, prompt: &str) -> Result<()> {
@@ -1349,7 +1352,7 @@ fn simulate_claude_session_for_prompt(
         "bitloops hooks claude-code stop",
         &stop_payload,
     )?;
-    Ok(())
+    drain_lifecycle_stop_spool_for_scenario(world)
 }
 
 fn build_host_shell_command(world: &QatWorld, script: &str) -> Result<Command> {

--- a/bitloops/tests/qat_support/helpers/mod.rs
+++ b/bitloops/tests/qat_support/helpers/mod.rs
@@ -135,6 +135,19 @@ fn with_scenario_app_env<T>(world: &QatWorld, f: impl FnOnce() -> T) -> T {
     f()
 }
 
+fn drain_lifecycle_stop_spool_for_scenario(world: &QatWorld) -> Result<()> {
+    with_scenario_app_env(world, || {
+        bitloops::daemon::drain_lifecycle_stop_spool_for_repo_for_tests(world.repo_dir())
+    })
+    .with_context(|| {
+        format!(
+            "draining lifecycle stop spool for QAT repo {}",
+            world.repo_dir().display()
+        )
+    })?;
+    Ok(())
+}
+
 #[derive(Debug, Serialize)]
 struct RunMetadata<'a> {
     scenario_name: &'a str,

--- a/bitloops/tests/test_command_support.rs
+++ b/bitloops/tests/test_command_support.rs
@@ -162,6 +162,7 @@ pub fn with_repo_app_env<T>(repo: &Path, f: impl FnOnce() -> T) -> T {
 }
 
 #[cfg(feature = "slow-tests")]
+#[allow(dead_code)]
 pub fn drain_lifecycle_stop_spool(repo: &Path) {
     with_repo_app_env(repo, || {
         bitloops::daemon::drain_lifecycle_stop_spool_for_repo_for_tests(repo)


### PR DESCRIPTION
## Summary

Fixes the slow-test fallout from async lifecycle stop hooks. The synthetic stop-hook tests now drain the lifecycle stop spool before asserting side effects, so they match the daemon-backed execution model.

## Changes

- Drain lifecycle stop spool in Claude, Cursor, Copilot, grouped E2E, and QAT stop-hook helpers.
- Expose the lifecycle spool drain test helper for `qat-tests` as well as `slow-tests`.
- Keep E2E spool draining conditional when a scenario temporarily removes the daemon binding.
- Move the semantic clone BDD scenario config split so daemon runtime/profile config stays daemon-scoped and semantic policy lives in repo policy.

## Validation

- `cargo dev-loop`
- `cargo qat-develop-gate --parallel 4`
- `git diff --check`