### PR TITLE
docs: improve hero fast-start command readability

### DIFF
--- a/documentation/src/pages/index.module.css
+++ b/documentation/src/pages/index.module.css
@@ -13,6 +13,23 @@
   }
 }
 
+.fastStart {
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 42rem;
+  margin: 0.75rem auto 0;
+}
+
+.fastStart code {
+  background-color: rgba(0, 0, 0, 0.35);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 0.15em 0.45em;
+  border-radius: 0.35rem;
+  font-weight: 600;
+}
+
 .buttons {
   display: flex;
   align-items: center;

--- a/documentation/src/pages/index.tsx
+++ b/documentation/src/pages/index.tsx
@@ -17,7 +17,7 @@ function HomepageHeader() {
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <p>
+        <p className={styles.fastStart}>
           Fastest scripted start: installer <code>--default-config</code>, then{' '}
           <code>bitloops init</code>. Manual setup:{' '}
           <code>bitloops configure --web</code>, then <code>bitloops init</code>


### PR DESCRIPTION
## Summary

The "Fastest start" command on the docs homepage was basically unreadable. 
Just white text sitting the Docusaurus default light code bg inside a purple banner.

This gives the fast-start paragraph its own styling with a darker code pill (dark background, white text, light border) so the command actually stands out against the gradient.

Not sure if this is ideal but the css seems to be concentrated in `documentation/src/pages/index.module.css`, lmk if it's bad